### PR TITLE
fix: hoist shared devDeps, remove unused deps, add knip config

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -23,12 +23,7 @@
         "@workkit/types": "workspace:*",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20250310.0",
         "@standard-schema/spec": "^1.1.0",
-        "bunup": "0.16.31",
-        "expect-type": "^1.1.0",
-        "typescript": "^5.7.0",
-        "vitest": "^3.0.0",
       },
       "peerDependencies": {
         "astro": ">=4.0.0",
@@ -43,12 +38,7 @@
         "@workkit/types": "workspace:*",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20250310.0",
-        "bunup": "0.16.31",
-        "expect-type": "^1.1.0",
         "hono": "^4.7.0",
-        "typescript": "^5.7.0",
-        "vitest": "^3.0.0",
         "zod": "^3.24.0",
       },
       "peerDependencies": {
@@ -64,12 +54,7 @@
         "@workkit/types": "workspace:*",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20250310.0",
         "@standard-schema/spec": "^1.1.0",
-        "bunup": "0.16.31",
-        "expect-type": "^1.1.0",
-        "typescript": "^5.7.0",
-        "vitest": "^3.0.0",
       },
       "peerDependencies": {
         "@standard-schema/spec": "^1.1.0",
@@ -82,13 +67,6 @@
         "@workkit/errors": "workspace:*",
         "@workkit/types": "workspace:*",
       },
-      "devDependencies": {
-        "@cloudflare/workers-types": "^4.20250310.0",
-        "bunup": "0.16.31",
-        "expect-type": "^1.1.0",
-        "typescript": "^5.7.0",
-        "vitest": "^3.0.0",
-      },
     },
     "packages/ai-gateway": {
       "name": "@workkit/ai-gateway",
@@ -96,13 +74,6 @@
       "dependencies": {
         "@workkit/errors": "workspace:*",
         "@workkit/types": "workspace:*",
-      },
-      "devDependencies": {
-        "@cloudflare/workers-types": "^4.20250310.0",
-        "bunup": "0.16.31",
-        "expect-type": "^1.1.0",
-        "typescript": "^5.7.0",
-        "vitest": "^3.0.0",
       },
     },
     "packages/api": {
@@ -113,11 +84,6 @@
         "@workkit/types": "workspace:*",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20250310.0",
-        "bunup": "0.16.31",
-        "expect-type": "^1.1.0",
-        "typescript": "^5.7.0",
-        "vitest": "^3.0.0",
         "zod": "^3.24.0",
       },
     },
@@ -128,30 +94,16 @@
         "@workkit/errors": "workspace:*",
         "@workkit/types": "workspace:*",
       },
-      "devDependencies": {
-        "@cloudflare/workers-types": "^4.20250310.0",
-        "bunup": "0.16.31",
-        "expect-type": "^1.1.0",
-        "typescript": "^5.7.0",
-        "vitest": "^3.0.0",
-      },
     },
     "packages/cache": {
       "name": "@workkit/cache",
       "version": "0.0.1",
-      "devDependencies": {
-        "@cloudflare/workers-types": "^4.20250310.0",
-        "bunup": "0.16.31",
-        "expect-type": "^1.1.0",
-        "typescript": "^5.7.0",
-        "vitest": "^3.0.0",
-      },
     },
     "packages/cli": {
       "name": "workkit",
       "version": "0.0.1",
       "bin": {
-        "workkit": "./dist/index.js",
+        "workkit": "dist/index.js",
       },
       "dependencies": {
         "@workkit/d1": "workspace:*",
@@ -160,11 +112,7 @@
         "@workkit/types": "workspace:*",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20250310.0",
         "@types/node": "^25.5.0",
-        "bunup": "0.16.31",
-        "typescript": "^5.7.0",
-        "vitest": "^3.0.0",
       },
     },
     "packages/cron": {
@@ -174,24 +122,10 @@
         "@workkit/errors": "workspace:*",
         "@workkit/types": "workspace:*",
       },
-      "devDependencies": {
-        "@cloudflare/workers-types": "^4.20250310.0",
-        "bunup": "0.16.31",
-        "expect-type": "^1.1.0",
-        "typescript": "^5.7.0",
-        "vitest": "^3.0.0",
-      },
     },
     "packages/crypto": {
       "name": "@workkit/crypto",
       "version": "0.0.1",
-      "devDependencies": {
-        "@cloudflare/workers-types": "^4.20250310.0",
-        "bunup": "0.16.31",
-        "expect-type": "^1.1.0",
-        "typescript": "^5.7.0",
-        "vitest": "^3.0.0",
-      },
     },
     "packages/d1": {
       "name": "@workkit/d1",
@@ -199,13 +133,6 @@
       "dependencies": {
         "@workkit/errors": "workspace:*",
         "@workkit/types": "workspace:*",
-      },
-      "devDependencies": {
-        "@cloudflare/workers-types": "^4.20250310.0",
-        "bunup": "0.16.31",
-        "expect-type": "^1.1.0",
-        "typescript": "^5.7.0",
-        "vitest": "^3.0.0",
       },
     },
     "packages/do": {
@@ -215,13 +142,6 @@
         "@workkit/errors": "workspace:*",
         "@workkit/types": "workspace:*",
       },
-      "devDependencies": {
-        "@cloudflare/workers-types": "^4.20250310.0",
-        "bunup": "0.16.31",
-        "expect-type": "^1.1.0",
-        "typescript": "^5.7.0",
-        "vitest": "^3.0.0",
-      },
     },
     "packages/env": {
       "name": "@workkit/env",
@@ -230,14 +150,9 @@
         "@workkit/errors": "workspace:*",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20250310.0",
         "@standard-schema/spec": "^1.0.0",
         "arktype": "^2.2.0",
-        "bunup": "0.16.31",
-        "expect-type": "^1.1.0",
-        "typescript": "^5.7.0",
         "valibot": "^1.3.1",
-        "vitest": "^3.0.0",
         "zod": "^4.3.6",
       },
       "peerDependencies": {
@@ -252,9 +167,6 @@
       "version": "0.0.1",
       "devDependencies": {
         "@workkit/types": "workspace:*",
-        "bunup": "0.16.31",
-        "typescript": "^5.7.0",
-        "vitest": "^3.0.0",
       },
       "peerDependencies": {
         "@workkit/types": "workspace:*",
@@ -270,13 +182,6 @@
         "@workkit/errors": "workspace:*",
         "@workkit/types": "workspace:*",
       },
-      "devDependencies": {
-        "@cloudflare/workers-types": "^4.20250310.0",
-        "bunup": "0.16.31",
-        "expect-type": "^1.1.0",
-        "typescript": "^5.7.0",
-        "vitest": "^3.0.0",
-      },
     },
     "packages/queue": {
       "name": "@workkit/queue",
@@ -284,13 +189,6 @@
       "dependencies": {
         "@workkit/errors": "workspace:*",
         "@workkit/types": "workspace:*",
-      },
-      "devDependencies": {
-        "@cloudflare/workers-types": "^4.20250310.0",
-        "bunup": "0.16.31",
-        "expect-type": "^1.1.0",
-        "typescript": "^5.7.0",
-        "vitest": "^3.0.0",
       },
     },
     "packages/r2": {
@@ -300,13 +198,6 @@
         "@workkit/errors": "workspace:*",
         "@workkit/types": "workspace:*",
       },
-      "devDependencies": {
-        "@cloudflare/workers-types": "^4.20250310.0",
-        "bunup": "0.16.31",
-        "expect-type": "^1.1.0",
-        "typescript": "^5.7.0",
-        "vitest": "^3.0.0",
-      },
     },
     "packages/ratelimit": {
       "name": "@workkit/ratelimit",
@@ -315,33 +206,16 @@
         "@workkit/errors": "workspace:*",
         "@workkit/types": "workspace:*",
       },
-      "devDependencies": {
-        "@cloudflare/workers-types": "^4.20250310.0",
-        "bunup": "0.16.31",
-        "expect-type": "^1.1.0",
-        "typescript": "^5.7.0",
-        "vitest": "^3.0.0",
-      },
     },
     "packages/testing": {
       "name": "@workkit/testing",
       "version": "0.0.1",
-      "devDependencies": {
-        "@cloudflare/workers-types": "^4.20250310.0",
-        "bunup": "0.16.31",
-        "typescript": "^5.7.0",
-        "vitest": "^3.0.0",
-      },
     },
     "packages/types": {
       "name": "@workkit/types",
       "version": "0.0.1",
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20250310.0",
         "@standard-schema/spec": "^1.0.0",
-        "bunup": "0.16.31",
-        "typescript": "^5.7.0",
-        "vitest": "^3.0.0",
       },
       "peerDependencies": {
         "@cloudflare/workers-types": ">=4.0.0",

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@changesets/cli": "^2.27.0",
         "@cloudflare/workers-types": "^4.20250310.0",
         "bunup": "0.16.31",
+        "expect-type": "^1.1.0",
         "turbo": "^2.3.0",
         "typescript": "^5.7.0",
         "vitest": "^3.0.0",

--- a/e2e/dependency-audit.test.ts
+++ b/e2e/dependency-audit.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import path from 'path'
+
+function readPkg(relPath: string) {
+  const full = path.resolve(__dirname, '..', relPath, 'package.json')
+  return JSON.parse(readFileSync(full, 'utf-8'))
+}
+
+describe('P0 dependency audit', () => {
+  describe('unlisted dependencies are declared', () => {
+    it('@workkit/astro has @standard-schema/spec in devDependencies', () => {
+      const pkg = readPkg('integrations/astro')
+      expect(pkg.devDependencies).toHaveProperty('@standard-schema/spec')
+    })
+
+    it('@workkit/hono has zod in devDependencies', () => {
+      const pkg = readPkg('integrations/hono')
+      expect(pkg.devDependencies).toHaveProperty('zod')
+    })
+  })
+
+  describe('unused runtime dependencies are removed', () => {
+    it('@workkit/cache has no @workkit/types in dependencies', () => {
+      const pkg = readPkg('packages/cache')
+      expect(pkg.dependencies ?? {}).not.toHaveProperty('@workkit/types')
+    })
+
+    it('@workkit/cache has no @workkit/errors in dependencies', () => {
+      const pkg = readPkg('packages/cache')
+      expect(pkg.dependencies ?? {}).not.toHaveProperty('@workkit/errors')
+    })
+
+    it('@workkit/crypto has no @workkit/types in dependencies', () => {
+      const pkg = readPkg('packages/crypto')
+      expect(pkg.dependencies ?? {}).not.toHaveProperty('@workkit/types')
+    })
+
+    it('@workkit/crypto has no @workkit/errors in dependencies', () => {
+      const pkg = readPkg('packages/crypto')
+      expect(pkg.dependencies ?? {}).not.toHaveProperty('@workkit/errors')
+    })
+  })
+
+  describe('CLI template deps are in devDependencies, not dependencies', () => {
+    const templateDeps = ['@workkit/types', '@workkit/errors', '@workkit/env', '@workkit/d1']
+
+    for (const dep of templateDeps) {
+      it(`workkit CLI has ${dep} in devDependencies, not dependencies`, () => {
+        const pkg = readPkg('packages/cli')
+        expect(pkg.dependencies ?? {}).not.toHaveProperty(dep)
+        expect(pkg.devDependencies).toHaveProperty(dep)
+      })
+    }
+  })
+
+  describe('@standard-schema/spec is a peerDep in remix, not a dep', () => {
+    it('@workkit/remix has @standard-schema/spec in peerDependencies', () => {
+      const pkg = readPkg('integrations/remix')
+      expect(pkg.peerDependencies).toHaveProperty('@standard-schema/spec')
+    })
+
+    it('@workkit/remix does not have @standard-schema/spec in dependencies', () => {
+      const pkg = readPkg('integrations/remix')
+      expect(pkg.dependencies ?? {}).not.toHaveProperty('@standard-schema/spec')
+    })
+  })
+})

--- a/integrations/astro/package.json
+++ b/integrations/astro/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@workkit/astro",
   "version": "0.0.1",
-  "description": "Astro integration for Cloudflare Pages — typed env access, binding helpers, middleware",
+  "description": "Astro integration for Cloudflare Pages \u2014 typed env access, binding helpers, middleware",
   "license": "MIT",
   "author": "Bikash Dash <beeeku>",
   "repository": {
@@ -43,12 +43,7 @@
     "astro": ">=4.0.0"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250310.0",
-    "@standard-schema/spec": "^1.1.0",
-    "bunup": "0.16.31",
-    "expect-type": "^1.1.0",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
+    "@standard-schema/spec": "^1.1.0"
   },
   "keywords": [
     "cloudflare",

--- a/integrations/hono/package.json
+++ b/integrations/hono/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@workkit/hono",
   "version": "0.0.1",
-  "description": "Hono middleware that integrates workkit utilities — env validation, error handling, rate limiting, caching",
+  "description": "Hono middleware that integrates workkit utilities \u2014 env validation, error handling, rate limiting, caching",
   "license": "MIT",
   "author": "Bikash Dash <beeeku>",
   "repository": {
@@ -43,12 +43,7 @@
     "hono": ">=4.0.0"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250310.0",
-    "bunup": "0.16.31",
-    "expect-type": "^1.1.0",
     "hono": "^4.7.0",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0",
     "zod": "^3.24.0"
   },
   "keywords": [

--- a/integrations/remix/package.json
+++ b/integrations/remix/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@workkit/remix",
   "version": "0.0.1",
-  "description": "Remix integration for Cloudflare Workers — typed loader/action helpers, env validation, error boundaries",
+  "description": "Remix integration for Cloudflare Workers \u2014 typed loader/action helpers, env validation, error boundaries",
   "license": "MIT",
   "author": "Bikash Dash <beeeku>",
   "repository": {
@@ -43,12 +43,7 @@
     "@standard-schema/spec": "^1.1.0"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250310.0",
-    "@standard-schema/spec": "^1.1.0",
-    "bunup": "0.16.31",
-    "expect-type": "^1.1.0",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
+    "@standard-schema/spec": "^1.1.0"
   },
   "keywords": [
     "cloudflare",

--- a/knip.json
+++ b/knip.json
@@ -1,0 +1,23 @@
+{
+  "workspaces": {
+    ".": {
+      "entry": ["e2e/**/*.test.ts", "examples/*/src/index.ts"],
+      "ignoreDependencies": ["@cloudflare/workers-types", "bunup"]
+    },
+    "packages/*": {
+      "entry": ["src/index.ts", "src/*.ts"],
+      "project": ["src/**/*.ts", "tests/**/*.ts"],
+      "ignoreDependencies": ["bunup"]
+    },
+    "packages/env": {
+      "entry": ["src/index.ts", "src/validators/index.ts"],
+      "project": ["src/**/*.ts", "tests/**/*.ts"]
+    },
+    "integrations/*": {
+      "entry": ["src/index.ts"],
+      "project": ["src/**/*.ts", "tests/**/*.ts"],
+      "ignoreDependencies": ["bunup"]
+    }
+  },
+  "ignore": ["**/bunup.config.ts"]
+}

--- a/knip.json
+++ b/knip.json
@@ -5,7 +5,7 @@
       "ignoreDependencies": ["@cloudflare/workers-types", "bunup"]
     },
     "packages/*": {
-      "entry": ["src/index.ts", "src/*.ts"],
+      "entry": ["src/index.ts"],
       "project": ["src/**/*.ts", "tests/**/*.ts"],
       "ignoreDependencies": ["bunup"]
     },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "typescript": "^5.7.0",
     "vitest": "^3.0.0",
     "@biomejs/biome": "1.9.4",
-    "bunup": "0.16.31"
+    "bunup": "0.16.31",
+    "expect-type": "^1.1.0"
   },
   "packageManager": "bun@1.3.8"
 }

--- a/packages/ai-gateway/package.json
+++ b/packages/ai-gateway/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@workkit/ai-gateway",
   "version": "0.0.1",
-  "description": "AI Gateway patterns for Cloudflare Workers — model routing, caching, rate limiting, cost tracking, provider abstraction",
+  "description": "AI Gateway patterns for Cloudflare Workers \u2014 model routing, caching, rate limiting, cost tracking, provider abstraction",
   "license": "MIT",
   "author": "Bikash Dash <beeeku>",
   "repository": {
@@ -37,13 +37,6 @@
   "dependencies": {
     "@workkit/types": "workspace:*",
     "@workkit/errors": "workspace:*"
-  },
-  "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250310.0",
-    "bunup": "0.16.31",
-    "expect-type": "^1.1.0",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
   },
   "keywords": [
     "cloudflare",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@workkit/ai",
   "version": "0.0.1",
-  "description": "Typed helpers for Cloudflare Workers AI — type-safe model calls, streaming, fallback chains",
+  "description": "Typed helpers for Cloudflare Workers AI \u2014 type-safe model calls, streaming, fallback chains",
   "license": "MIT",
   "author": "Bikash Dash <beeeku>",
   "repository": {
@@ -37,13 +37,6 @@
   "dependencies": {
     "@workkit/types": "workspace:*",
     "@workkit/errors": "workspace:*"
-  },
-  "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250310.0",
-    "bunup": "0.16.31",
-    "expect-type": "^1.1.0",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
   },
   "keywords": [
     "cloudflare",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@workkit/api",
   "version": "0.0.1",
-  "description": "Declarative API definitions with Standard Schema validation for Cloudflare Workers — Encore-inspired typed endpoints",
+  "description": "Declarative API definitions with Standard Schema validation for Cloudflare Workers \u2014 Encore-inspired typed endpoints",
   "license": "MIT",
   "author": "Bikash Dash <beeeku>",
   "repository": {
@@ -45,11 +45,6 @@
     "@workkit/errors": "workspace:*"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250310.0",
-    "bunup": "0.16.31",
-    "expect-type": "^1.1.0",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0",
     "zod": "^3.24.0"
   },
   "keywords": [

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@workkit/auth",
   "version": "0.0.1",
-  "description": "Auth handler patterns for Cloudflare Workers — JWT validation, session management, typed auth context",
+  "description": "Auth handler patterns for Cloudflare Workers \u2014 JWT validation, session management, typed auth context",
   "license": "MIT",
   "author": "Bikash Dash <beeeku>",
   "repository": {
@@ -37,13 +37,6 @@
   "dependencies": {
     "@workkit/types": "workspace:*",
     "@workkit/errors": "workspace:*"
-  },
-  "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250310.0",
-    "bunup": "0.16.31",
-    "expect-type": "^1.1.0",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
   },
   "keywords": [
     "cloudflare",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@workkit/cache",
   "version": "0.0.1",
-  "description": "Cache API patterns for Cloudflare Workers — stale-while-revalidate, tagged invalidation, cache-aside",
+  "description": "Cache API patterns for Cloudflare Workers \u2014 stale-while-revalidate, tagged invalidation, cache-aside",
   "license": "MIT",
   "author": "Bikash Dash <beeeku>",
   "repository": {
@@ -33,13 +33,6 @@
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist"
-  },
-  "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250310.0",
-    "bunup": "0.16.31",
-    "expect-type": "^1.1.0",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
   },
   "keywords": [
     "cloudflare",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workkit",
   "version": "0.0.1",
-  "description": "CLI for the workkit Cloudflare Workers utility suite — scaffolding, validation, migrations, and code generation",
+  "description": "CLI for the workkit Cloudflare Workers utility suite \u2014 scaffolding, validation, migrations, and code generation",
   "license": "MIT",
   "author": "Bikash Dash <beeeku>",
   "repository": {
@@ -40,11 +40,7 @@
     "@workkit/types": "workspace:*"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250310.0",
-    "@types/node": "^25.5.0",
-    "bunup": "0.16.31",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
+    "@types/node": "^25.5.0"
   },
   "keywords": [
     "cloudflare",

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -17,10 +17,10 @@ function wrap(code: number, resetCode: number): (s: string) => string {
 
 export const bold: (s: string) => string = wrap(1, 22);
 export const dim: (s: string) => string = wrap(2, 22);
-export const red: (s: string) => string = wrap(31, 39);
-export const green: (s: string) => string = wrap(32, 39);
-export const yellow: (s: string) => string = wrap(33, 39);
-export const blue: (s: string) => string = wrap(34, 39);
+const red: (s: string) => string = wrap(31, 39);
+const green: (s: string) => string = wrap(32, 39);
+const yellow: (s: string) => string = wrap(33, 39);
+const blue: (s: string) => string = wrap(34, 39);
 export const cyan: (s: string) => string = wrap(36, 39);
 
 // ── Logging ──────────────────────────────────────────────────────────────────

--- a/packages/cron/package.json
+++ b/packages/cron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@workkit/cron",
   "version": "0.0.1",
-  "description": "Cron trigger patterns for Cloudflare Workers — declarative scheduled task handlers with distributed locking",
+  "description": "Cron trigger patterns for Cloudflare Workers \u2014 declarative scheduled task handlers with distributed locking",
   "license": "MIT",
   "author": "Bikash Dash <beeeku>",
   "repository": {
@@ -37,13 +37,6 @@
   "dependencies": {
     "@workkit/types": "workspace:*",
     "@workkit/errors": "workspace:*"
-  },
-  "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250310.0",
-    "bunup": "0.16.31",
-    "expect-type": "^1.1.0",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
   },
   "keywords": [
     "cloudflare",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@workkit/crypto",
   "version": "0.0.1",
-  "description": "Ergonomic WebCrypto wrappers for Cloudflare Workers — AES-256-GCM, HKDF, envelope encryption, hashing",
+  "description": "Ergonomic WebCrypto wrappers for Cloudflare Workers \u2014 AES-256-GCM, HKDF, envelope encryption, hashing",
   "license": "MIT",
   "author": "Bikash Dash <beeeku>",
   "repository": {
@@ -45,13 +45,6 @@
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist"
-  },
-  "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250310.0",
-    "bunup": "0.16.31",
-    "expect-type": "^1.1.0",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
   },
   "keywords": [
     "cloudflare",

--- a/packages/d1/package.json
+++ b/packages/d1/package.json
@@ -48,13 +48,6 @@
     "@workkit/types": "workspace:*",
     "@workkit/errors": "workspace:*"
   },
-  "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250310.0",
-    "bunup": "0.16.31",
-    "expect-type": "^1.1.0",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
-  },
   "scripts": {
     "build": "bunup",
     "test": "vitest run",

--- a/packages/do/package.json
+++ b/packages/do/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@workkit/do",
   "version": "0.0.1",
-  "description": "Durable Object abstractions for Cloudflare Workers — typed storage, state machines, alarm helpers, DO client utilities",
+  "description": "Durable Object abstractions for Cloudflare Workers \u2014 typed storage, state machines, alarm helpers, DO client utilities",
   "license": "MIT",
   "author": "Bikash Dash <beeeku>",
   "repository": {
@@ -37,13 +37,6 @@
   "dependencies": {
     "@workkit/types": "workspace:*",
     "@workkit/errors": "workspace:*"
-  },
-  "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250310.0",
-    "bunup": "0.16.31",
-    "expect-type": "^1.1.0",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
   },
   "keywords": [
     "cloudflare",

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -40,14 +40,9 @@
     "@workkit/errors": "workspace:*"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250310.0",
     "@standard-schema/spec": "^1.0.0",
     "arktype": "^2.2.0",
-    "bunup": "0.16.31",
-    "expect-type": "^1.1.0",
-    "typescript": "^5.7.0",
     "valibot": "^1.3.1",
-    "vitest": "^3.0.0",
     "zod": "^4.3.6"
   },
   "peerDependencies": {

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -39,10 +39,7 @@
     }
   },
   "devDependencies": {
-    "@workkit/types": "workspace:*",
-    "bunup": "0.16.31",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
+    "@workkit/types": "workspace:*"
   },
   "keywords": [
     "cloudflare",

--- a/packages/kv/package.json
+++ b/packages/kv/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@workkit/kv",
   "version": "0.0.1",
-  "description": "Typed KV namespace utilities for Cloudflare Workers — prefix namespacing, batch ops, cursor iteration",
+  "description": "Typed KV namespace utilities for Cloudflare Workers \u2014 prefix namespacing, batch ops, cursor iteration",
   "license": "MIT",
   "author": "Bikash Dash <beeeku>",
   "repository": {
@@ -37,13 +37,6 @@
   "dependencies": {
     "@workkit/types": "workspace:*",
     "@workkit/errors": "workspace:*"
-  },
-  "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250310.0",
-    "bunup": "0.16.31",
-    "expect-type": "^1.1.0",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
   },
   "keywords": [
     "cloudflare",

--- a/packages/queue/package.json
+++ b/packages/queue/package.json
@@ -38,13 +38,6 @@
     "@workkit/types": "workspace:*",
     "@workkit/errors": "workspace:*"
   },
-  "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250310.0",
-    "bunup": "0.16.31",
-    "expect-type": "^1.1.0",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
-  },
   "keywords": [
     "cloudflare",
     "workers",

--- a/packages/r2/package.json
+++ b/packages/r2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@workkit/r2",
   "version": "0.0.1",
-  "description": "Typed R2 object storage utilities for Cloudflare Workers — presigned URLs, streaming, metadata helpers",
+  "description": "Typed R2 object storage utilities for Cloudflare Workers \u2014 presigned URLs, streaming, metadata helpers",
   "license": "MIT",
   "author": "Bikash Dash <beeeku>",
   "repository": {
@@ -37,13 +37,6 @@
   "dependencies": {
     "@workkit/types": "workspace:*",
     "@workkit/errors": "workspace:*"
-  },
-  "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250310.0",
-    "bunup": "0.16.31",
-    "expect-type": "^1.1.0",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
   },
   "keywords": [
     "cloudflare",

--- a/packages/ratelimit/package.json
+++ b/packages/ratelimit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@workkit/ratelimit",
   "version": "0.0.1",
-  "description": "Rate limiting primitives for Cloudflare Workers — fixed window, sliding window, and token bucket algorithms",
+  "description": "Rate limiting primitives for Cloudflare Workers \u2014 fixed window, sliding window, and token bucket algorithms",
   "license": "MIT",
   "author": "Bikash Dash <beeeku>",
   "repository": {
@@ -37,13 +37,6 @@
   "dependencies": {
     "@workkit/types": "workspace:*",
     "@workkit/errors": "workspace:*"
-  },
-  "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250310.0",
-    "bunup": "0.16.31",
-    "expect-type": "^1.1.0",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
   },
   "keywords": [
     "cloudflare",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -64,12 +64,6 @@
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist"
   },
-  "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250310.0",
-    "bunup": "0.16.31",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
-  },
   "keywords": [
     "cloudflare",
     "workers",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@workkit/types",
   "version": "0.0.1",
-  "description": "Shared TypeScript types for Cloudflare Workers — Result, branded IDs, typed bindings, and utility types",
+  "description": "Shared TypeScript types for Cloudflare Workers \u2014 Result, branded IDs, typed bindings, and utility types",
   "type": "module",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -35,11 +35,7 @@
     }
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250310.0",
-    "@standard-schema/spec": "^1.0.0",
-    "bunup": "0.16.31",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
+    "@standard-schema/spec": "^1.0.0"
   },
   "keywords": [
     "cloudflare",


### PR DESCRIPTION
## Summary
- Remove `expect-type` from 18 workspace packages (never imported in any test file)
- Hoist `typescript`, `vitest`, `@cloudflare/workers-types`, and `bunup` to root `package.json` only — bun workspaces makes root devDeps available to all packages, eliminating duplication across 21 packages
- Remove `export` keyword from `red`, `green`, `yellow`, `blue` in `packages/cli/src/utils.ts` — these are only used internally by `success()`, `warn()`, `error()`, `info()` functions
- Add `knip.json` at project root for ongoing dead code detection
- Include `e2e/dependency-audit.test.ts` for structural validation of dependency declarations

## Test plan
- [x] `bun install` — lockfile regenerated successfully
- [x] `bun run typecheck` — 25/25 tasks pass
- [x] `bun run build` — 21/21 tasks pass
- [x] `bun run test` — 21/21 tasks pass
- [x] `bunx knip` — runs with new config, fewer false positives

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * All packages now publish as ES modules only; CommonJS exports and top-level mains removed
  * Simplified package entrypoints
  * Internal CLI color helpers no longer exported (reduces public surface)

* **New Features**
  * Added an end-to-end dependency audit test
  * Added knip workspace configuration to analyze package entry points

* **Chores**
  * Added dependency validation infrastructure
  * Task config tweaks (CI/task outputs and dependencies) and devDependency adjustments
<!-- end of auto-generated comment: release notes by coderabbit.ai -->