### PR TITLE
docs: add CLI commands section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,24 @@ Every package wraps a Cloudflare binding or API with type safety, better DX, and
 | [`@workkit/astro`](integrations/astro) | Astro middleware and helpers for Cloudflare bindings |
 | [`@workkit/remix`](integrations/remix) | Typed Remix loaders and actions with env validation |
 
+## CLI
+
+Scaffold projects, validate bindings, run migrations, and generate code.
+
+```bash
+bunx workkit init --template hono --features env,d1
+```
+
+| Command | Description |
+|---------|-------------|
+| `workkit init` | Scaffold a new Workers project |
+| `workkit check` | Validate bindings against env schema |
+| `workkit d1 migrate` | Run D1 migrations |
+| `workkit d1 seed` | Seed D1 from fixture files |
+| `workkit gen client` | Generate typed API client from route definitions |
+| `workkit gen docs` | Generate OpenAPI docs from route definitions |
+| `workkit catalog` | Show available packages and their status |
+
 ## Quick Start
 
 **1. Install what you need**


### PR DESCRIPTION
## Summary
- Adds a CLI section to the main README documenting all 7 commands
- Shows `bunx workkit init` as the primary usage example
- Placed between Integrations and Quick Start sections

## Test plan
- [x] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive CLI section documenting tooling for scaffolding Workers projects, validating bindings, managing D1 database migrations and seeding, and generating typed API clients and OpenAPI documentation.
  * Included command reference guide with example project initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->