### PR TITLE
feat(docs): deploy to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,50 @@
+name: Deploy Docs to GitHub Pages
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'apps/docs/**'
+      - '.github/workflows/deploy-docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        working-directory: apps/docs
+        run: npm install
+
+      - name: Build docs
+        working-directory: apps/docs
+        run: npm run build
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: apps/docs/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -4,7 +4,8 @@ import tailwind from '@astrojs/tailwind';
 import react from '@astrojs/react';
 
 export default defineConfig({
-  site: 'https://workkit.bika.sh',
+  site: 'https://beeeku.github.io',
+  base: '/workkit',
   integrations: [
     starlight({
       title: 'workkit',

--- a/apps/docs/wrangler.toml
+++ b/apps/docs/wrangler.toml
@@ -1,3 +1,0 @@
-name = "workkit-docs"
-compatibility_date = "2025-03-21"
-pages_build_output_dir = "dist"


### PR DESCRIPTION
## Summary
- Add GitHub Pages deployment workflow (`deploy-docs.yml`)
- Update Astro config with `site` and `base` for GitHub Pages URL structure
- Auto-deploys on push to master when docs change

## After merging
GitHub Pages needs to be enabled in repo settings → Pages → Source: GitHub Actions

Site will be at: https://beeeku.github.io/workkit/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Set up automated documentation deployment to GitHub Pages
  * Updated documentation site configuration and hosting location

<!-- end of auto-generated comment: release notes by coderabbit.ai -->