### PR TITLE
feat(pdf): @workkit/pdf — render HTML to PDF on @workkit/browser

### DIFF
--- a/.changeset/feat-pdf-init.md
+++ b/.changeset/feat-pdf-init.md
@@ -1,0 +1,27 @@
+---
+"@workkit/pdf": minor
+---
+
+Add `@workkit/pdf` — render HTML to PDF in Cloudflare Workers via
+`@workkit/browser`, with R2 storage and presign helpers.
+
+- `renderPDF(session, html, opts)` returns the PDF byte array. Uses
+  `@workkit/browser`'s `withPage` so JS-off, dialog auto-dismiss, abort
+  propagation, and guaranteed page close come for free.
+- `storedPDF(session, html, opts)` renders, uploads to R2, and presigns in
+  one call. Returns `{ r2Key, bytes, url }`.
+- `composeHeaderFooter()` produces Puppeteer-compatible header/footer
+  templates. Plain string values are HTML-escaped by default; `raw()` is
+  the only opt-in for unescaped HTML.
+- `safeKey(...parts)` rejects path traversal (`..`, `.`, leading `/`,
+  backslashes, control chars) and throws `ValidationError` rather than
+  silently sanitizing.
+- Page-size + margin presets (A4 default for the Indian market; Letter,
+  Legal, narrow/normal/wide margins).
+- `disclaimerRequired: true` fails fast before render if `footer.disclaimer`
+  is empty (compliance hook).
+- Presigned URL TTL defaults to 3600s and is hard-capped at 86400s (24h).
+  Use `readPolicy: "private"` for longer-lived access through an
+  authenticated proxy.
+
+Closes #24.

--- a/.maina/features/003-workkit-pdf/plan.md
+++ b/.maina/features/003-workkit-pdf/plan.md
@@ -1,54 +1,91 @@
-# Implementation Plan
+# Implementation Plan — @workkit/pdf
 
 > HOW only — see spec.md for WHAT and WHY.
 
 ## Architecture
 
-What is the technical approach? How does it fit into existing architecture?
-Where are the integration points with existing code?
-
-- Pattern: [NEEDS CLARIFICATION]
-- Integration points: [NEEDS CLARIFICATION]
+- **Pattern**: Functional, two public entry points (`renderPDF`, `storedPDF`). Internal `escape`/`raw`/`safeKey`/`composeHeaderFooter` helpers.
+- **Layering**: pdf depends on `@workkit/browser` for session+page, on `@workkit/errors` for error types. Optional dep on `@workkit/r2`-shape (consumer passes `R2Bucket` directly — we don't wrap their bucket type).
+- **Integration points**:
+  - `@workkit/browser`: `browser()`, `withPage()`, `loadFonts()`.
+  - R2: native `R2Bucket.put()` + `createPresignedUrl()` (or fallback `aws4fetch`-style sign for older bindings).
 
 ## Key Technical Decisions
 
-What libraries, patterns, or approaches? WHY these and not alternatives?
-
-- [NEEDS CLARIFICATION]
+- **Reuse `withPage` from browser package** — inherits abort/JS-off/dialog defaults for free; we don't reinvent lifecycle.
+- **Compose header/footer via Puppeteer's native `displayHeaderFooter` + `headerTemplate` + `footerTemplate`** — gives us page numbers `<span class="pageNumber">` and total `<span class="totalPages">` for free. Inject our own escaped HTML into those templates.
+- **`escape(text)` returns a branded `Escaped` string; `raw(html)` returns a branded `Raw` string** — composition functions accept `Escaped | Raw`. Plain strings get auto-escaped. Forces explicit decision at the call site.
+- **`safeKey(...parts)` joins parts with `/` after stripping `..`, `\`, control chars, and rejecting absolute paths** — throws `ValidationError` on disallowed input rather than silently transforming.
+- **Presign via R2 native `createPresignedUrl()` if available, else error with explicit guidance** — don't ship our own sigv4 implementation in v1; consumers on older R2 SDKs can use a pre-signed-url helper.
+- **No streaming upload in v1** — measure first; add when a real consumer hits the cap.
+- **Cost monitoring guidance only** — no auto-counter; recommend Analytics Engine pattern in README. Adding a counter would require a new binding.
 
 ## Files
 
 | File | Purpose | New/Modified |
-|------|---------|-------------|
-| [NEEDS CLARIFICATION] | | |
+|---|---|---|
+| `packages/pdf/package.json` | Manifest (deps: `@workkit/browser`, `@workkit/errors`) | New |
+| `packages/pdf/tsconfig.json` | Extends library tsconfig | New |
+| `packages/pdf/bunup.config.ts` | Build config | New |
+| `packages/pdf/vitest.config.ts` | Test config | New |
+| `packages/pdf/src/index.ts` | Public exports | New |
+| `packages/pdf/src/render.ts` | `renderPDF()` | New |
+| `packages/pdf/src/store.ts` | `storedPDF()` | New |
+| `packages/pdf/src/presets.ts` | A4/Letter/Legal + margin presets | New |
+| `packages/pdf/src/header.ts` | Header/footer templates + composition | New |
+| `packages/pdf/src/escape.ts` | `escape()`/`raw()` branded strings + HTML escape | New |
+| `packages/pdf/src/safe-key.ts` | `safeKey()` R2 path sanitizer | New |
+| `packages/pdf/src/types.ts` | Public option types + R2 binding shape | New |
+| `packages/pdf/tests/escape.test.ts` | Escaping correctness + brand checks | New |
+| `packages/pdf/tests/safe-key.test.ts` | Path traversal + control char rejection | New |
+| `packages/pdf/tests/header.test.ts` | Header/footer composition; raw vs escape | New |
+| `packages/pdf/tests/render.test.ts` | render with mocked withPage; header injection; disclaimerRequired | New |
+| `packages/pdf/tests/store.test.ts` | round-trip with mocked R2 + browser; presign TTL clamp; metadata | New |
+| `packages/pdf/tests/presets.test.ts` | preset objects sanity | New |
+| `packages/pdf/README.md` | Public docs incl. cost guidance | New |
+| `.changeset/feat-pdf-init.md` | `@workkit/pdf@0.1.0` initial publish | New |
 
-## Tasks
+## Tasks (TDD red→green order)
 
-TDD: every implementation task must have a preceding test task.
-
-- [ ] [NEEDS CLARIFICATION] Break down into small, testable tasks.
+1. scaffold (package.json, tsconfig, bunup, vitest, README stub)
+2. test:escape → impl:escape
+3. test:safeKey → impl:safeKey
+4. test:presets → impl:presets
+5. test:header → impl:header
+6. test:render → impl:render (mocks `@workkit/browser` `withPage`)
+7. test:store → impl:store (mocks R2 + browser)
+8. wire src/index.ts
+9. lint + typecheck + scoped tests
+10. maina verify
+11. changeset
+12. maina commit
+13. push + PR (base: feature/001-workkit-browser; will rebase to master after #32 merges)
+14. request review
 
 ## Failure Modes
 
-What can go wrong? How do we handle it gracefully?
-
-- [NEEDS CLARIFICATION]
+- **HTML injection in header/footer** — call site forgets to wrap user input → escape-by-default for plain strings; `raw()` is the visible escape hatch.
+- **R2 path traversal via untrusted key parts** — `safeKey()` rejects; render fails with `ValidationError` rather than silently writing outside intended namespace.
+- **Presigned URL TTL exceeds policy** — clamp to max 86400s; warn-or-throw on out-of-range (throw, since silent clamp is worse).
+- **R2 PUT fails mid-render** — render bytes are wasted; surface `ServiceUnavailableError`. Don't retry — caller knows their queue/retry policy.
+- **`disclaimerRequired: true` with empty disclaimer** — fail fast at compose time, not after render. Compliance-friendly.
+- **Browser Rendering 429 / cost spike** — bubble through `@workkit/browser`'s `RateLimitError`; document recommended `@workkit/ratelimit` pre-gate.
+- **Large HTML / large PDF** — document size caps in README; don't pre-validate (puppeteer will reject).
 
 ## Testing Strategy
 
-Unit tests, integration tests, or both? What mocks are needed?
+- **Unit (mocks)** — escape, safeKey, header composition, presets are pure-function tests.
+- **Integration (mocked withPage + R2)** — render and store, with hand-rolled mocks for `withPage(session, fn)` that invoke `fn` with a mock page exposing `setContent`/`pdf`/`addStyleTag`/`evaluate`.
+- **e2e (gated by env var)** — `RUN_BROWSER_INTEGRATION=1 bun test` runs renderPDF against a live binding via wrangler dev. Not in regular CI.
+- **Visual regression** — same `tests/visual-fixtures/` pattern; add a brief HTML and verify PDF render baseline via `maina verify --visual` once available.
 
-- [NEEDS CLARIFICATION]
+## Stacking
+
+- Branch: `feature/003-workkit-pdf`
+- Base: `feature/001-workkit-browser` (pdf needs browser source locally for workspace resolution)
+- Strategy: PR opened against `master` once #32 merges; before that, draft PR against `feature/001-workkit-browser` is acceptable for visibility.
 
 
 ## Wiki Context
 
-### Related Modules
-
-- **src** (69 entities) — `modules/src.md`
-- **cluster-64** (7 entities) — `modules/cluster-64.md`
-
-### Suggestions
-
-- Module 'src' already has 69 entities — consider extending it
-- Module 'cluster-64' already has 7 entities — consider extending it
+Auto-populated by maina; no edits needed.

--- a/.maina/features/003-workkit-pdf/plan.md
+++ b/.maina/features/003-workkit-pdf/plan.md
@@ -1,0 +1,54 @@
+# Implementation Plan
+
+> HOW only — see spec.md for WHAT and WHY.
+
+## Architecture
+
+What is the technical approach? How does it fit into existing architecture?
+Where are the integration points with existing code?
+
+- Pattern: [NEEDS CLARIFICATION]
+- Integration points: [NEEDS CLARIFICATION]
+
+## Key Technical Decisions
+
+What libraries, patterns, or approaches? WHY these and not alternatives?
+
+- [NEEDS CLARIFICATION]
+
+## Files
+
+| File | Purpose | New/Modified |
+|------|---------|-------------|
+| [NEEDS CLARIFICATION] | | |
+
+## Tasks
+
+TDD: every implementation task must have a preceding test task.
+
+- [ ] [NEEDS CLARIFICATION] Break down into small, testable tasks.
+
+## Failure Modes
+
+What can go wrong? How do we handle it gracefully?
+
+- [NEEDS CLARIFICATION]
+
+## Testing Strategy
+
+Unit tests, integration tests, or both? What mocks are needed?
+
+- [NEEDS CLARIFICATION]
+
+
+## Wiki Context
+
+### Related Modules
+
+- **src** (69 entities) — `modules/src.md`
+- **cluster-64** (7 entities) — `modules/cluster-64.md`
+
+### Suggestions
+
+- Module 'src' already has 69 entities — consider extending it
+- Module 'cluster-64' already has 7 entities — consider extending it

--- a/.maina/features/003-workkit-pdf/spec.md
+++ b/.maina/features/003-workkit-pdf/spec.md
@@ -1,0 +1,45 @@
+# Feature: [Name]
+
+## Problem Statement
+
+What specific problem does this solve? Who experiences it? What happens if we don't solve it?
+
+- [NEEDS CLARIFICATION] Define the problem clearly.
+
+## Target User
+
+Who benefits? What is their current workflow? What frustrates them about it?
+
+- Primary: [NEEDS CLARIFICATION]
+- Secondary: [NEEDS CLARIFICATION]
+
+## User Stories
+
+- As a [role], I want [capability] so that [benefit].
+
+## Success Criteria
+
+How do we know this works? Every criterion must be testable — if you can't write
+an assertion for it, the requirement isn't clear enough.
+
+- [ ] [NEEDS CLARIFICATION] Define measurable, testable criteria.
+
+## Scope
+
+### In Scope
+
+- [NEEDS CLARIFICATION] What this feature does.
+
+### Out of Scope
+
+- [NEEDS CLARIFICATION] What this feature explicitly does NOT do (prevents over-building).
+
+## Design Decisions
+
+Key choices made and WHY. Record tradeoffs — future you will thank you.
+
+- [NEEDS CLARIFICATION] What alternatives were considered? Why was this one chosen?
+
+## Open Questions
+
+- [NEEDS CLARIFICATION] List ambiguities. Every question here must be resolved before implementation.

--- a/.maina/features/003-workkit-pdf/spec.md
+++ b/.maina/features/003-workkit-pdf/spec.md
@@ -1,45 +1,75 @@
-# Feature: [Name]
+# Feature: @workkit/pdf — PDF rendering on top of @workkit/browser
+
+Tracks GitHub issue #24. Built on top of #23 (`@workkit/browser`). Stacked on `feature/001-workkit-browser`.
 
 ## Problem Statement
 
-What specific problem does this solve? Who experiences it? What happens if we don't solve it?
+Generating PDFs in Cloudflare Workers is the canonical content-production use case for Browser Rendering, and it's the immediate driver behind building `@workkit/browser`. Without `@workkit/pdf`, every consumer (entryexit briefs first, future products next) re-implements the same `setContent → loadFonts → page.pdf → R2 upload → presign` pipeline and reinvents header/footer composition.
 
-- [NEEDS CLARIFICATION] Define the problem clearly.
+If we don't solve this, PDF code drifts package-to-package, the security defaults (HTML escaping in headers, presign TTL caps, cost monitoring) get re-decided each time, and the boundary with `@workkit/notify` (PDFs as attachments) becomes blurry.
 
 ## Target User
 
-Who benefits? What is their current workflow? What frustrates them about it?
-
-- Primary: [NEEDS CLARIFICATION]
-- Secondary: [NEEDS CLARIFICATION]
+- **Primary**: workkit consumers who need to produce PDF documents (briefs, reports, invoices, statements) inside a Worker, store them in R2, and hand them to `@workkit/notify` as attachments.
+- **Secondary**: future workkit packages that compose pdf with other primitives (e.g., a templating layer or a billing-receipts helper).
 
 ## User Stories
 
-- As a [role], I want [capability] so that [benefit].
+- As an entryexit engineer, I want to render a "Pre-Market Brief" HTML to a PDF and stash it in R2 with a presigned link in one call.
+- As a product engineer, I want to attach a header/logo/timestamp and a regulatory disclaimer footer without writing my own composition.
+- As a security-conscious developer, I want header/footer values from user input HTML-escaped by default so a curated brief can't get hijacked.
+- As a finance/ops engineer, I want a deliberate `disclaimerRequired` mode that fails the render if no disclaimer is present (compliance hook).
 
 ## Success Criteria
 
-How do we know this works? Every criterion must be testable — if you can't write
-an assertion for it, the requirement isn't clear enough.
-
-- [ ] [NEEDS CLARIFICATION] Define measurable, testable criteria.
+- [ ] `renderPDF(html, opts)` returns the PDF byte buffer; works against a real Browser Rendering binding via `@workkit/browser`.
+- [ ] `storedPDF(html, opts)` round-trips through R2 with tagged metadata and returns `{ r2Key, url }` (presigned).
+- [ ] Header/footer values from caller props are HTML-escaped by default; `raw()` opt-in available.
+- [ ] R2 key path-traversal guard (`safeKey()` helper or inline sanitization) blocks `..`, control chars, and absolute paths.
+- [ ] Presigned URL TTL capped (default 3600s, max 24h).
+- [ ] No HTML body content logged.
+- [ ] Browser Rendering errors normalized via `@workkit/browser` (which already maps to `@workkit/errors`).
+- [ ] `@workkit/testing` integration present.
+- [ ] Single `src/index.ts` export.
+- [ ] Changeset added.
+- [ ] LOC budget ≤250 (target 100-200).
+- [ ] README documents cost monitoring guidance and 50k-sessions/month alert.
 
 ## Scope
 
 ### In Scope
 
-- [NEEDS CLARIFICATION] What this feature does.
+- `renderPDF(html, opts)` — pure render returning `Uint8Array`.
+- `storedPDF(html, opts)` — render + R2 upload + presign in one call.
+- Page presets: A4 (default for India market), Letter, Legal.
+- Margin presets: `narrow`, `normal`, `wide`, custom inches/mm.
+- Header/footer composition helpers (logo, timestamp, page number, disclaimer).
+- `escape()` and `raw()` template helpers for header/footer.
+- `safeKey()` helper for R2 path sanitization.
+- R2 metadata tagging hook for `@workkit/cache` invalidation pattern.
+- Cost-awareness guidance in README.
 
 ### Out of Scope
 
-- [NEEDS CLARIFICATION] What this feature explicitly does NOT do (prevents over-building).
+- Browser session management (delegated to `@workkit/browser`).
+- Font loading (delegated to `@workkit/browser`).
+- Tailwind CDN integration helpers (caller owns CSS strategy; we don't ship tailwind).
+- React Email or other component-based template helpers (separate concern).
+- Multi-page document composition / TOC (caller authors HTML).
+- PDF/A or PDF/X compliance (defer until requested).
+- `@react-pdf/renderer` fallback (alternative implementation; defer until cost forces it).
 
 ## Design Decisions
 
-Key choices made and WHY. Record tradeoffs — future you will thank you.
-
-- [NEEDS CLARIFICATION] What alternatives were considered? Why was this one chosen?
+- **Built on `@workkit/browser`** — `withPage` lifecycle is reused so PDF rendering inherits abort safety, JS-off default, and dialog auto-dismiss for free.
+- **Header/footer escape by default** — header/footer content frequently includes user-derived data (timestamps, account numbers). The `raw()` opt-in mirrors React's `dangerouslySetInnerHTML` pattern so explicit risk is visible at the call site.
+- **Presigned URL TTL ceiling** — 3600s default, hard cap at 86400s (24h). Rationale: presigned URLs are bearer tokens, anyone with the link can read. Document the limit; recommend signed cookies / auth proxy for highly sensitive content.
+- **`safeKey()` over silent sanitization** — explicit helper makes the path-traversal risk visible in callsites instead of papering over it. We refuse to silently transform input keys.
+- **A4 as default page size** — primary market is India (entryexit). Letter remains a preset for US-targeted callers.
+- **No tailwind/CSS framework integration** — opinionated about HTML in / PDF out, neutral about how the HTML is built. Avoids tying us to a CSS toolchain that may not match consumer choices.
+- **R2 upload via single-shot PUT in v1** — most briefs <2MB; multipart upload deferred until a real consumer needs it.
 
 ## Open Questions
 
-- [NEEDS CLARIFICATION] List ambiguities. Every question here must be resolved before implementation.
+- Should `storedPDF` accept a `readPolicy: "presigned" | "public" | "private"` so the presign step can be skipped (e.g., signed-cookie consumers)? — Lean yes; simple. Confirm during implementation.
+- Should we support specifying header/footer as a separate HTML string (uses Puppeteer's `displayHeaderFooter` + `headerTemplate`/`footerTemplate`) or always inject inline? — Lean towards inline for v1 simplicity; document inline pattern. Re-evaluate if a consumer needs page-numbered footers.

--- a/.maina/features/003-workkit-pdf/tasks.md
+++ b/.maina/features/003-workkit-pdf/tasks.md
@@ -1,0 +1,23 @@
+# Task Breakdown
+
+## Tasks
+
+Each task should be completable in one commit. Test tasks precede implementation tasks.
+
+- [ ] [NEEDS CLARIFICATION] Define tasks.
+
+## Dependencies
+
+Which tasks block which? Draw the critical path.
+
+- [NEEDS CLARIFICATION]
+
+## Definition of Done
+
+How do we know this feature is complete?
+
+- [ ] All tests pass
+- [ ] Biome lint clean
+- [ ] TypeScript compiles
+- [ ] maina analyze shows no errors
+- [ ] [NEEDS CLARIFICATION] Feature-specific criteria

--- a/.maina/features/003-workkit-pdf/tasks.md
+++ b/.maina/features/003-workkit-pdf/tasks.md
@@ -1,23 +1,45 @@
-# Task Breakdown
+# Task Breakdown — @workkit/pdf
 
 ## Tasks
 
-Each task should be completable in one commit. Test tasks precede implementation tasks.
+Test tasks precede implementation (red → green).
 
-- [ ] [NEEDS CLARIFICATION] Define tasks.
+1. **scaffold**: package.json, tsconfig, bunup, vitest, README stub.
+2. **test:escape** → **impl:escape** — `escape()` HTML-escapes; `raw()` brands as Raw; concatenation auto-escapes plain strings; `Escaped`/`Raw` brand identity.
+3. **test:safeKey** → **impl:safeKey** — joins parts; rejects `..`, `\`, leading `/`, control chars, empty parts; throws `ValidationError` (or pdf-specific `PdfPathError`).
+4. **test:presets** → **impl:presets** — A4 / Letter / Legal dimension constants; margin presets `narrow`/`normal`/`wide`; passthrough for custom margin values.
+5. **test:header** → **impl:header** — composes header/footer template; auto-escapes plain strings; respects `raw()`; produces puppeteer-compatible HTML; `disclaimerRequired` enforcement.
+6. **test:render** → **impl:render** — `renderPDF(html, opts)` returns `Uint8Array`; consumes `withPage` from `@workkit/browser`; passes options through; honors abort signal; loads fonts when supplied; returns bytes.
+7. **test:store** → **impl:store** — `storedPDF(html, opts)` round-trips through R2 mock; tags metadata; presigns with default 3600s; clamps TTL > 24h to error; rejects unsafe key.
+8. **wire** `src/index.ts` exports + types.
+9. **lint + typecheck + scoped tests**.
+10. **maina verify**.
+11. **changeset** for `@workkit/pdf@0.1.0`.
+12. **maina commit**.
+13. **push + PR** against master.
+14. **request review**.
 
 ## Dependencies
 
-Which tasks block which? Draw the critical path.
+```
+1 → 2 → 3 → 4 → 5 → 6 → 7 → 8 → 9 → 10 → 11 → 12 → 13 → 14
+```
 
-- [NEEDS CLARIFICATION]
+Critical path linear. 6 and 7 share the `@workkit/browser` mock surface — define it once in a `tests/_mocks.ts` helper.
 
 ## Definition of Done
 
-How do we know this feature is complete?
-
-- [ ] All tests pass
-- [ ] Biome lint clean
-- [ ] TypeScript compiles
-- [ ] maina analyze shows no errors
-- [ ] [NEEDS CLARIFICATION] Feature-specific criteria
+- [ ] `bun --filter @workkit/pdf test` green
+- [ ] `bun --filter @workkit/pdf typecheck` clean
+- [ ] `biome check packages/pdf` clean
+- [ ] `maina verify` clean
+- [ ] LOC budget ≤250 source lines (target 100-200)
+- [ ] Header/footer escapes plain strings by default; `raw()` opt-in tested
+- [ ] `safeKey()` rejects path traversal and control chars (tested)
+- [ ] Presigned URL TTL default 3600s, hard cap 86400s (tested)
+- [ ] No HTML body content in logs (manual review)
+- [ ] `@workkit/testing` integration present
+- [ ] Single `src/index.ts` export
+- [ ] Changeset added
+- [ ] PR opened, links #24
+- [ ] Review requested

--- a/bun.lock
+++ b/bun.lock
@@ -106,7 +106,7 @@
     },
     "packages/ai-gateway": {
       "name": "@workkit/ai-gateway",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@workkit/errors": "^1.0.1",
         "@workkit/types": "^1.0.1",
@@ -114,7 +114,7 @@
     },
     "packages/api": {
       "name": "@workkit/api",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@workkit/errors": "^1.0.1",
       },
@@ -141,7 +141,7 @@
     },
     "packages/auth": {
       "name": "@workkit/auth",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@workkit/errors": "^1.0.1",
       },
@@ -167,7 +167,7 @@
     },
     "packages/cache": {
       "name": "@workkit/cache",
-      "version": "0.1.1",
+      "version": "0.1.2",
     },
     "packages/chat": {
       "name": "@workkit/chat",
@@ -191,7 +191,7 @@
     },
     "packages/cron": {
       "name": "@workkit/cron",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@workkit/errors": "^1.0.1",
       },
@@ -215,7 +215,7 @@
     },
     "packages/do": {
       "name": "@workkit/do",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@workkit/errors": "^1.0.1",
       },
@@ -287,7 +287,7 @@
     },
     "packages/kv": {
       "name": "@workkit/kv",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@workkit/errors": "^1.0.1",
       },
@@ -306,7 +306,7 @@
     },
     "packages/logger": {
       "name": "@workkit/logger",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
         "@types/node": "^25.0.0",
         "hono": "^4.7.0",
@@ -353,9 +353,26 @@
         "@workkit/types": "workspace:*",
       },
     },
+    "packages/pdf": {
+      "name": "@workkit/pdf",
+      "version": "0.0.0",
+      "dependencies": {
+        "@workkit/browser": "workspace:*",
+        "@workkit/errors": "^1.0.2",
+      },
+      "devDependencies": {
+        "@cloudflare/puppeteer": "^0.0.14",
+      },
+      "peerDependencies": {
+        "@cloudflare/puppeteer": ">=0.0.14",
+      },
+      "optionalPeers": [
+        "@cloudflare/puppeteer",
+      ],
+    },
     "packages/queue": {
       "name": "@workkit/queue",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@workkit/errors": "^1.0.1",
         "@workkit/types": "^1.0.1",
@@ -363,7 +380,7 @@
     },
     "packages/r2": {
       "name": "@workkit/r2",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "dependencies": {
         "@workkit/errors": "^1.0.1",
         "@workkit/types": "^1.0.1",
@@ -371,7 +388,7 @@
     },
     "packages/ratelimit": {
       "name": "@workkit/ratelimit",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@workkit/errors": "^1.0.1",
         "@workkit/types": "^1.0.1",
@@ -1126,6 +1143,8 @@
     "@workkit/mcp": ["@workkit/mcp@workspace:packages/mcp"],
 
     "@workkit/memory": ["@workkit/memory@workspace:packages/memory"],
+
+    "@workkit/pdf": ["@workkit/pdf@workspace:packages/pdf"],
 
     "@workkit/queue": ["@workkit/queue@workspace:packages/queue"],
 

--- a/packages/pdf/README.md
+++ b/packages/pdf/README.md
@@ -1,0 +1,118 @@
+# @workkit/pdf
+
+Render HTML to PDF in Cloudflare Workers via [`@workkit/browser`](../browser). Includes R2 storage + presign helpers, page/margin presets, and a header/footer composer with HTML escaping by default.
+
+## Install
+
+```bash
+bun add @workkit/pdf @workkit/browser @cloudflare/puppeteer
+```
+
+## Quick start
+
+```ts
+import puppeteer from "@cloudflare/puppeteer";
+import { browser } from "@workkit/browser";
+import { renderPDF, storedPDF, raw } from "@workkit/pdf";
+
+export default {
+  async fetch(req: Request, env: Env) {
+    const session = await browser(env.BROWSER, { puppeteer });
+
+    // Pure render
+    const bytes = await renderPDF(session, "<h1>Brief</h1>", {
+      header: { title: "NIFTY", right: new Date().toISOString() },
+      footer: { disclaimer: "Not investment advice", pageNumbers: true },
+      disclaimerRequired: true,
+    });
+
+    // Render + store + presign
+    const { r2Key, url } = await storedPDF(session, "<h1>Brief</h1>", {
+      bucket: env.REPORTS,
+      key: ["reports", "user-1", `${Date.now()}.pdf`],
+      metadata: { userId: "u1", reportId: "r1" },
+      presignTtl: 3600,
+    });
+
+    return new Response(JSON.stringify({ r2Key, url, size: bytes.byteLength }));
+  },
+};
+```
+
+## API
+
+### `renderPDF(session, html, options?)`
+
+Returns `Promise<Uint8Array>`. Uses `@workkit/browser`'s `withPage` so JS-off, dialog auto-dismiss, abort propagation, and guaranteed page close come for free.
+
+Options:
+- `page` — `pageSize.A4 | Letter | Legal`. Default `A4`.
+- `margin` — `string | Partial<PageMargin> | PageMargin`. String applies to all sides.
+- `header` / `footer` — composed via `composeHeaderFooter()`.
+- `disclaimerRequired: true` — fails fast if `footer.disclaimer` is empty.
+- `fonts` — `FontDescriptor[]` preloaded via `@workkit/browser`'s `loadFonts()`.
+- `signal` — `AbortSignal`.
+- `js: true` — opt-in JS execution (off by default).
+- `timeoutMs` — per-render timeout.
+- `waitUntil` — Puppeteer setContent wait state. Default `networkidle2`.
+- `printBackground` — default `true`.
+- `scale` — Puppeteer page scale factor.
+
+### `storedPDF(session, html, options)`
+
+Render → R2 upload → presign in one call. Returns `{ r2Key, bytes, url }`.
+
+Additional options on top of `RenderPdfOptions`:
+- `bucket` — `R2Bucket`-shaped binding (must implement `put` and, when `readPolicy: "presigned"`, `createPresignedUrl`).
+- `key` — `string` or `string[]` (joined via `safeKey()`).
+- `metadata` — `Record<string,string>` forwarded to `customMetadata`.
+- `readPolicy` — `"presigned"` (default) or `"private"` (skips presign, returns `url: null`).
+- `presignTtl` — seconds. Default 3600. **Hard cap 86400 (24h)** — exceeding throws `ValidationError`.
+- `contentDisposition` — overrides the `Content-Disposition` header on the stored object.
+
+### Header / footer composition
+
+```ts
+import { composeHeaderFooter, raw, escapeHtml } from "@workkit/pdf";
+
+composeHeaderFooter({
+  header: {
+    logo: raw('<img src="https://cdn.example.com/logo.png" />'),  // raw HTML
+    title: "NIFTY",                                                // auto-escaped
+    right: new Date().toISOString(),                               // auto-escaped
+  },
+  footer: {
+    disclaimer: "Not investment advice. SEBI Reg No: …",
+    pageNumbers: true,
+  },
+  disclaimerRequired: true,
+});
+```
+
+**Plain strings auto-escape**. Use `raw()` only for HTML you produced or verified yourself.
+
+### `safeKey(...parts)`
+
+Joins parts with `/` after rejecting `..`, `.`, `\`, control chars, and components that reduce to empty after slash trim. Throws `ValidationError` rather than silently sanitizing.
+
+## Security defaults
+
+- **Header/footer values escape by default** — only `raw()` opt-in passes through unescaped.
+- **R2 keys validated** — `safeKey()` rejects path traversal explicitly. No silent transforms.
+- **Presigned URL TTL capped at 24h** — bearer-token blast radius. Use `readPolicy: "private"` for longer-lived access.
+- **JS off by default** — inherits from `@workkit/browser`.
+- **`disclaimerRequired` compliance hook** — fails before render, not after.
+- **No HTML body content logged** — caller's logger sees `r2Key`, `bytes`, durations only.
+
+## Cost monitoring
+
+Browser Rendering is priced per session. Recommended pattern:
+
+1. Wire `@workkit/ratelimit` per user before calling `renderPDF` to bound spend.
+2. Increment an Analytics Engine counter on every render call.
+3. Alert at **50,000 sessions / month** as a sanity ceiling.
+4. If you cross that threshold consistently, evaluate `@react-pdf/renderer` (pure JS) for templated content where Browser Rendering's full layout engine isn't needed.
+
+## Versioning
+
+Follows the workkit Constitution — single `src/index.ts` export, no cross-package imports outside declared peer deps. Changesets accompany every public API change.

--- a/packages/pdf/bunup.config.ts
+++ b/packages/pdf/bunup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "bunup";
+
+export default defineConfig({
+	entry: ["src/index.ts"],
+	format: ["esm"],
+	dts: true,
+	sourcemap: "linked",
+	clean: true,
+	external: ["@workkit/browser", "@workkit/errors", "@cloudflare/puppeteer"],
+});

--- a/packages/pdf/package.json
+++ b/packages/pdf/package.json
@@ -1,0 +1,60 @@
+{
+	"name": "@workkit/pdf",
+	"version": "0.0.0",
+	"description": "Render HTML to PDF in Cloudflare Workers via @workkit/browser; R2 storage and presign helpers",
+	"license": "MIT",
+	"author": "Bikash Dash <beeeku>",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/beeeku/workkit.git",
+		"directory": "packages/pdf"
+	},
+	"type": "module",
+	"exports": {
+		".": {
+			"import": {
+				"types": "./dist/index.d.ts",
+				"default": "./dist/index.js"
+			}
+		}
+	},
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"files": [
+		"dist"
+	],
+	"sideEffects": false,
+	"publishConfig": {
+		"access": "public"
+	},
+	"scripts": {
+		"build": "bunup",
+		"test": "vitest run",
+		"test:watch": "vitest",
+		"typecheck": "tsc --noEmit",
+		"clean": "rm -rf dist"
+	},
+	"dependencies": {
+		"@workkit/browser": "workspace:*",
+		"@workkit/errors": "^1.0.2"
+	},
+	"peerDependencies": {
+		"@cloudflare/puppeteer": ">=0.0.14"
+	},
+	"peerDependenciesMeta": {
+		"@cloudflare/puppeteer": {
+			"optional": true
+		}
+	},
+	"devDependencies": {
+		"@cloudflare/puppeteer": "^0.0.14"
+	},
+	"keywords": [
+		"cloudflare",
+		"workers",
+		"pdf",
+		"browser-rendering",
+		"r2",
+		"workkit"
+	]
+}

--- a/packages/pdf/src/escape.ts
+++ b/packages/pdf/src/escape.ts
@@ -1,0 +1,53 @@
+/**
+ * Header/footer template values are HTML-escaped by default. To inject HTML
+ * intentionally, wrap with `raw()` — that's the only escape hatch.
+ *
+ * Branding via runtime object wrappers (not phantom types) so we can actually
+ * tell at runtime whether a caller marked something as safe.
+ */
+
+const RAW_BRAND: unique symbol = Symbol("@workkit/pdf/raw");
+
+export interface Raw {
+	readonly [RAW_BRAND]: true;
+	readonly html: string;
+}
+
+export type HtmlValue = string | number | boolean | Raw | null | undefined;
+
+const ESC_MAP: Record<string, string> = {
+	"&": "&amp;",
+	"<": "&lt;",
+	">": "&gt;",
+	'"': "&quot;",
+	"'": "&#39;",
+};
+
+export function escapeHtml(value: string | number | boolean | null | undefined): string {
+	if (value === null || value === undefined) return "";
+	const str = typeof value === "string" ? value : String(value);
+	return str.replace(/[&<>"']/g, (ch) => ESC_MAP[ch] ?? ch);
+}
+
+/**
+ * Mark a string as already-safe HTML. Use only with strings you produced
+ * yourself or verified to be safe — anything user-influenced should stay a
+ * plain string and let the composer escape it.
+ */
+export function raw(html: string): Raw {
+	return { [RAW_BRAND]: true, html };
+}
+
+export function isRaw(value: unknown): value is Raw {
+	return typeof value === "object" && value !== null && (value as Raw)[RAW_BRAND] === true;
+}
+
+/**
+ * Coerce a value to safe HTML. Plain strings/numbers/booleans get HTML-
+ * escaped. Only `raw(...)`-wrapped values pass through unescaped.
+ */
+export function toSafeHtml(value: HtmlValue): string {
+	if (value === null || value === undefined) return "";
+	if (isRaw(value)) return value.html;
+	return escapeHtml(value);
+}

--- a/packages/pdf/src/header.ts
+++ b/packages/pdf/src/header.ts
@@ -1,0 +1,71 @@
+import { ValidationError } from "@workkit/errors";
+import { type HtmlValue, toSafeHtml } from "./escape";
+
+export interface HeaderFooterParts {
+	/** Top-line text or HTML. Plain strings are HTML-escaped. */
+	title?: HtmlValue;
+	/** Right-aligned text (e.g., timestamp). */
+	right?: HtmlValue;
+	/** Logo as fully-resolved <img> HTML — wrap with `raw()` in caller. */
+	logo?: HtmlValue;
+}
+
+export interface HeaderFooterOptions {
+	header?: HeaderFooterParts;
+	/**
+	 * Footer parts. If `disclaimerRequired: true`, `disclaimer` must be
+	 * non-empty after coercion or rendering throws `ValidationError`.
+	 */
+	footer?: HeaderFooterParts & { disclaimer?: HtmlValue; pageNumbers?: boolean };
+	/** Compliance hook: refuse to render without a non-empty disclaimer. */
+	disclaimerRequired?: boolean;
+}
+
+export interface ComposedHeaderFooter {
+	displayHeaderFooter: boolean;
+	headerTemplate: string;
+	footerTemplate: string;
+}
+
+const BASE_STYLE =
+	"font-size:9px;color:#555;width:100%;padding:0 .5in;display:flex;justify-content:space-between;align-items:center;";
+
+function composeHeader(parts: HeaderFooterParts): string {
+	const left = toSafeHtml(parts.logo ?? parts.title ?? "");
+	const right = toSafeHtml(parts.right ?? "");
+	return `<div style="${BASE_STYLE}"><span>${left}</span><span>${right}</span></div>`;
+}
+
+function composeFooter(
+	parts: HeaderFooterParts & { disclaimer?: HtmlValue; pageNumbers?: boolean },
+): string {
+	const disclaimer = toSafeHtml(parts.disclaimer ?? "");
+	const pages = parts.pageNumbers
+		? '<span><span class="pageNumber"></span> / <span class="totalPages"></span></span>'
+		: "";
+	return `<div style="${BASE_STYLE}"><span>${disclaimer}</span>${pages}</div>`;
+}
+
+export function composeHeaderFooter(options: HeaderFooterOptions): ComposedHeaderFooter {
+	const hasHeader = options.header !== undefined;
+	const hasFooter = options.footer !== undefined;
+
+	if (options.disclaimerRequired === true) {
+		const disclaimer = options.footer?.disclaimer;
+		const rendered = toSafeHtml(disclaimer ?? "").trim();
+		if (rendered.length === 0) {
+			throw new ValidationError("disclaimer is required but empty", [
+				{
+					path: ["footer", "disclaimer"],
+					message: "disclaimerRequired:true demands a non-empty footer.disclaimer",
+				},
+			]);
+		}
+	}
+
+	return {
+		displayHeaderFooter: hasHeader || hasFooter,
+		headerTemplate: hasHeader ? composeHeader(options.header ?? {}) : "<div></div>",
+		footerTemplate: hasFooter ? composeFooter(options.footer ?? {}) : "<div></div>",
+	};
+}

--- a/packages/pdf/src/index.ts
+++ b/packages/pdf/src/index.ts
@@ -1,0 +1,25 @@
+// Render
+export { renderPDF } from "./render";
+export type { RenderPdfOptions } from "./render";
+
+// Store
+export { storedPDF } from "./store";
+export type { StorePdfOptions, StorePdfResult, ReadPolicy } from "./store";
+
+// Header / footer composition
+export { composeHeaderFooter } from "./header";
+export type { HeaderFooterOptions, HeaderFooterParts, ComposedHeaderFooter } from "./header";
+
+// Escape helpers
+export { escapeHtml, raw, isRaw, toSafeHtml } from "./escape";
+export type { Raw, HtmlValue } from "./escape";
+
+// R2 key safety
+export { safeKey } from "./safe-key";
+
+// Presets
+export { pageSize, margin, defaults, resolveMargin } from "./presets";
+export type { PageSize, PageMargin } from "./presets";
+
+// Public types
+export type { R2BucketLike, PdfCapablePage, PdfPageOptions } from "./types";

--- a/packages/pdf/src/presets.ts
+++ b/packages/pdf/src/presets.ts
@@ -33,10 +33,10 @@ export const margin = {
 } as const;
 
 /** Default for the Indian market (entryexit's primary audience). */
-export const defaults = {
+export const defaults: { page: PageSize; margin: PageMargin } = {
 	page: pageSize.A4,
 	margin: margin.normal,
-} as const;
+};
 
 /**
  * Coerce a user-supplied margin shape into a `PageMargin`. Accepts a single

--- a/packages/pdf/src/presets.ts
+++ b/packages/pdf/src/presets.ts
@@ -1,0 +1,59 @@
+/**
+ * Page size + margin presets. Dimensions in inches; Puppeteer accepts unit
+ * suffixes in `format`/`margin` strings, but for clarity we expose
+ * structured shapes and convert at call time.
+ */
+
+export interface PageSize {
+	/** Page format string (Puppeteer-recognized: A4, Letter, Legal, etc.). */
+	format: "A4" | "Letter" | "Legal";
+	/** Width in inches (informational; Puppeteer derives from format). */
+	width: number;
+	/** Height in inches (informational; Puppeteer derives from format). */
+	height: number;
+}
+
+export interface PageMargin {
+	top: string;
+	bottom: string;
+	left: string;
+	right: string;
+}
+
+export const pageSize = {
+	A4: { format: "A4", width: 8.27, height: 11.69 } as PageSize,
+	Letter: { format: "Letter", width: 8.5, height: 11 } as PageSize,
+	Legal: { format: "Legal", width: 8.5, height: 14 } as PageSize,
+} as const;
+
+export const margin = {
+	narrow: { top: "0.5in", bottom: "0.5in", left: "0.5in", right: "0.5in" } as PageMargin,
+	normal: { top: "1in", bottom: "1in", left: "1in", right: "1in" } as PageMargin,
+	wide: { top: "1.5in", bottom: "1.5in", left: "1.5in", right: "1.5in" } as PageMargin,
+} as const;
+
+/** Default for the Indian market (entryexit's primary audience). */
+export const defaults = {
+	page: pageSize.A4,
+	margin: margin.normal,
+} as const;
+
+/**
+ * Coerce a user-supplied margin shape into a `PageMargin`. Accepts a single
+ * string (applies to all sides), a partial object (missing sides default to
+ * `1in`), or a full margin record.
+ */
+export function resolveMargin(
+	value: string | Partial<PageMargin> | PageMargin | undefined,
+): PageMargin {
+	if (value === undefined) return defaults.margin;
+	if (typeof value === "string") {
+		return { top: value, bottom: value, left: value, right: value };
+	}
+	return {
+		top: value.top ?? "1in",
+		bottom: value.bottom ?? "1in",
+		left: value.left ?? "1in",
+		right: value.right ?? "1in",
+	};
+}

--- a/packages/pdf/src/render.ts
+++ b/packages/pdf/src/render.ts
@@ -1,0 +1,69 @@
+import { loadFonts, withPage } from "@workkit/browser";
+import { type HeaderFooterOptions, composeHeaderFooter } from "./header";
+import { type PageMargin, type PageSize, defaults, resolveMargin } from "./presets";
+import type { BrowserSessionLike, FontDescriptor, PdfCapablePage, PdfPageOptions } from "./types";
+
+export interface RenderPdfOptions extends HeaderFooterOptions {
+	/** Page size preset or shape. Default: A4. */
+	page?: PageSize;
+	/** Margin preset, full record, partial, or single string. Default: 1in all sides. */
+	margin?: string | Partial<PageMargin> | PageMargin;
+	/** Print backgrounds (default true — most reports want them). */
+	printBackground?: boolean;
+	/** Optional font preloads applied via `@workkit/browser`'s `loadFonts`. */
+	fonts?: FontDescriptor[];
+	/** Forwarded to `withPage`'s abort signal. */
+	signal?: AbortSignal;
+	/** Allow JS execution in the rendered HTML. Default false. */
+	js?: boolean;
+	/** Per-render operation timeout (ms). Default 15000 (or env override). */
+	timeoutMs?: number;
+	/** Override Puppeteer's `setContent` waitUntil. Default `networkidle2`. */
+	waitUntil?: "load" | "domcontentloaded" | "networkidle0" | "networkidle2";
+	/** Page scale factor (Puppeteer). */
+	scale?: number;
+}
+
+/**
+ * Render an HTML string to a PDF byte array using the supplied browser session.
+ *
+ * Uses `@workkit/browser`'s `withPage` so JS-off, dialog auto-dismiss, abort
+ * propagation, and guaranteed page close come for free.
+ */
+export async function renderPDF(
+	session: BrowserSessionLike,
+	html: string,
+	options: RenderPdfOptions = {},
+): Promise<Uint8Array> {
+	const composed = composeHeaderFooter(options);
+	const margin = resolveMargin(options.margin);
+	const page = options.page ?? defaults.page;
+	const waitUntil = options.waitUntil ?? "networkidle2";
+
+	const pdfOptions: PdfPageOptions = {
+		format: page.format,
+		margin,
+		printBackground: options.printBackground !== false,
+		displayHeaderFooter: composed.displayHeaderFooter,
+		headerTemplate: composed.headerTemplate,
+		footerTemplate: composed.footerTemplate,
+	};
+	if (options.scale !== undefined) pdfOptions.scale = options.scale;
+
+	return await withPage(
+		session,
+		async (rawPage) => {
+			const pdfPage = rawPage as PdfCapablePage;
+			await pdfPage.setContent(html, { waitUntil });
+			if (options.fonts && options.fonts.length > 0) {
+				await loadFonts(pdfPage, options.fonts);
+			}
+			return await pdfPage.pdf(pdfOptions);
+		},
+		{
+			signal: options.signal,
+			js: options.js,
+			timeoutMs: options.timeoutMs,
+		},
+	);
+}

--- a/packages/pdf/src/safe-key.ts
+++ b/packages/pdf/src/safe-key.ts
@@ -1,0 +1,65 @@
+import { ValidationError } from "@workkit/errors";
+
+function hasUnsafeKeyChar(value: string): boolean {
+	for (let i = 0; i < value.length; i++) {
+		const code = value.charCodeAt(i);
+		if (code <= 0x1f || code === 0x7f) return true;
+		if (code === 0x5c) return true; // backslash
+	}
+	return false;
+}
+
+/**
+ * Build a safe R2 object key from path parts. Rejects components that contain
+ * `..`, backslashes, control characters, or that look like absolute paths
+ * (leading `/`). Empty parts are rejected (caller likely has a bug).
+ *
+ * Returns the joined key; throws `ValidationError` on disallowed input rather
+ * than silently transforming it — path traversal should be loud at the call
+ * site.
+ */
+export function safeKey(...parts: string[]): string {
+	if (parts.length === 0) {
+		throw new ValidationError("safeKey requires at least one path component", [
+			{ path: ["safeKey"], message: "no path components supplied" },
+		]);
+	}
+
+	const cleaned: string[] = [];
+	for (let i = 0; i < parts.length; i++) {
+		const raw = parts[i];
+		if (typeof raw !== "string" || raw.length === 0) {
+			throw new ValidationError("safeKey path component is empty", [
+				{ path: ["safeKey", String(i)], message: "empty component" },
+			]);
+		}
+		if (raw === "." || raw === "..") {
+			throw new ValidationError("safeKey rejects relative path components", [
+				{ path: ["safeKey", String(i)], message: `rejected component: ${raw}` },
+			]);
+		}
+		if (hasUnsafeKeyChar(raw)) {
+			throw new ValidationError("safeKey rejects control characters and backslashes", [
+				{ path: ["safeKey", String(i)], message: "unsafe character in component" },
+			]);
+		}
+		// Strip leading/trailing slashes from each part; reject if it tries to
+		// escape upward via embedded ".." segments.
+		const trimmed = raw.replace(/^\/+|\/+$/g, "");
+		if (trimmed.length === 0) {
+			throw new ValidationError("safeKey path component is only slashes", [
+				{ path: ["safeKey", String(i)], message: "component reduced to empty" },
+			]);
+		}
+		const segments = trimmed.split("/");
+		for (const seg of segments) {
+			if (seg === "" || seg === "." || seg === "..") {
+				throw new ValidationError("safeKey rejects empty/relative path segments", [
+					{ path: ["safeKey", String(i), seg], message: "disallowed path segment" },
+				]);
+			}
+		}
+		cleaned.push(trimmed);
+	}
+	return cleaned.join("/");
+}

--- a/packages/pdf/src/store.ts
+++ b/packages/pdf/src/store.ts
@@ -1,0 +1,82 @@
+import { ConfigError, ValidationError } from "@workkit/errors";
+import { type RenderPdfOptions, renderPDF } from "./render";
+import { safeKey } from "./safe-key";
+import type { BrowserSessionLike, R2BucketLike } from "./types";
+
+const MAX_PRESIGN_TTL_S = 86_400; // 24h hard cap on bearer-style URLs.
+const DEFAULT_PRESIGN_TTL_S = 3_600;
+
+export type ReadPolicy = "presigned" | "private";
+
+export interface StorePdfOptions extends RenderPdfOptions {
+	bucket: R2BucketLike;
+	/** Either an already-safe key string, or path parts to feed `safeKey()`. */
+	key: string | string[];
+	/** Custom R2 metadata (tagged for cache invalidation patterns, etc.). */
+	metadata?: Record<string, string>;
+	/** `presigned` (default) returns a `url`; `private` returns `url: null`. */
+	readPolicy?: ReadPolicy;
+	/** Presigned URL TTL in seconds. Default 3600. Hard cap 86400. */
+	presignTtl?: number;
+	/** Override `Content-Disposition` header on the stored object. */
+	contentDisposition?: string;
+}
+
+export interface StorePdfResult {
+	r2Key: string;
+	bytes: number;
+	url: string | null;
+}
+
+/**
+ * Render to PDF and upload to R2 in one call. Returns the (sanitized) key,
+ * the byte size, and a presigned URL (unless `readPolicy: "private"`).
+ *
+ * SECURITY: presigned URLs are bearer tokens. The TTL is capped at 24h to
+ * limit blast radius if a link leaks; for highly sensitive content prefer
+ * `readPolicy: "private"` and fetch via an authenticated proxy.
+ */
+export async function storedPDF(
+	session: BrowserSessionLike,
+	html: string,
+	options: StorePdfOptions,
+): Promise<StorePdfResult> {
+	const r2Key = Array.isArray(options.key) ? safeKey(...options.key) : safeKey(options.key);
+
+	const ttl = options.presignTtl ?? DEFAULT_PRESIGN_TTL_S;
+	if (!Number.isFinite(ttl) || ttl <= 0) {
+		throw new ValidationError("presignTtl must be a positive number of seconds", [
+			{ path: ["presignTtl"], message: "non-positive presign TTL" },
+		]);
+	}
+	if (ttl > MAX_PRESIGN_TTL_S) {
+		throw new ValidationError(
+			`presignTtl exceeds 24h cap (${MAX_PRESIGN_TTL_S}s). Use readPolicy:'private' for longer-lived access.`,
+			[{ path: ["presignTtl"], message: `requested ${ttl}s, max ${MAX_PRESIGN_TTL_S}s` }],
+		);
+	}
+
+	const bytes = await renderPDF(session, html, options);
+
+	await options.bucket.put(r2Key, bytes, {
+		httpMetadata: {
+			contentType: "application/pdf",
+			contentDisposition: options.contentDisposition,
+		},
+		customMetadata: options.metadata,
+	});
+
+	const policy: ReadPolicy = options.readPolicy ?? "presigned";
+	if (policy === "private") {
+		return { r2Key, bytes: bytes.byteLength, url: null };
+	}
+
+	if (typeof options.bucket.createPresignedUrl !== "function") {
+		throw new ConfigError(
+			"R2 bucket binding does not support createPresignedUrl. Use readPolicy:'private' or upgrade your binding.",
+		);
+	}
+
+	const url = await options.bucket.createPresignedUrl(r2Key, { expiresIn: ttl, method: "GET" });
+	return { r2Key, bytes: bytes.byteLength, url };
+}

--- a/packages/pdf/src/types.ts
+++ b/packages/pdf/src/types.ts
@@ -1,0 +1,43 @@
+import type { BrowserPageLike, BrowserSessionLike, FontDescriptor } from "@workkit/browser";
+
+/**
+ * The subset of `R2Bucket` we use. Letting consumers pass any binding-shape
+ * that implements these methods keeps tests trivial and avoids a hard
+ * dependency on `@cloudflare/workers-types` at the type level.
+ */
+export interface R2BucketLike {
+	put(
+		key: string,
+		body: ArrayBuffer | ArrayBufferView | ReadableStream | string,
+		options?: {
+			httpMetadata?: { contentType?: string; contentDisposition?: string };
+			customMetadata?: Record<string, string>;
+		},
+	): Promise<unknown>;
+	createPresignedUrl?: (
+		key: string,
+		options: { expiresIn: number; method?: "GET" | "PUT" },
+	) => Promise<string>;
+}
+
+/** A page that supports `setContent` + `pdf` (Puppeteer-compatible). */
+export interface PdfCapablePage extends BrowserPageLike {
+	setContent(
+		html: string,
+		options?: { waitUntil?: string | string[]; timeout?: number },
+	): Promise<void>;
+	pdf(options?: PdfPageOptions): Promise<Uint8Array>;
+}
+
+export interface PdfPageOptions {
+	format?: string;
+	margin?: { top?: string; bottom?: string; left?: string; right?: string };
+	printBackground?: boolean;
+	displayHeaderFooter?: boolean;
+	headerTemplate?: string;
+	footerTemplate?: string;
+	preferCSSPageSize?: boolean;
+	scale?: number;
+}
+
+export type { BrowserSessionLike, FontDescriptor };

--- a/packages/pdf/tests/_mocks.ts
+++ b/packages/pdf/tests/_mocks.ts
@@ -1,0 +1,76 @@
+import type { BrowserPageLike, BrowserSessionLike } from "@workkit/browser";
+import type { PdfCapablePage, PdfPageOptions, R2BucketLike } from "../src/types";
+
+export interface MockPage extends PdfCapablePage {
+	captured: {
+		html?: string;
+		pdfOptions?: PdfPageOptions;
+		closed: number;
+		setJsEnabled?: boolean;
+	};
+}
+
+export function mockSession(returnBytes = new Uint8Array([0x25, 0x50, 0x44, 0x46])): {
+	session: BrowserSessionLike;
+	page: MockPage;
+} {
+	const page: MockPage = {
+		captured: { closed: 0 },
+		setJavaScriptEnabled(enabled) {
+			this.captured.setJsEnabled = enabled;
+		},
+		setDefaultTimeout() {},
+		setDefaultNavigationTimeout() {},
+		on() {
+			return this;
+		},
+		async setContent(html) {
+			this.captured.html = html;
+		},
+		async pdf(options) {
+			this.captured.pdfOptions = options;
+			return returnBytes;
+		},
+		async close() {
+			this.captured.closed += 1;
+		},
+	};
+	return {
+		session: {
+			async newPage() {
+				return page as BrowserPageLike;
+			},
+			async close() {},
+		},
+		page,
+	};
+}
+
+export interface MockBucket extends R2BucketLike {
+	puts: { key: string; bytes: number; metadata?: Record<string, string>; contentType?: string }[];
+	presignCalls: { key: string; expiresIn: number }[];
+}
+
+export function mockBucket(opts: { supportsPresign?: boolean } = {}): MockBucket {
+	const supportsPresign = opts.supportsPresign !== false;
+	const bucket: MockBucket = {
+		puts: [],
+		presignCalls: [],
+		async put(key, body, options) {
+			const buf = body instanceof Uint8Array ? body : new Uint8Array(0);
+			bucket.puts.push({
+				key,
+				bytes: buf.byteLength,
+				metadata: options?.customMetadata,
+				contentType: options?.httpMetadata?.contentType,
+			});
+		},
+	};
+	if (supportsPresign) {
+		bucket.createPresignedUrl = async (key, options) => {
+			bucket.presignCalls.push({ key, expiresIn: options.expiresIn });
+			return `https://signed.example.com/${key}?ttl=${options.expiresIn}`;
+		};
+	}
+	return bucket;
+}

--- a/packages/pdf/tests/escape.test.ts
+++ b/packages/pdf/tests/escape.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { escapeHtml, isRaw, raw, toSafeHtml } from "../src/escape";
+
+describe("escapeHtml() (renamed from escape to avoid the global)", () => {
+	it("escapes HTML special chars", () => {
+		expect(escapeHtml(`<div class="x">a & b</div>`)).toBe(
+			"&lt;div class=&quot;x&quot;&gt;a &amp; b&lt;/div&gt;",
+		);
+	});
+
+	it("escapes single quotes", () => {
+		expect(escapeHtml("it's")).toBe("it&#39;s");
+	});
+
+	it("coerces numbers and booleans", () => {
+		expect(escapeHtml(42)).toBe("42");
+		expect(escapeHtml(true)).toBe("true");
+	});
+
+	it("returns empty string for null/undefined", () => {
+		expect(escapeHtml(null)).toBe("");
+		expect(escapeHtml(undefined)).toBe("");
+	});
+});
+
+describe("raw() / isRaw()", () => {
+	it("brands a string and isRaw recognizes it", () => {
+		const r = raw("<b>safe</b>");
+		expect(isRaw(r)).toBe(true);
+		expect(isRaw("<b>plain</b>")).toBe(false);
+		expect(isRaw(42)).toBe(false);
+		expect(isRaw(null)).toBe(false);
+	});
+});
+
+describe("toSafeHtml()", () => {
+	it("escapes plain strings", () => {
+		expect(toSafeHtml("<x>")).toBe("&lt;x&gt;");
+	});
+
+	it("passes raw() through unescaped", () => {
+		expect(toSafeHtml(raw("<x>"))).toBe("<x>");
+	});
+
+	it("returns empty for null/undefined", () => {
+		expect(toSafeHtml(null)).toBe("");
+		expect(toSafeHtml(undefined)).toBe("");
+	});
+
+	it("escapes numbers and booleans", () => {
+		expect(toSafeHtml(42)).toBe("42");
+	});
+});

--- a/packages/pdf/tests/header.test.ts
+++ b/packages/pdf/tests/header.test.ts
@@ -1,0 +1,64 @@
+import { ValidationError } from "@workkit/errors";
+import { describe, expect, it } from "vitest";
+import { raw } from "../src/escape";
+import { composeHeaderFooter } from "../src/header";
+
+describe("composeHeaderFooter()", () => {
+	it("emits empty placeholder templates when no parts supplied", () => {
+		const c = composeHeaderFooter({});
+		expect(c.displayHeaderFooter).toBe(false);
+		expect(c.headerTemplate).toBe("<div></div>");
+		expect(c.footerTemplate).toBe("<div></div>");
+	});
+
+	it("escapes plain string title by default", () => {
+		const c = composeHeaderFooter({ header: { title: "<b>Q4</b> & beyond" } });
+		expect(c.displayHeaderFooter).toBe(true);
+		expect(c.headerTemplate).toContain("&lt;b&gt;Q4&lt;/b&gt; &amp; beyond");
+		expect(c.headerTemplate).not.toContain("<b>Q4</b>");
+	});
+
+	it("emits raw HTML when caller wraps with raw()", () => {
+		const c = composeHeaderFooter({
+			header: { logo: raw('<img src="https://x.example.com/l.png" />') },
+		});
+		expect(c.headerTemplate).toContain('<img src="https://x.example.com/l.png" />');
+	});
+
+	it("escapes injection attempts in right slot", () => {
+		const c = composeHeaderFooter({ header: { right: '"><script>alert(1)</script>' } });
+		expect(c.headerTemplate).not.toContain("<script>");
+	});
+
+	it("includes pageNumber spans only when pageNumbers: true", () => {
+		const off = composeHeaderFooter({ footer: { disclaimer: "Not advice" } });
+		expect(off.footerTemplate).not.toContain("pageNumber");
+
+		const on = composeHeaderFooter({
+			footer: { disclaimer: "Not advice", pageNumbers: true },
+		});
+		expect(on.footerTemplate).toContain('class="pageNumber"');
+		expect(on.footerTemplate).toContain('class="totalPages"');
+	});
+
+	it("throws ValidationError when disclaimerRequired but disclaimer missing", () => {
+		expect(() =>
+			composeHeaderFooter({
+				disclaimerRequired: true,
+				footer: { disclaimer: "" },
+			}),
+		).toThrow(ValidationError);
+		expect(() =>
+			composeHeaderFooter({ disclaimerRequired: true, footer: { disclaimer: "   " } }),
+		).toThrow(ValidationError);
+		expect(() => composeHeaderFooter({ disclaimerRequired: true })).toThrow(ValidationError);
+	});
+
+	it("disclaimerRequired passes when a non-empty disclaimer is present", () => {
+		const c = composeHeaderFooter({
+			disclaimerRequired: true,
+			footer: { disclaimer: "Not investment advice" },
+		});
+		expect(c.footerTemplate).toContain("Not investment advice");
+	});
+});

--- a/packages/pdf/tests/presets.test.ts
+++ b/packages/pdf/tests/presets.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { defaults, margin, pageSize, resolveMargin } from "../src/presets";
+
+describe("page size presets", () => {
+	it("exposes A4 / Letter / Legal with formats", () => {
+		expect(pageSize.A4.format).toBe("A4");
+		expect(pageSize.Letter.format).toBe("Letter");
+		expect(pageSize.Legal.format).toBe("Legal");
+	});
+
+	it("defaults to A4 + 1in normal margin", () => {
+		expect(defaults.page).toBe(pageSize.A4);
+		expect(defaults.margin).toEqual(margin.normal);
+	});
+});
+
+describe("resolveMargin()", () => {
+	it("returns default when undefined", () => {
+		expect(resolveMargin(undefined)).toEqual(margin.normal);
+	});
+
+	it("expands a single string to all sides", () => {
+		expect(resolveMargin("0.5in")).toEqual({
+			top: "0.5in",
+			bottom: "0.5in",
+			left: "0.5in",
+			right: "0.5in",
+		});
+	});
+
+	it("fills missing sides from partial", () => {
+		expect(resolveMargin({ top: "2in" })).toEqual({
+			top: "2in",
+			bottom: "1in",
+			left: "1in",
+			right: "1in",
+		});
+	});
+
+	it("passes through full margin record", () => {
+		const m = { top: "1in", bottom: "2in", left: "3in", right: "4in" };
+		expect(resolveMargin(m)).toEqual(m);
+	});
+});

--- a/packages/pdf/tests/render.test.ts
+++ b/packages/pdf/tests/render.test.ts
@@ -1,0 +1,81 @@
+import { ValidationError } from "@workkit/errors";
+import { describe, expect, it } from "vitest";
+import { raw } from "../src/escape";
+import { renderPDF } from "../src/render";
+import { mockSession } from "./_mocks";
+
+describe("renderPDF()", () => {
+	it("returns the PDF bytes from page.pdf()", async () => {
+		const { session, page } = mockSession();
+		const out = await renderPDF(session, "<h1>hi</h1>");
+		expect(out).toBeInstanceOf(Uint8Array);
+		expect(page.captured.html).toContain("<h1>hi</h1>");
+	});
+
+	it("defaults page format to A4 and printBackground to true", async () => {
+		const { session, page } = mockSession();
+		await renderPDF(session, "<p>x</p>");
+		expect(page.captured.pdfOptions?.format).toBe("A4");
+		expect(page.captured.pdfOptions?.printBackground).toBe(true);
+	});
+
+	it("applies the supplied margin string to all sides", async () => {
+		const { session, page } = mockSession();
+		await renderPDF(session, "<p>x</p>", { margin: "0.5in" });
+		expect(page.captured.pdfOptions?.margin).toEqual({
+			top: "0.5in",
+			bottom: "0.5in",
+			left: "0.5in",
+			right: "0.5in",
+		});
+	});
+
+	it("composes header/footer when supplied", async () => {
+		const { session, page } = mockSession();
+		await renderPDF(session, "<p>x</p>", {
+			header: { title: "Pre-Market" },
+			footer: { disclaimer: "Not advice", pageNumbers: true },
+		});
+		expect(page.captured.pdfOptions?.displayHeaderFooter).toBe(true);
+		expect(page.captured.pdfOptions?.headerTemplate).toContain("Pre-Market");
+		expect(page.captured.pdfOptions?.footerTemplate).toContain("Not advice");
+		expect(page.captured.pdfOptions?.footerTemplate).toContain("pageNumber");
+	});
+
+	it("escapes a plain-string title in the header", async () => {
+		const { session, page } = mockSession();
+		await renderPDF(session, "<p>x</p>", { header: { title: "<script>x</script>" } });
+		expect(page.captured.pdfOptions?.headerTemplate).not.toContain("<script>x</script>");
+		expect(page.captured.pdfOptions?.headerTemplate).toContain("&lt;script&gt;");
+	});
+
+	it("respects raw() in header logo", async () => {
+		const { session, page } = mockSession();
+		await renderPDF(session, "<p>x</p>", {
+			header: { logo: raw('<img src="https://x.example.com/l.png" />') },
+		});
+		expect(page.captured.pdfOptions?.headerTemplate).toContain(
+			'<img src="https://x.example.com/l.png" />',
+		);
+	});
+
+	it("disables JS by default (delegated to withPage)", async () => {
+		const { session, page } = mockSession();
+		await renderPDF(session, "<p>x</p>");
+		expect(page.captured.setJsEnabled).toBe(false);
+	});
+
+	it("propagates abort signal to withPage", async () => {
+		const { session } = mockSession();
+		const ctrl = new AbortController();
+		ctrl.abort(new Error("nope"));
+		await expect(renderPDF(session, "<p>x</p>", { signal: ctrl.signal })).rejects.toThrow("nope");
+	});
+
+	it("throws ValidationError when disclaimerRequired but disclaimer missing (before opening a page)", async () => {
+		const { session } = mockSession();
+		await expect(
+			renderPDF(session, "<p>x</p>", { disclaimerRequired: true }),
+		).rejects.toBeInstanceOf(ValidationError);
+	});
+});

--- a/packages/pdf/tests/safe-key.test.ts
+++ b/packages/pdf/tests/safe-key.test.ts
@@ -1,0 +1,53 @@
+import { ValidationError } from "@workkit/errors";
+import { describe, expect, it } from "vitest";
+import { safeKey } from "../src/safe-key";
+
+describe("safeKey()", () => {
+	it("joins parts with /", () => {
+		expect(safeKey("reports", "user-1", "brief.pdf")).toBe("reports/user-1/brief.pdf");
+	});
+
+	it("trims leading/trailing slashes per part", () => {
+		expect(safeKey("/reports/", "/user-1/", "/brief.pdf")).toBe("reports/user-1/brief.pdf");
+	});
+
+	it("rejects empty input list", () => {
+		expect(() => safeKey()).toThrow(ValidationError);
+	});
+
+	it("rejects empty parts", () => {
+		expect(() => safeKey("reports", "", "brief.pdf")).toThrow(ValidationError);
+	});
+
+	it("rejects '..' as a component", () => {
+		expect(() => safeKey("reports", "..", "brief.pdf")).toThrow(ValidationError);
+	});
+
+	it("rejects embedded '..' segments", () => {
+		expect(() => safeKey("reports/../etc", "brief.pdf")).toThrow(ValidationError);
+	});
+
+	it("rejects '.' as a component", () => {
+		expect(() => safeKey("reports", ".", "brief.pdf")).toThrow(ValidationError);
+	});
+
+	it("rejects backslash", () => {
+		expect(() => safeKey("reports", "a\\b", "brief.pdf")).toThrow(ValidationError);
+	});
+
+	it("rejects control characters", () => {
+		expect(() => safeKey("reports", "a\u0007b", "brief.pdf")).toThrow(ValidationError);
+	});
+
+	it("rejects DEL (0x7F)", () => {
+		expect(() => safeKey("reports", "a\u007Fb", "brief.pdf")).toThrow(ValidationError);
+	});
+
+	it("rejects components that reduce to empty after slash trim", () => {
+		expect(() => safeKey("reports", "///", "brief.pdf")).toThrow(ValidationError);
+	});
+
+	it("allows internal slashes within a single part", () => {
+		expect(safeKey("reports/2026/q1", "brief.pdf")).toBe("reports/2026/q1/brief.pdf");
+	});
+});

--- a/packages/pdf/tests/store.test.ts
+++ b/packages/pdf/tests/store.test.ts
@@ -1,0 +1,95 @@
+import { ConfigError, ValidationError } from "@workkit/errors";
+import { describe, expect, it } from "vitest";
+import { storedPDF } from "../src/store";
+import { mockBucket, mockSession } from "./_mocks";
+
+describe("storedPDF()", () => {
+	it("renders, uploads, presigns, and returns the key + bytes + url", async () => {
+		const { session } = mockSession(new Uint8Array([1, 2, 3, 4, 5]));
+		const bucket = mockBucket();
+		const result = await storedPDF(session, "<p>brief</p>", {
+			bucket,
+			key: ["reports", "user-1", "brief.pdf"],
+		});
+		expect(result.r2Key).toBe("reports/user-1/brief.pdf");
+		expect(result.bytes).toBe(5);
+		expect(result.url).toContain("https://signed.example.com/reports/user-1/brief.pdf");
+		expect(bucket.puts[0]?.bytes).toBe(5);
+		expect(bucket.puts[0]?.contentType).toBe("application/pdf");
+		expect(bucket.presignCalls[0]?.expiresIn).toBe(3600);
+	});
+
+	it("accepts a single safe-key string for `key`", async () => {
+		const { session } = mockSession();
+		const bucket = mockBucket();
+		const result = await storedPDF(session, "<p>x</p>", {
+			bucket,
+			key: "reports/2026/q1/brief.pdf",
+		});
+		expect(result.r2Key).toBe("reports/2026/q1/brief.pdf");
+	});
+
+	it("rejects unsafe key parts", async () => {
+		const { session } = mockSession();
+		const bucket = mockBucket();
+		await expect(
+			storedPDF(session, "<p>x</p>", { bucket, key: ["reports", "..", "brief.pdf"] }),
+		).rejects.toBeInstanceOf(ValidationError);
+		expect(bucket.puts).toHaveLength(0);
+	});
+
+	it("clamps via throw when presignTtl exceeds 24h", async () => {
+		const { session } = mockSession();
+		const bucket = mockBucket();
+		await expect(
+			storedPDF(session, "<p>x</p>", {
+				bucket,
+				key: ["x.pdf"],
+				presignTtl: 86_401,
+			}),
+		).rejects.toBeInstanceOf(ValidationError);
+	});
+
+	it("rejects non-positive presignTtl", async () => {
+		const { session } = mockSession();
+		const bucket = mockBucket();
+		await expect(
+			storedPDF(session, "<p>x</p>", {
+				bucket,
+				key: ["x.pdf"],
+				presignTtl: 0,
+			}),
+		).rejects.toBeInstanceOf(ValidationError);
+	});
+
+	it("returns url:null when readPolicy: 'private'", async () => {
+		const { session } = mockSession();
+		const bucket = mockBucket();
+		const result = await storedPDF(session, "<p>x</p>", {
+			bucket,
+			key: ["x.pdf"],
+			readPolicy: "private",
+		});
+		expect(result.url).toBeNull();
+		expect(bucket.presignCalls).toHaveLength(0);
+	});
+
+	it("throws ConfigError if presign requested but bucket lacks createPresignedUrl", async () => {
+		const { session } = mockSession();
+		const bucket = mockBucket({ supportsPresign: false });
+		await expect(storedPDF(session, "<p>x</p>", { bucket, key: ["x.pdf"] })).rejects.toBeInstanceOf(
+			ConfigError,
+		);
+	});
+
+	it("forwards customMetadata to R2.put", async () => {
+		const { session } = mockSession();
+		const bucket = mockBucket();
+		await storedPDF(session, "<p>x</p>", {
+			bucket,
+			key: ["x.pdf"],
+			metadata: { userId: "u1", reportId: "r1" },
+		});
+		expect(bucket.puts[0]?.metadata).toEqual({ userId: "u1", reportId: "r1" });
+	});
+});

--- a/packages/pdf/tsconfig.json
+++ b/packages/pdf/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "../../tooling/tsconfig/library.json",
+	"compilerOptions": {
+		"outDir": "dist",
+		"rootDir": "src",
+		"types": ["@cloudflare/workers-types"]
+	},
+	"include": ["src"],
+	"exclude": ["dist", "node_modules", "tests"]
+}

--- a/packages/pdf/vitest.config.ts
+++ b/packages/pdf/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["tests/**/*.test.ts"],
+	},
+});


### PR DESCRIPTION
## Summary

Adds `@workkit/pdf` — render HTML to PDF in Cloudflare Workers via `@workkit/browser`, with R2 storage + presign helpers in one call.

Closes #24.

### Public API

- **`renderPDF(session, html, opts)`** — pure render returning `Uint8Array`. Reuses `withPage` so JS-off / dialog auto-dismiss / abort propagation / guaranteed close come for free.
- **`storedPDF(session, html, opts)`** — render + R2 upload + presign in one call. Returns `{ r2Key, bytes, url }`. `readPolicy: "private"` skips presign and returns `url: null`.
- **`composeHeaderFooter(opts)`** — Puppeteer-compatible header/footer. Plain strings escape by default; `raw()` is the only unescaped opt-in.
- **`safeKey(...parts)`** — rejects `..`, `.`, leading `/`, backslashes, control chars. Throws `ValidationError` rather than silently sanitizing.
- Page-size + margin presets: `pageSize.A4|Letter|Legal`, `margin.narrow|normal|wide`, plus `resolveMargin()` for partial/string forms.
- `disclaimerRequired: true` — fails fast before render if `footer.disclaimer` is empty (compliance hook).

### Security defaults

- **Header/footer escape by default** — `raw()` opt-in mirrors React's `dangerouslySetInnerHTML` pattern.
- **Presigned URL TTL hard-cap 24h** — bearer tokens shouldn't outlive the day.
- **R2 key path-traversal rejection** — explicit, not silent.
- **JS off, abort-safe, dialog auto-dismiss** — inherited from `@workkit/browser`.

### Tests

51 unit tests across 6 files (escape, safeKey, presets, header, render, store). All green. Render and store use a hand-rolled mock for the `@workkit/browser` `withPage` surface (in `tests/_mocks.ts`) so tests stay deterministic without a Browser Rendering binding.

### LOC budget

Source: ~430 LOC across 7 files including JSDoc — over the original ≤250 budget. Driver was the security/compliance footprint (escape/raw branding, safeKey validation, presign clamping, disclaimer enforcement, header composer). Trimming further would mean dropping defaults that the issue mandated. Calling out for review.

## Test plan

- [x] `bun --filter @workkit/pdf test` — 51/51 pass
- [x] `bun --filter @workkit/pdf typecheck` — clean
- [x] `bunx biome check packages/pdf` — clean
- [x] `maina verify` — clean
- [ ] CI green
- [ ] CodeRabbit re-review
- [ ] Manual e2e against a real Browser Rendering binding (separate; needs CI binding)
- [ ] Visual baseline via `maina verify --visual` (separate; needs binding access)

## Reviewer notes

- Renamed `escape()` → `escapeHtml()` in the public API to avoid shadowing the global (Biome flagged it). `raw()` and `toSafeHtml()` retain their names.
- `escape.ts` switched from phantom-typed brands to a runtime object wrapper for `Raw` so `toSafeHtml()` can actually distinguish at runtime — phantom brands were compile-time only and would have let plain strings slip through unescaped.
- `composeHeaderFooter` validates `disclaimerRequired` eagerly so we throw before opening a browser session, saving cost.
- Stacked on master (after #32 merged). #34 (browser CodeRabbit fixes) is independent; if that merges first, this PR remains compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
