### PR TITLE
feat(notify): WhatsApp adapter as @workkit/notify/whatsapp (Meta + Twilio/Gupshup stubs)

### DIFF
--- a/.changeset/feat-notify-whatsapp.md
+++ b/.changeset/feat-notify-whatsapp.md
@@ -1,0 +1,59 @@
+---
+"@workkit/notify": minor
+---
+
+Add **WhatsApp** transport adapter as a subpath import of `@workkit/notify`
+(`@workkit/notify/whatsapp`). Closes #29.
+
+### Provider strategy
+
+- **Meta WhatsApp Business Cloud API** — fully implemented as the reference
+  default. Direct `fetch` to Graph API; no SDK.
+- **Twilio + Gupshup** — stubs that throw `not implemented`. The provider
+  interface is stable; concrete impls are a swap-in.
+
+### Adapter (`whatsappAdapter({ provider, db, ... })`)
+
+- **Opt-in proof required pre-send** via D1-backed `wa_optin_proofs`
+  table. Refuses to call the provider if the row is missing or revoked
+  (`OptInRequiredError`).
+- **24h session window** detected from `wa_inbound_log` — outside the
+  window forces template send; inside allows session text. Override via
+  `forceTemplate: true`.
+- **DND India** check via injected callback, invoked only for
+  `category: "marketing"` templates.
+- **`MarketingPauseRegistry`** — flipped on Meta `account_update.phone_quality`
+  low/flagged webhooks; subsequent marketing sends fail with
+  `MarketingPausedError`. Transactional sends unaffected.
+- **Inbound STOP/UNSUBSCRIBE keywords** (multi-locale: EN/HI/ES/FR;
+  caller-extensible) trigger automatic opt-out via the injected hook.
+- **E.164 enforcement** (`WhatsAppPhoneFormatError` pre-send).
+- **Optional `phoneCipher`** for at-rest encryption (default identity).
+- **R2 etag → media-id cache** (D1-backed, default 30d TTL) so identical
+  attachments aren't re-uploaded per recipient.
+- **Meta webhook handshake** — `provider.handleVerificationChallenge(req, verifyToken)`
+  for the GET `?hub.mode=subscribe` setup flow.
+- **`X-Hub-Signature-256` HMAC-SHA256** signature verification.
+
+### D1 schema
+
+Three tables: `wa_optin_proofs`, `wa_media_cache`, `wa_inbound_log`.
+Run `WA_ALL_MIGRATIONS` once.
+
+### `forgetWhatsAppUser(db, userId)`
+
+Cascades through opt-in proof + inbound log. Caller invokes
+`@workkit/notify`'s `forgetUser` for the rest of the GDPR/DPDP cascade.
+
+### Tests
+
+58 new unit tests across keywords, phone, opt-in, session-window,
+marketing-pause, media-cache, meta provider, adapter orchestrator, and
+forget. SQLite-backed `NotifyD1` mock (via `better-sqlite3`) exercises
+real SQL semantics.
+
+### Out of scope (follow-ups)
+
+- Twilio + Gupshup concrete impls (community).
+- Cross-isolate marketing-pause coordination (DO).
+- Rich interactive templates (buttons, lists).

--- a/.maina/features/007-notify-whatsapp/plan.md
+++ b/.maina/features/007-notify-whatsapp/plan.md
@@ -1,0 +1,114 @@
+# Implementation Plan — @workkit/notify/whatsapp
+
+> HOW only — see spec.md for WHAT and WHY.
+
+## Architecture
+
+- **Pattern**: factory `whatsappAdapter(options)` returns `Adapter<WhatsAppPayload>`. The `provider` is pluggable: `metaWaProvider({...})`, `twilioWaProvider({...})` (stub), `gupshupWaProvider({...})` (stub).
+- **Layering** (under `packages/notify/src/adapters/whatsapp/`):
+  - `adapter.ts` — `whatsappAdapter`; orchestrates opt-in check → DND → 24h-window route → provider call → marketing-pause check.
+  - `provider.ts` — `WaProvider` interface + shared types.
+  - `providers/meta.ts` — Meta WA Cloud API impl (send, parseWebhook, verifySignature, uploadMedia, handleVerificationChallenge).
+  - `providers/twilio.ts`, `providers/gupshup.ts` — stubs.
+  - `opt-in.ts` — D1 schema + `recordOptIn`/`isOptedIn`/`revokeOptIn`/check helpers.
+  - `media-cache.ts` — `R2 etag → providerMediaId` cache (D1-backed; 30d TTL).
+  - `session-window.ts` — track inbound timestamp per recipient; `withinSessionWindow(at)` predicate.
+  - `marketing-pause.ts` — in-memory pause flag; emits audit event when toggled.
+  - `keywords.ts` — multi-locale STOP/UNSUBSCRIBE keyword matcher.
+  - `phone.ts` — E.164 validation + cipher hook (encrypt/decrypt callbacks).
+  - `errors.ts` — `OptInRequiredError`, `TemplateNotApprovedError`, `WhatsAppPhoneFormatError`, `WebhookSignatureError`.
+  - `forget.ts` — `forgetWhatsAppUser` cascade.
+  - `schema.ts` — `WA_OPTIN_MIGRATION_SQL`, `WA_MEDIA_CACHE_MIGRATION_SQL`, `WA_INBOUND_LOG_MIGRATION_SQL`.
+
+## Key Technical Decisions
+
+- **Direct `fetch` to Meta Graph API** (`https://graph.facebook.com/v20.0/{phoneNumberId}/messages`) — same pattern as the email adapter; no SDK.
+- **Provider as object, not class** — stateless, easy to swap, easy to test.
+- **24h window via D1**: `wa_inbound_log(user_id, last_inbound_at)` — updated on every inbound webhook event. `withinSessionWindow` reads this in-line; routing decided pre-send. Pluggable via callback for callers using DOs.
+- **Marketing pause** — `MarketingPauseRegistry` class with `pause()/resume()/isPaused()`. Adapter consults it before sending `category: marketing` templates. Quality-rating webhooks call `pause()`. Caller-callable `resume()` for human review.
+- **Opt-in proof contract** — adapter expects an injected `optInChecker(userId)` callback. Default `db`-backed implementation reads from `wa_optin_proofs` table; callers can swap for their own user-table integration.
+- **Phone cipher** — `phoneCipher: { encrypt(plain): Promise<string>; decrypt(cipher): Promise<string> }`. Optional; default identity (plain E.164 stored).
+- **Multi-locale STOP keywords** — small allowlist: `STOP, STOP ALL, UNSUBSCRIBE, REMOVE` (EN); `रोक, बंद` (HI); `ALTO, BAJA` (ES); `ARRÊT, STOP` (FR). Case-insensitive, whitespace-trimmed. Caller can extend via `extraStopKeywords: string[]`.
+- **DND check** — caller-supplied `dndCheck(phoneE164): Promise<boolean>` callback. Adapter only calls it for `category: marketing`. Returns true ⇒ skip send (record `status: skipped`).
+- **Signature verification** — Meta uses `X-Hub-Signature-256: sha256=<hex>`. HMAC-SHA256 of raw body with the app secret.
+- **Webhook GET-handshake** — Meta sends `?hub.mode=subscribe&hub.challenge=<n>&hub.verify_token=<t>` on initial setup. `provider.handleVerificationChallenge(req, verifyToken)` returns the challenge if `verify_token` matches, else 403.
+
+## Files
+
+| File | Purpose | New/Modified |
+|---|---|---|
+| `packages/notify/package.json` | Add `./whatsapp` subpath export | Modified |
+| `packages/notify/bunup.config.ts` | Add whatsapp entry | Modified |
+| `packages/notify/src/adapters/whatsapp/adapter.ts` | `whatsappAdapter` orchestrator | New |
+| `packages/notify/src/adapters/whatsapp/provider.ts` | `WaProvider` interface + send/event/media types | New |
+| `packages/notify/src/adapters/whatsapp/providers/meta.ts` | Meta WA Cloud API impl | New |
+| `packages/notify/src/adapters/whatsapp/providers/twilio.ts` | Stub (throw) | New |
+| `packages/notify/src/adapters/whatsapp/providers/gupshup.ts` | Stub (throw) | New |
+| `packages/notify/src/adapters/whatsapp/opt-in.ts` | D1 helpers + `OptInRequiredError` check | New |
+| `packages/notify/src/adapters/whatsapp/media-cache.ts` | etag→mediaId cache | New |
+| `packages/notify/src/adapters/whatsapp/session-window.ts` | inbound log + 24h check | New |
+| `packages/notify/src/adapters/whatsapp/marketing-pause.ts` | `MarketingPauseRegistry` | New |
+| `packages/notify/src/adapters/whatsapp/keywords.ts` | multi-locale STOP matcher | New |
+| `packages/notify/src/adapters/whatsapp/phone.ts` | E.164 validate + cipher hook | New |
+| `packages/notify/src/adapters/whatsapp/errors.ts` | adapter-specific errors | New |
+| `packages/notify/src/adapters/whatsapp/forget.ts` | cascade | New |
+| `packages/notify/src/adapters/whatsapp/schema.ts` | D1 migration SQL | New |
+| `packages/notify/src/adapters/whatsapp/index.ts` | public exports for `./whatsapp` subpath | New |
+| `packages/notify/tests/adapters/whatsapp/*.test.ts` | provider, opt-in, session-window, keywords, phone, adapter | New |
+| `packages/notify/README.md` | add WhatsApp section | Modified |
+| `.changeset/feat-notify-whatsapp.md` | `@workkit/notify` minor — adds whatsapp subpath | New |
+
+## Tasks (TDD)
+
+1. update `package.json` exports + `bunup.config.ts` entry
+2. impl:errors + impl:schema
+3. test:keywords → impl:keywords
+4. test:phone → impl:phone
+5. test:opt-in → impl:opt-in
+6. test:session-window → impl:session-window
+7. test:marketing-pause → impl:marketing-pause
+8. test:media-cache → impl:media-cache
+9. test:provider:meta → impl:providers/meta (uses ^)
+10. impl:providers/twilio + impl:providers/gupshup (stubs)
+11. test:adapter → impl:adapter (orchestrator)
+12. impl:forget
+13. wire `src/adapters/whatsapp/index.ts`
+14. README + changeset
+15. lint + typecheck + scoped tests
+16. maina verify
+17. maina commit + push + PR
+18. request review
+
+## Failure Modes
+
+- **Missing/revoked opt-in proof** → `OptInRequiredError` from adapter; row not sent.
+- **Phone not E.164** → `WhatsAppPhoneFormatError` pre-send.
+- **Quality rating dropped (Meta webhook)** → marketing-pause flag set; subsequent `category: marketing` sends return `status: skipped` with reason `marketing-paused`. Audit row written.
+- **DND blocked** → `status: skipped` with reason `dnd`.
+- **Outside 24h window + no template** → adapter returns `status: failed` with `cannot send session message outside 24h window`.
+- **Template variable count mismatch** → `TemplateNotApprovedError` (sub-class for variable mismatch) pre-send.
+- **Meta provider 4xx** (e.g., template not approved, account suspended) → normalize to `TemplateNotApprovedError` or pass-through `status: failed` with provider error.
+- **Meta provider 429** → `status: failed`; queue retry policy handles backoff.
+- **Webhook signature mismatch** → adapter `verifySignature` returns false; notify-core's webhookHandler returns 401.
+- **Webhook GET-handshake mismatch** (wrong verify_token) → `handleVerificationChallenge` returns null; route returns 403.
+- **Inbound STOP** → automatic opt-out via the configured hook; webhook returns 200.
+- **R2 media object missing** → fail fast with explicit error; no partial media reference sent.
+
+## Testing Strategy
+
+- All unit tests; no live Meta calls.
+- Reuse the `better-sqlite3`-backed D1 mock from #39 for opt-in/media-cache/session-window queries.
+- Hand-rolled `fetch` mock (vi.fn) for Meta API.
+- Webhook signature tested with a known-good HMAC-SHA256 (sha256=<hex>) pair generated inline.
+- Multi-locale keyword matching tested against EN/HI/ES/FR samples.
+
+## Stacking
+
+- Branch: `feature/007-notify-whatsapp`
+- Base: `feature/006-notify-adapters` (needs the same package.json/bunup multi-entry surface)
+- After #39 merges: rebase onto master so this PR's diff shows only whatsapp.
+
+
+## Wiki Context
+
+Auto-populated; no edits.

--- a/.maina/features/007-notify-whatsapp/spec.md
+++ b/.maina/features/007-notify-whatsapp/spec.md
@@ -1,0 +1,98 @@
+# Feature: @workkit/notify/whatsapp — WhatsApp transport adapter
+
+Tracks GitHub issue #29. Lands as a subpath of `@workkit/notify` (matching the email + inapp adapters in #39). Stacked on `feature/006-notify-adapters`; will rebase onto master after that PR merges.
+
+## Problem Statement
+
+`@workkit/notify` core (#26) + email/inapp adapters (#39) ship without WhatsApp. WhatsApp is the dominant transactional channel in India (entryexit.ai's primary market) and a strong differentiator vs email-only flows globally. Without an adapter, every product wires Meta/Twilio/Gupshup directly and re-implements the same compliance story (DND India, opt-in proofs, 24h session window, hard-bounce/quality drop handling).
+
+The provider landscape is messy:
+- **Meta WhatsApp Business Cloud API** is the primary path: free 1,000 conversations/mo, no BSP markup, global. Direct HTTP API.
+- **Twilio** is the global onboarding-friendly path: per-message margin, simpler dashboard, no need for Meta Business verification.
+- **Gupshup** dominates the Indian market: Hindi templates, INR billing, local support.
+
+Build the adapter so the provider is pluggable behind a stable interface; ship Meta direct as the reference implementation; stub Twilio/Gupshup with explicit "not implemented" so callers can fill them in without forking.
+
+## Target User
+
+- **Primary**: workkit consumers needing transactional WhatsApp delivery (entryexit's pre-market briefs first; future SaaS products with Indian/global reach next).
+- **Secondary**: workkit/community contributors filling in Twilio/Gupshup providers.
+- **Compliance engineers**: ensure DND India + Meta opt-in requirements + 24h-window enforcement land in code, not in tribal knowledge.
+
+## User Stories
+
+- As a product engineer, I want `whatsappAdapter({ provider: metaWaProvider({...}) })` registered as the `whatsapp` channel.
+- As a security engineer, I want webhook signatures verified per provider (Meta uses `X-Hub-Signature-256`).
+- As a compliance engineer, I want pre-send opt-in proof checks and DND India lookups for marketing-category templates.
+- As an SRE, I want quality-rating webhook events to automatically pause `category: marketing` sends pending review.
+- As a developer, I want to send approved templates AND session messages within the 24h customer service window — the adapter routes automatically based on the conversation state.
+- As a developer, I want media attachments to fetch from R2 with a cached `etag → mediaId` mapping so the same R2 object isn't re-uploaded per recipient.
+
+## Success Criteria
+
+- [ ] `whatsappAdapter({ provider, webhook?, optIn, ... })` returns `Adapter<WhatsAppPayload>` registered as the `whatsapp` channel.
+- [ ] **Provider interface** stable: `send`, `parseWebhook`, `verifySignature`, optional `uploadMedia`, optional `handleVerificationChallenge` (Meta GET handshake).
+- [ ] **Meta provider** fully implemented (direct `fetch` to Graph API).
+- [ ] **Twilio + Gupshup providers** stubbed with `throw new Error("not implemented — see #29 for tracking")` and a clear extension point.
+- [ ] **24h session window** detected automatically — outside window forces template send; inside window allows session messages.
+- [ ] **Template variable validation** pre-send: count must match approved template's placeholder count; per-variable length capped at 1024 chars (WA max).
+- [ ] **Phone number E.164 enforcement** — adapter rejects malformed numbers before provider call.
+- [ ] **Inbound STOP/UNSUBSCRIBE keywords** (multi-locale: EN, HI, ES, FR) automatically opt-out the user via the injected hook.
+- [ ] **Opt-in proof storage** — D1 schema (`wa_optin_proofs`) + `recordOptIn` helper. Adapter MUST check this table pre-send; missing/revoked rows → `OptInRequiredError`.
+- [ ] **DND India** check for `category: "marketing"` templates only (transactional exempt). Pluggable `dndCheck` callback.
+- [ ] **Quality-rating webhook** (Meta `account_update.phone_quality`) automatically pauses `category: marketing` sends; emits an audit event.
+- [ ] **Webhook signature verified** per provider; replay window enforced (5 min).
+- [ ] **Media upload caching** — `R2 etag → providerMediaId` cache. Default 30d TTL (matches Meta retention).
+- [ ] **Phone numbers encrypted at rest** — adapter exposes `phoneCipher` callback for caller-supplied AES-GCM encrypt/decrypt.
+- [ ] **`forgetWhatsAppUser(db, userId)`** cascades through `wa_optin_proofs` + `wa_media_cache` (caller's user_id-keyed rows).
+- [ ] `@workkit/testing` integration present.
+- [ ] LOC budget ≤700 source for the whatsapp subpath (ambitious — Meta provider alone is ~250 LOC).
+- [ ] Single subpath export `@workkit/notify/whatsapp`.
+- [ ] Changeset added.
+
+## Scope (v1 PR)
+
+### In Scope
+
+- `whatsappAdapter(options)` returning `Adapter<WhatsAppPayload>`.
+- Provider interface (`WaProvider`).
+- **Meta provider** (`metaWaProvider`) fully implemented:
+  - Template + session send via Graph API.
+  - Media upload via Graph API; R2-etag cache.
+  - Webhook GET-verification challenge handler.
+  - `X-Hub-Signature-256` HMAC-SHA256 webhook signature verification.
+  - Event parser: `messages.statuses.delivered/read/sent/failed`, `messages` (inbound), `account_update.phone_quality` (quality alerts).
+- **Twilio + Gupshup providers** stubbed (signature verification + 1-line throw).
+- Opt-in proof storage (D1 schema + helpers).
+- Quality-rating-driven marketing pause (in-memory flag for v1; per-account D1 row in v2).
+- Multi-locale STOP keyword recognition.
+- DND India callback hook.
+- Phone-number E.164 validation + cipher hook.
+- `WA_OPTIN_MIGRATION_SQL` + `WA_MEDIA_CACHE_MIGRATION_SQL` schema exports.
+- `forgetWhatsAppUser` cascade.
+
+### Out of Scope (separate concerns)
+
+- Two-way conversational flows / agent integration (caller wires `@workkit/agent`).
+- Rich interactive templates (buttons, lists) — start with text + media in v1.
+- Twilio + Gupshup full implementations (community contribution / future PRs).
+- Cross-account quality-rating coordination (single Worker isolate scope for the marketing-pause flag in v1; multi-isolate via DO is future).
+- BSP migration tooling.
+
+## Design Decisions
+
+- **Meta direct as the default reference impl** — no per-message margin, free first 1k conversations/mo, global. Documented as the recommended path.
+- **Provider interface, not BSP-locked** — Twilio + Gupshup stubs included so the upgrade path is "swap one factory call" not "fork the package".
+- **24h session window inferred from conversation state**, not from caller — adapter tracks the most recent inbound message timestamp per recipient (D1) and auto-routes template-vs-session.
+- **Opt-in proof check is pre-send** — refuses to call the provider without a row. Surface as `OptInRequiredError` so callers can render a "verify your WhatsApp" UI flow rather than ship a silent failure.
+- **DND check is a callback** — workkit doesn't ship DND India integration (TRAI registry has its own auth flow); we expose the integration point and keep the rest of the pipeline intact.
+- **Quality-rating pause is per-isolate in v1** — getting cross-isolate fan-out right requires a Durable Object. Acceptable for v1 because Meta's quality metric is slow-moving; a 30-second propagation gap is fine.
+- **Phone-number cipher is opt-in** — caller supplies an AES-GCM key + encrypt/decrypt callback. Default mode stores plain E.164 (consumer can switch later without schema migration since the column is `BLOB`-friendly).
+- **Webhook GET-verification challenge handler** is exposed as `provider.handleVerificationChallenge(req, verifyToken)` — Meta requires a one-shot GET handshake on webhook setup; the helper handles it inline.
+- **Media cache key is `r2://<key>:<etag>`** — etag changes invalidate the cached upload automatically.
+
+## Open Questions
+
+- Is the multi-locale STOP keyword list canonical enough for v1, or do we delegate to caller? — Lean: ship a small allowlist (EN/HI/ES/FR), document, let callers extend.
+- Should the marketing-pause flag persist across deploys? — v1 in-memory, v2 D1 row. Documented.
+- Do we need a per-recipient session-window override (e.g., "force template even within 24h")? — Yes, optional `sendOptions.forceTemplate: true`.

--- a/.maina/features/007-notify-whatsapp/tasks.md
+++ b/.maina/features/007-notify-whatsapp/tasks.md
@@ -1,0 +1,39 @@
+# Task Breakdown — @workkit/notify/whatsapp
+
+1. update `package.json` exports + bunup entry for `./whatsapp`
+2. impl:errors + impl:schema (D1 migration SQL)
+3. test:keywords → impl:keywords (multi-locale STOP matcher)
+4. test:phone → impl:phone (E.164 + cipher hook)
+5. test:opt-in → impl:opt-in (`isOptedIn`, `recordOptIn`, `revokeOptIn`)
+6. test:session-window → impl:session-window (inbound log + 24h check)
+7. test:marketing-pause → impl:marketing-pause (`MarketingPauseRegistry`)
+8. test:media-cache → impl:media-cache (etag→mediaId)
+9. test:provider:meta → impl:providers/meta (send + parseWebhook + verifySignature + uploadMedia + handleVerificationChallenge)
+10. impl:providers/twilio + impl:providers/gupshup (stubs)
+11. test:adapter → impl:adapter (orchestrator)
+12. impl:forget
+13. wire `src/adapters/whatsapp/index.ts`
+14. README + changeset
+15. lint + typecheck + scoped tests
+16. maina verify
+17. maina commit + push + PR
+18. request review
+
+## Definition of Done
+
+- All tests green
+- Typecheck + lint clean
+- maina verify clean
+- LOC ≤700 source for whatsapp subpath
+- Meta provider end-to-end (mocked fetch + mocked D1)
+- Twilio + Gupshup throw with explicit "not implemented" message
+- 24h session window auto-routing (test)
+- Opt-in proof check pre-send; `OptInRequiredError` (test)
+- Multi-locale STOP keyword matching (EN/HI/ES/FR)
+- DND callback only invoked for `category: marketing` (test)
+- Quality-rating webhook flips marketing-pause flag (test)
+- Webhook GET-verification challenge handler (test)
+- Single src/adapters/whatsapp/index.ts export
+- Changeset
+- PR opened, links #29
+- Review requested

--- a/packages/notify/README.md
+++ b/packages/notify/README.md
@@ -8,7 +8,7 @@ Adapters ship as **subpath imports** in this same package — bring the runtime 
 |---|---|---|
 | `@workkit/notify/email` | Resend HTTP API + React Email | `@react-email/render` |
 | `@workkit/notify/inapp` | D1-backed feed + SSE streaming | — |
-| `@workkit/notify/whatsapp` | Meta WA Cloud API + Twilio + Gupshup _(landing in #29)_ | _(see issue)_ |
+| `@workkit/notify/whatsapp` | Meta WA Cloud API (default) + Twilio/Gupshup stubs | — |
 
 ## Install
 
@@ -210,6 +210,65 @@ await markRead(env.DB, { userId, ids: ["..."] });
 - `safeLink` rejects `javascript:`/`data:`/`file:` schemes.
 - `forgetInAppUser(db, userId, registry?)` cascades + drops active SSE subs.
 
+### WhatsApp — `@workkit/notify/whatsapp`
+
+```ts
+import {
+  whatsappAdapter,
+  metaWaProvider,
+  twilioWaProvider,
+  gupshupWaProvider,
+  recordOptIn,
+  MarketingPauseRegistry,
+  WA_ALL_MIGRATIONS,
+} from "@workkit/notify/whatsapp";
+
+for (const sql of WA_ALL_MIGRATIONS) await env.DB.exec(sql);
+
+const provider = metaWaProvider({
+  accessToken: env.WA_ACCESS_TOKEN,
+  phoneNumberId: env.WA_PHONE_NUMBER_ID,
+});
+const pauseRegistry = new MarketingPauseRegistry();
+
+const whatsapp = whatsappAdapter({
+  provider,
+  db: env.DB,
+  bucket: env.MEDIA,
+  pauseRegistry,
+  dndCheck: async (e164) => /* TRAI lookup */ false,
+  optOutHook: async (userId, channel, _notificationId, reason) => {
+    /* notify-core's optOut() helper */
+  },
+  userIdFromPhone: async (e164) => /* lookup your internal id */ null,
+});
+
+// Persist opt-in proof when the user clicks the WhatsApp opt-in.
+await recordOptIn({ db: env.DB }, {
+  userId: "u1",
+  phoneE164: "+919999999999",
+  method: "checkbox-signup",
+  sourceUrl: "https://app.example.com/onboarding",
+});
+
+// Mount the webhook (signature verification + handshake)
+app.get("/wa/webhook", (req) =>
+  provider.handleVerificationChallenge(req.raw, env.WA_WEBHOOK_VERIFY_TOKEN) ??
+  new Response("not a verification challenge", { status: 400 }),
+);
+```
+
+- **Provider-pluggable**: `metaWaProvider` is the reference impl; `twilioWaProvider` and `gupshupWaProvider` are stubs (community contribution welcome).
+- **Opt-in proof required pre-send** — `OptInRequiredError` if the proof row is missing or revoked.
+- **24h session window** auto-routed: outside the window forces template send; inside allows session text.
+- **DND callback** invoked only for `category: "marketing"` templates (transactional exempt).
+- **Marketing-pause registry** flips on quality-rating webhooks (`account_update.phone_quality` low/flagged); transactional sends unaffected.
+- **Inbound STOP/UNSUBSCRIBE** keywords (multi-locale: EN/HI/ES/FR) trigger automatic opt-out via the injected hook.
+- **E.164 enforcement**, optional `phoneCipher` for at-rest encryption.
+- **R2 etag → media-id cache** so the same R2 object isn't re-uploaded per recipient (default 30d TTL, matches Meta retention).
+- **Meta webhook GET-handshake** handler bundled.
+- **Single-isolate scope** for the marketing-pause flag; multi-isolate fan-out via Durable Object is a v2 concern.
+
 ## Security & compliance
 
 - **Opt-out re-checked at dispatch** (not just at enqueue) so a `STOP` between request and queue worker is honored.
@@ -224,12 +283,14 @@ await markRead(env.DB, { userId, ids: ["..."] });
 
 ## Out of scope (separate issues)
 
-- WhatsApp adapter (#29) — Meta direct + Twilio + Gupshup. Will land as `@workkit/notify/whatsapp`.
+- Twilio + Gupshup full WhatsApp implementations — interface stable; community contribution welcome.
 - Per-provider rate limiting (lands with each adapter).
 - Queue-side draining of pending messages on `forgetUser` (gap in `@workkit/queue`).
 - D1/R2-backed editable template registry.
 - Cross-isolate SSE fan-out (DO-backed adapter — future).
+- Cross-isolate WhatsApp marketing-pause coordination (DO-backed — future).
 - Push notifications (FCM/APNs — future).
+- Rich interactive WhatsApp templates (buttons, lists) — future.
 
 ## Versioning
 

--- a/packages/notify/bunup.config.ts
+++ b/packages/notify/bunup.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig } from "bunup";
 
 export default defineConfig({
-	entry: ["src/index.ts", "src/adapters/email/index.ts", "src/adapters/inapp/index.ts"],
+	entry: [
+		"src/index.ts",
+		"src/adapters/email/index.ts",
+		"src/adapters/inapp/index.ts",
+		"src/adapters/whatsapp/index.ts",
+	],
 	format: ["esm"],
 	dts: true,
 	sourcemap: "linked",

--- a/packages/notify/package.json
+++ b/packages/notify/package.json
@@ -28,6 +28,12 @@
 				"types": "./dist/adapters/inapp/index.d.ts",
 				"default": "./dist/adapters/inapp/index.js"
 			}
+		},
+		"./whatsapp": {
+			"import": {
+				"types": "./dist/adapters/whatsapp/index.d.ts",
+				"default": "./dist/adapters/whatsapp/index.js"
+			}
 		}
 	},
 	"module": "./dist/index.js",
@@ -72,6 +78,10 @@
 		"resend",
 		"sse",
 		"in-app",
+		"whatsapp",
+		"meta",
+		"twilio",
+		"gupshup",
 		"workkit"
 	]
 }

--- a/packages/notify/src/adapters/whatsapp/adapter.ts
+++ b/packages/notify/src/adapters/whatsapp/adapter.ts
@@ -30,7 +30,9 @@ interface R2BucketLike {
 /**
  * Pluggable check for "is the recipient on the DND registry?". Adapter
  * only invokes this for `category: "marketing"` templates. Returning true
- * causes the send to be marked `skipped`.
+ * suppresses the send and is reported through the adapter's existing
+ * failure result path (`AdapterSendResult.status` does not include
+ * `skipped`).
  */
 export type DndChecker = (phoneE164: string) => Promise<boolean>;
 
@@ -74,6 +76,11 @@ const PROVIDER_NAMES = new Set<WaProvider["name"]>(["meta", "twilio", "gupshup"]
 export function whatsappAdapter(options: WhatsAppAdapterOptions): Adapter<WhatsAppPayload> {
 	if (!PROVIDER_NAMES.has(options.provider.name)) {
 		throw new Error(`unknown WhatsApp provider: ${(options.provider as WaProvider).name}`);
+	}
+	if (options.optOutHook && !options.userIdFromPhone) {
+		throw new Error(
+			"whatsappAdapter: `optOutHook` requires `userIdFromPhone` so inbound STOP webhooks can be attributed to the correct internal user id. Without it, STOP messages are dropped to avoid mis-keyed opt-outs.",
+		);
 	}
 	const pause = options.pauseRegistry ?? new MarketingPauseRegistry();
 
@@ -163,6 +170,24 @@ export function whatsappAdapter(options: WhatsAppAdapterOptions): Adapter<WhatsA
 				}
 			}
 
+			// Inside the 24h window with no template: send a session text
+			// derived from the channel template's `body(payload)` (or media-
+			// only). Without `body` AND without media, we'd have nothing to
+			// hand the provider — fail fast with a clear error.
+			let sessionText: string | undefined;
+			if (!useTemplate) {
+				sessionText = (args.template as { body?: (p: WhatsAppPayload) => string }).body?.(
+					args.payload,
+				);
+				if (!sessionText && !media) {
+					return {
+						status: "failed",
+						error:
+							"WhatsApp session message requires `template.body(payload)` to produce text (or `media`)",
+					};
+				}
+			}
+
 			try {
 				const result = await options.provider.send({
 					toE164,
@@ -174,6 +199,7 @@ export function whatsappAdapter(options: WhatsAppAdapterOptions): Adapter<WhatsA
 								variables: template.variables?.(args.payload),
 							}
 						: undefined,
+					sessionText,
 					media,
 				});
 				return { status: "sent", providerId: result.providerId };
@@ -219,9 +245,15 @@ async function handleInbound(
 	at: number,
 	options: WhatsAppAdapterOptions,
 ): Promise<void> {
-	// Update session-window state first — this is what unblocks session-message
-	// sends without forcing a template.
-	const userId = (await options.userIdFromPhone?.(fromE164)) ?? fromE164;
+	// Resolve to your internal userId. If not configured, we cannot safely
+	// touch user-keyed state (opt-in proofs, etc.) — silently return rather
+	// than write rows under the wrong key. The constructor warns at definition
+	// time if `optOutHook` is supplied without `userIdFromPhone`.
+	const resolved = options.userIdFromPhone ? await options.userIdFromPhone(fromE164) : undefined;
+	if (resolved === undefined || resolved === null) {
+		return;
+	}
+	const userId = resolved;
 	await recordInbound({ db: options.db }, { userId, at, text });
 
 	if (text && isStopKeyword(text, options.stopKeywords)) {

--- a/packages/notify/src/adapters/whatsapp/adapter.ts
+++ b/packages/notify/src/adapters/whatsapp/adapter.ts
@@ -1,0 +1,231 @@
+import type {
+	Adapter,
+	AdapterSendArgs,
+	AdapterSendResult,
+	NotifyD1,
+	WebhookEvent,
+} from "../../types";
+import { MarketingPausedError, OptInRequiredError, WhatsAppPhoneFormatError } from "./errors";
+import { type StopMatchOptions, isStopKeyword } from "./keywords";
+import { MarketingPauseRegistry } from "./marketing-pause";
+import { cacheKey, getCached, putCached } from "./media-cache";
+import { isOptedIn, revokeOptIn } from "./opt-in";
+import { type PhoneCipher, assertE164 } from "./phone";
+import type { WaProvider, WhatsAppCategory } from "./provider";
+import { recordInbound, withinSessionWindow } from "./session-window";
+
+export interface WhatsAppPayload {
+	[key: string]: unknown;
+}
+
+interface R2BucketLike {
+	get(key: string): Promise<{
+		body: ReadableStream | null;
+		arrayBuffer(): Promise<ArrayBuffer>;
+		etag?: string;
+		httpMetadata?: { contentType?: string };
+	} | null>;
+}
+
+/**
+ * Pluggable check for "is the recipient on the DND registry?". Adapter
+ * only invokes this for `category: "marketing"` templates. Returning true
+ * causes the send to be marked `skipped`.
+ */
+export type DndChecker = (phoneE164: string) => Promise<boolean>;
+
+/**
+ * Caller-provided opt-out hook. Invoked when an inbound message matches a
+ * STOP/UNSUBSCRIBE keyword (after webhook signature verification).
+ * `notificationId: null` because STOPs are global by intent.
+ */
+export type WaOptOutHook = (
+	userId: string,
+	channel: "whatsapp",
+	notificationId: null,
+	reason: "inbound-stop",
+) => Promise<void>;
+
+export interface WhatsAppTemplateRef {
+	name: string;
+	language: string;
+	variables?: (payload: WhatsAppPayload) => ReadonlyArray<string>;
+	category: WhatsAppCategory;
+	media?: (payload: WhatsAppPayload) => { r2Key: string; mimeType?: string } | undefined;
+}
+
+export interface WhatsAppAdapterOptions {
+	provider: WaProvider;
+	db: NotifyD1;
+	bucket?: R2BucketLike;
+	cipher?: PhoneCipher;
+	pauseRegistry?: MarketingPauseRegistry;
+	dndCheck?: DndChecker;
+	optOutHook?: WaOptOutHook;
+	stopKeywords?: StopMatchOptions;
+	/** Optional resolver: webhook payload `from` (E.164) → your internal userId. */
+	userIdFromPhone?: (phoneE164: string) => Promise<string | null>;
+	/** Force template send even when inside the 24h session window (rare; defaults false). */
+	forceTemplate?: boolean;
+}
+
+const PROVIDER_NAMES = new Set<WaProvider["name"]>(["meta", "twilio", "gupshup"]);
+
+export function whatsappAdapter(options: WhatsAppAdapterOptions): Adapter<WhatsAppPayload> {
+	if (!PROVIDER_NAMES.has(options.provider.name)) {
+		throw new Error(`unknown WhatsApp provider: ${(options.provider as WaProvider).name}`);
+	}
+	const pause = options.pauseRegistry ?? new MarketingPauseRegistry();
+
+	return {
+		async send(args: AdapterSendArgs<WhatsAppPayload>): Promise<AdapterSendResult> {
+			let toE164: string;
+			try {
+				toE164 = assertE164(args.address);
+			} catch (err) {
+				if (err instanceof WhatsAppPhoneFormatError) {
+					return { status: "failed", error: err.message };
+				}
+				throw err;
+			}
+
+			// Opt-in proof: refuse to call the provider without one.
+			const ok = await isOptedIn({ db: options.db, cipher: options.cipher }, args.userId);
+			if (!ok) {
+				return { status: "failed", error: new OptInRequiredError(args.userId).message };
+			}
+
+			const tpl = args.template as { template?: WhatsAppTemplateRef };
+			const template = tpl.template;
+			const isMarketing = template?.category === "marketing";
+
+			// Marketing-pause check.
+			if (isMarketing && pause.isPaused()) {
+				return {
+					status: "failed",
+					error: new MarketingPausedError(args.notificationId).message,
+				};
+			}
+
+			// DND check (marketing only).
+			if (isMarketing && options.dndCheck) {
+				const blocked = await options.dndCheck(toE164);
+				if (blocked) {
+					return { status: "failed", error: "dnd-india: recipient on do-not-disturb registry" };
+				}
+			}
+
+			// 24h session-window routing: outside window forces template send.
+			const inWindow = await withinSessionWindow({ db: options.db }, args.userId);
+			const useTemplate = options.forceTemplate || !inWindow || template !== undefined;
+
+			if (useTemplate && !template) {
+				return {
+					status: "failed",
+					error: "WhatsApp send outside the 24h session window requires an approved template",
+				};
+			}
+
+			// Optional media: upload (or reuse cached id) before send.
+			let media: { mediaId: string; mimeType?: string } | undefined;
+			if (template?.media) {
+				const ref = template.media(args.payload);
+				if (ref) {
+					if (!options.bucket) {
+						return { status: "failed", error: "WhatsApp media requires bucket option" };
+					}
+					const obj = await options.bucket.get(ref.r2Key);
+					if (!obj) {
+						return { status: "failed", error: `R2 object missing: ${ref.r2Key}` };
+					}
+					const etag = obj.etag ?? "noetag";
+					const key = cacheKey(options.provider.name, ref.r2Key, etag);
+					const cached = await getCached({ db: options.db }, key);
+					if (cached) {
+						media = { mediaId: cached.mediaId, mimeType: cached.mimeType };
+					} else {
+						const bytes = new Uint8Array(await obj.arrayBuffer());
+						const mimeType =
+							ref.mimeType ?? obj.httpMetadata?.contentType ?? "application/octet-stream";
+						const uploaded = await options.provider.uploadMedia({
+							bytes,
+							mimeType,
+							filename: ref.r2Key.split("/").pop(),
+						});
+						await putCached({ db: options.db }, key, {
+							provider: options.provider.name,
+							mediaId: uploaded.mediaId,
+							mimeType,
+							bytes: bytes.byteLength,
+						});
+						media = { mediaId: uploaded.mediaId, mimeType };
+					}
+				}
+			}
+
+			try {
+				const result = await options.provider.send({
+					toE164,
+					template: template
+						? {
+								name: template.name,
+								language: template.language,
+								category: template.category,
+								variables: template.variables?.(args.payload),
+							}
+						: undefined,
+					media,
+				});
+				return { status: "sent", providerId: result.providerId };
+			} catch (err) {
+				return { status: "failed", error: err instanceof Error ? err.message : String(err) };
+			}
+		},
+
+		async parseWebhook(req: Request): Promise<WebhookEvent[]> {
+			const events = await options.provider.parseWebhook(req);
+			const out: WebhookEvent[] = [];
+			for (const ev of events) {
+				if (ev.kind === "delivery") {
+					out.push(ev.event);
+					continue;
+				}
+				if (ev.kind === "inbound") {
+					await handleInbound(ev.message.from, ev.message.text, ev.message.at, options);
+					continue;
+				}
+				if (ev.kind === "quality") {
+					if (ev.alert.level === "low" || ev.alert.level === "flagged") {
+						await pause.pause(`meta-quality:${ev.alert.level}`);
+					}
+				}
+			}
+			return out;
+		},
+
+		async verifySignature(req: Request, secret: string): Promise<boolean> {
+			try {
+				return await options.provider.verifySignature(req, secret);
+			} catch {
+				return false;
+			}
+		},
+	};
+}
+
+async function handleInbound(
+	fromE164: string,
+	text: string | undefined,
+	at: number,
+	options: WhatsAppAdapterOptions,
+): Promise<void> {
+	// Update session-window state first — this is what unblocks session-message
+	// sends without forcing a template.
+	const userId = (await options.userIdFromPhone?.(fromE164)) ?? fromE164;
+	await recordInbound({ db: options.db }, { userId, at, text });
+
+	if (text && isStopKeyword(text, options.stopKeywords)) {
+		await revokeOptIn({ db: options.db, cipher: options.cipher }, userId, "inbound-stop");
+		await options.optOutHook?.(userId, "whatsapp", null, "inbound-stop");
+	}
+}

--- a/packages/notify/src/adapters/whatsapp/errors.ts
+++ b/packages/notify/src/adapters/whatsapp/errors.ts
@@ -1,0 +1,39 @@
+import { ConfigError, ValidationError } from "@workkit/errors";
+
+export class OptInRequiredError extends ValidationError {
+	constructor(userId: string, channel = "whatsapp") {
+		super(`opt-in proof required before sending on ${channel} for user ${userId}`, [
+			{ path: ["optIn", userId], message: "missing or revoked opt-in" },
+		]);
+	}
+}
+
+export class TemplateNotApprovedError extends ConfigError {
+	constructor(reason: string) {
+		super(`WhatsApp template rejected: ${reason}`);
+	}
+}
+
+export class WhatsAppPhoneFormatError extends ValidationError {
+	constructor(value: string) {
+		super(`WhatsApp recipient is not E.164: ${JSON.stringify(value)}`, [
+			{ path: ["address"], message: "expected leading + and 8–15 digits" },
+		]);
+	}
+}
+
+export class WhatsAppWebhookSignatureError extends ValidationError {
+	constructor(reason: string) {
+		super(`WhatsApp webhook signature verification failed: ${reason}`, [
+			{ path: ["webhook"], message: reason },
+		]);
+	}
+}
+
+export class MarketingPausedError extends ValidationError {
+	constructor(notificationId: string) {
+		super(`marketing sends are paused; refused to send ${notificationId}`, [
+			{ path: ["category"], message: "marketing-paused" },
+		]);
+	}
+}

--- a/packages/notify/src/adapters/whatsapp/forget.ts
+++ b/packages/notify/src/adapters/whatsapp/forget.ts
@@ -1,0 +1,34 @@
+import type { NotifyD1 } from "../../types";
+
+export interface ForgetWhatsAppResult {
+	optInRowsDeleted: number;
+	mediaCacheRowsDeleted: number;
+	inboundLogRowsDeleted: number;
+}
+
+/**
+ * Cascade-delete a user's WhatsApp footprint from D1: opt-in proof,
+ * inbound message log. Media-cache rows are NOT user-keyed (they're keyed
+ * by R2 etag) so we leave them; the global TTL purge handles eviction.
+ *
+ * Caller should also invoke `@workkit/notify`'s `forgetUser` to drop the
+ * preferences/opt-out/delivery-record rows in the same transaction.
+ */
+export async function forgetWhatsAppUser(
+	db: NotifyD1,
+	userId: string,
+): Promise<ForgetWhatsAppResult> {
+	const optIn = await db
+		.prepare("DELETE FROM wa_optin_proofs WHERE user_id = ?")
+		.bind(userId)
+		.run();
+	const inbound = await db
+		.prepare("DELETE FROM wa_inbound_log WHERE user_id = ?")
+		.bind(userId)
+		.run();
+	return {
+		optInRowsDeleted: optIn.meta?.changes ?? 0,
+		mediaCacheRowsDeleted: 0,
+		inboundLogRowsDeleted: inbound.meta?.changes ?? 0,
+	};
+}

--- a/packages/notify/src/adapters/whatsapp/index.ts
+++ b/packages/notify/src/adapters/whatsapp/index.ts
@@ -1,0 +1,81 @@
+// Adapter
+export { whatsappAdapter } from "./adapter";
+export type {
+	DndChecker,
+	WaOptOutHook,
+	WhatsAppAdapterOptions,
+	WhatsAppPayload,
+	WhatsAppTemplateRef,
+} from "./adapter";
+
+// Provider interface + types
+export type {
+	WaInboundMessage,
+	WaMediaRef,
+	WaProvider,
+	WaProviderEvent,
+	WaQualityAlert,
+	WaSendArgs,
+	WaSendResult,
+	WaTemplateRef,
+	WaUploadArgs,
+	WhatsAppCategory,
+} from "./provider";
+
+// Providers
+export { metaWaProvider } from "./providers/meta";
+export type { MetaWaProviderOptions } from "./providers/meta";
+export { twilioWaProvider } from "./providers/twilio";
+export type { TwilioWaProviderOptions } from "./providers/twilio";
+export { gupshupWaProvider } from "./providers/gupshup";
+export type { GupshupWaProviderOptions } from "./providers/gupshup";
+
+// Opt-in
+export { recordOptIn, revokeOptIn, isOptedIn, getOptInProof } from "./opt-in";
+export type { OptInProof, RecordOptInArgs, OptInDeps } from "./opt-in";
+
+// Session window
+export { recordInbound, withinSessionWindow, SESSION_WINDOW_MS } from "./session-window";
+
+// Marketing pause
+export { MarketingPauseRegistry } from "./marketing-pause";
+export type { MarketingPauseAuditEvent, MarketingPauseAuditHook } from "./marketing-pause";
+
+// Media cache
+export {
+	cacheKey,
+	getCached,
+	putCached,
+	purgeExpiredMedia,
+	DEFAULT_MEDIA_TTL_MS,
+} from "./media-cache";
+export type { CachedMedia } from "./media-cache";
+
+// Phone
+export { assertE164, isE164, identityCipher } from "./phone";
+export type { PhoneCipher } from "./phone";
+
+// Keywords
+export { isStopKeyword, defaultStopKeywords } from "./keywords";
+export type { StopMatchOptions } from "./keywords";
+
+// Forget
+export { forgetWhatsAppUser } from "./forget";
+export type { ForgetWhatsAppResult } from "./forget";
+
+// Schema
+export {
+	WA_OPTIN_MIGRATION_SQL,
+	WA_MEDIA_CACHE_MIGRATION_SQL,
+	WA_INBOUND_LOG_MIGRATION_SQL,
+	WA_ALL_MIGRATIONS,
+} from "./schema";
+
+// Errors
+export {
+	MarketingPausedError,
+	OptInRequiredError,
+	TemplateNotApprovedError,
+	WhatsAppPhoneFormatError,
+	WhatsAppWebhookSignatureError,
+} from "./errors";

--- a/packages/notify/src/adapters/whatsapp/keywords.ts
+++ b/packages/notify/src/adapters/whatsapp/keywords.ts
@@ -1,0 +1,52 @@
+/**
+ * Multi-locale STOP/UNSUBSCRIBE keyword recognition.
+ *
+ * Caller can extend via `extraStopKeywords: string[]` on the adapter.
+ * Matching is case-insensitive, whitespace-trimmed; the body must equal
+ * the keyword (no substring matches — "I'd like to stop receiving these"
+ * does NOT count).
+ */
+
+const DEFAULT_STOP_KEYWORDS: ReadonlyArray<string> = [
+	// English
+	"stop",
+	"stop all",
+	"unsubscribe",
+	"remove",
+	"cancel",
+	// Hindi (Devanagari + ASCII transliteration)
+	"रोक",
+	"बंद",
+	"रोकें",
+	"रद्द",
+	"rok",
+	"band",
+	// Spanish
+	"alto",
+	"baja",
+	"cancelar",
+	// French
+	"arrêt",
+	"arret",
+	"désabonner",
+	"desabonner",
+];
+
+export interface StopMatchOptions {
+	extraKeywords?: ReadonlyArray<string>;
+}
+
+export function isStopKeyword(text: string, options: StopMatchOptions = {}): boolean {
+	const normalized = text.trim().toLowerCase();
+	if (normalized.length === 0) return false;
+	const list = [...DEFAULT_STOP_KEYWORDS, ...(options.extraKeywords ?? [])];
+	for (const kw of list) {
+		if (normalized === kw.toLowerCase()) return true;
+	}
+	return false;
+}
+
+/** Exposed for tests + consumer introspection. */
+export function defaultStopKeywords(): ReadonlyArray<string> {
+	return DEFAULT_STOP_KEYWORDS;
+}

--- a/packages/notify/src/adapters/whatsapp/marketing-pause.ts
+++ b/packages/notify/src/adapters/whatsapp/marketing-pause.ts
@@ -1,0 +1,50 @@
+/**
+ * In-memory marketing-pause flag, single-Worker-isolate scope.
+ *
+ * Quality-rating webhooks call `pause()` to halt `category: marketing` sends
+ * pending operator review. Multi-isolate fan-out is a v2 concern (Durable
+ * Object). For v1, Meta's quality metric is slow-moving — a 30s propagation
+ * gap across isolates is acceptable.
+ *
+ * Audit hook receives every transition so callers can persist + alert.
+ */
+
+export interface MarketingPauseAuditEvent {
+	at: number;
+	state: "paused" | "resumed";
+	reason: string;
+}
+
+export type MarketingPauseAuditHook = (event: MarketingPauseAuditEvent) => void | Promise<void>;
+
+export class MarketingPauseRegistry {
+	private paused = false;
+	private reason: string | undefined;
+	private auditHook: MarketingPauseAuditHook | undefined;
+
+	constructor(options: { auditHook?: MarketingPauseAuditHook } = {}) {
+		this.auditHook = options.auditHook;
+	}
+
+	isPaused(): boolean {
+		return this.paused;
+	}
+
+	pauseReason(): string | undefined {
+		return this.reason;
+	}
+
+	async pause(reason: string): Promise<void> {
+		if (this.paused) return;
+		this.paused = true;
+		this.reason = reason;
+		await this.auditHook?.({ at: Date.now(), state: "paused", reason });
+	}
+
+	async resume(reason: string): Promise<void> {
+		if (!this.paused) return;
+		this.paused = false;
+		this.reason = undefined;
+		await this.auditHook?.({ at: Date.now(), state: "resumed", reason });
+	}
+}

--- a/packages/notify/src/adapters/whatsapp/media-cache.ts
+++ b/packages/notify/src/adapters/whatsapp/media-cache.ts
@@ -19,10 +19,7 @@ export function cacheKey(provider: string, r2Key: string, etag: string): string 
 	return `${provider}://${r2Key}:${etag}`;
 }
 
-export async function getCached(
-	deps: MediaCacheDeps,
-	key: string,
-): Promise<CachedMedia | null> {
+export async function getCached(deps: MediaCacheDeps, key: string): Promise<CachedMedia | null> {
 	const row = await deps.db
 		.prepare(
 			"SELECT media_id, mime_type, bytes, uploaded_at, expires_at FROM wa_media_cache WHERE cache_key = ?",
@@ -76,9 +73,7 @@ export async function putCached(
 		.run();
 }
 
-export async function purgeExpiredMedia(
-	deps: MediaCacheDeps,
-): Promise<{ deleted: number }> {
+export async function purgeExpiredMedia(deps: MediaCacheDeps): Promise<{ deleted: number }> {
 	const now = deps.now?.() ?? Date.now();
 	const r = await deps.db
 		.prepare("DELETE FROM wa_media_cache WHERE expires_at IS NOT NULL AND expires_at < ?")

--- a/packages/notify/src/adapters/whatsapp/media-cache.ts
+++ b/packages/notify/src/adapters/whatsapp/media-cache.ts
@@ -82,4 +82,4 @@ export async function purgeExpiredMedia(deps: MediaCacheDeps): Promise<{ deleted
 	return { deleted: r.meta?.changes ?? 0 };
 }
 
-export const DEFAULT_MEDIA_TTL_MS = DEFAULT_TTL_MS;
+export const DEFAULT_MEDIA_TTL_MS: number = DEFAULT_TTL_MS;

--- a/packages/notify/src/adapters/whatsapp/media-cache.ts
+++ b/packages/notify/src/adapters/whatsapp/media-cache.ts
@@ -1,0 +1,90 @@
+import type { NotifyD1 } from "../../types";
+
+export interface MediaCacheDeps {
+	db: NotifyD1;
+	now?: () => number;
+}
+
+export interface CachedMedia {
+	mediaId: string;
+	mimeType?: string;
+	bytes?: number;
+	uploadedAt: number;
+	expiresAt?: number;
+}
+
+const DEFAULT_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days — matches Meta retention
+
+export function cacheKey(provider: string, r2Key: string, etag: string): string {
+	return `${provider}://${r2Key}:${etag}`;
+}
+
+export async function getCached(
+	deps: MediaCacheDeps,
+	key: string,
+): Promise<CachedMedia | null> {
+	const row = await deps.db
+		.prepare(
+			"SELECT media_id, mime_type, bytes, uploaded_at, expires_at FROM wa_media_cache WHERE cache_key = ?",
+		)
+		.bind(key)
+		.first<{
+			media_id: string;
+			mime_type: string | null;
+			bytes: number | null;
+			uploaded_at: number;
+			expires_at: number | null;
+		}>();
+	if (!row) return null;
+	const now = deps.now?.() ?? Date.now();
+	if (row.expires_at !== null && row.expires_at < now) return null;
+	return {
+		mediaId: row.media_id,
+		mimeType: row.mime_type ?? undefined,
+		bytes: row.bytes ?? undefined,
+		uploadedAt: row.uploaded_at,
+		expiresAt: row.expires_at ?? undefined,
+	};
+}
+
+export async function putCached(
+	deps: MediaCacheDeps,
+	key: string,
+	args: {
+		provider: string;
+		mediaId: string;
+		mimeType?: string;
+		bytes?: number;
+		ttlMs?: number;
+	},
+): Promise<void> {
+	const now = deps.now?.() ?? Date.now();
+	const ttl = args.ttlMs ?? DEFAULT_TTL_MS;
+	await deps.db
+		.prepare(
+			"INSERT INTO wa_media_cache(cache_key, provider, media_id, mime_type, bytes, uploaded_at, expires_at) VALUES (?, ?, ?, ?, ?, ?, ?) ON CONFLICT(cache_key) DO UPDATE SET media_id = excluded.media_id, mime_type = excluded.mime_type, bytes = excluded.bytes, uploaded_at = excluded.uploaded_at, expires_at = excluded.expires_at",
+		)
+		.bind(
+			key,
+			args.provider,
+			args.mediaId,
+			args.mimeType ?? null,
+			args.bytes ?? null,
+			now,
+			now + ttl,
+		)
+		.run();
+}
+
+export async function purgeExpiredMedia(
+	deps: MediaCacheDeps,
+): Promise<{ deleted: number }> {
+	const now = deps.now?.() ?? Date.now();
+	const r = await deps.db
+		.prepare("DELETE FROM wa_media_cache WHERE expires_at IS NOT NULL AND expires_at < ?")
+		.bind(now)
+		.run();
+	return { deleted: r.meta?.changes ?? 0 };
+}
+
+export const DEFAULT_MEDIA_TTL_MS = DEFAULT_TTL_MS;

--- a/packages/notify/src/adapters/whatsapp/opt-in.ts
+++ b/packages/notify/src/adapters/whatsapp/opt-in.ts
@@ -1,5 +1,5 @@
 import type { NotifyD1 } from "../../types";
-import type { PhoneCipher } from "./phone";
+import { type PhoneCipher, assertE164 } from "./phone";
 
 export interface OptInProof {
 	userId: string;
@@ -49,8 +49,11 @@ async function encrypt(cipher: PhoneCipher | undefined, value: string): Promise<
 }
 
 export async function recordOptIn(deps: OptInDeps, args: RecordOptInArgs): Promise<void> {
+	// Validate E.164 at write time too (not just at send time) so the
+	// compliance artifact never contains malformed numbers.
+	const validatedPhone = assertE164(args.phoneE164);
 	const ts = deps.now?.() ?? Date.now();
-	const phoneStored = await encrypt(deps.cipher, args.phoneE164);
+	const phoneStored = await encrypt(deps.cipher, validatedPhone);
 	await deps.db
 		.prepare(
 			"INSERT INTO wa_optin_proofs(user_id, phone_e164, opted_in_at, method, source_url, ip_hash, user_agent, revoked_at, revoke_reason) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL) ON CONFLICT(user_id) DO UPDATE SET phone_e164 = excluded.phone_e164, opted_in_at = excluded.opted_in_at, method = excluded.method, source_url = excluded.source_url, ip_hash = excluded.ip_hash, user_agent = excluded.user_agent, revoked_at = NULL, revoke_reason = NULL",

--- a/packages/notify/src/adapters/whatsapp/opt-in.ts
+++ b/packages/notify/src/adapters/whatsapp/opt-in.ts
@@ -67,25 +67,17 @@ export async function recordOptIn(deps: OptInDeps, args: RecordOptInArgs): Promi
 		.run();
 }
 
-export async function revokeOptIn(
-	deps: OptInDeps,
-	userId: string,
-	reason: string,
-): Promise<void> {
+export async function revokeOptIn(deps: OptInDeps, userId: string, reason: string): Promise<void> {
 	const ts = deps.now?.() ?? Date.now();
 	await deps.db
-		.prepare(
-			"UPDATE wa_optin_proofs SET revoked_at = ?, revoke_reason = ? WHERE user_id = ?",
-		)
+		.prepare("UPDATE wa_optin_proofs SET revoked_at = ?, revoke_reason = ? WHERE user_id = ?")
 		.bind(ts, reason, userId)
 		.run();
 }
 
 export async function isOptedIn(deps: OptInDeps, userId: string): Promise<boolean> {
 	const row = await deps.db
-		.prepare(
-			"SELECT revoked_at FROM wa_optin_proofs WHERE user_id = ?",
-		)
+		.prepare("SELECT revoked_at FROM wa_optin_proofs WHERE user_id = ?")
 		.bind(userId)
 		.first<{ revoked_at: number | null }>();
 	if (!row) return false;

--- a/packages/notify/src/adapters/whatsapp/opt-in.ts
+++ b/packages/notify/src/adapters/whatsapp/opt-in.ts
@@ -1,0 +1,114 @@
+import type { NotifyD1 } from "../../types";
+import type { PhoneCipher } from "./phone";
+
+export interface OptInProof {
+	userId: string;
+	phoneE164: string;
+	optedInAt: number;
+	method: string;
+	sourceUrl?: string;
+	ipHash?: string;
+	userAgent?: string;
+	revokedAt?: number;
+	revokeReason?: string;
+}
+
+export interface RecordOptInArgs {
+	userId: string;
+	phoneE164: string;
+	method: string;
+	sourceUrl?: string;
+	ipHash?: string;
+	userAgent?: string;
+}
+
+export interface OptInDeps {
+	db: NotifyD1;
+	cipher?: PhoneCipher;
+	now?: () => number;
+}
+
+interface RawRow {
+	user_id: string;
+	phone_e164: string;
+	opted_in_at: number;
+	method: string;
+	source_url: string | null;
+	ip_hash: string | null;
+	user_agent: string | null;
+	revoked_at: number | null;
+	revoke_reason: string | null;
+}
+
+async function decrypt(cipher: PhoneCipher | undefined, value: string): Promise<string> {
+	return cipher ? await cipher.decrypt(value) : value;
+}
+
+async function encrypt(cipher: PhoneCipher | undefined, value: string): Promise<string> {
+	return cipher ? await cipher.encrypt(value) : value;
+}
+
+export async function recordOptIn(deps: OptInDeps, args: RecordOptInArgs): Promise<void> {
+	const ts = deps.now?.() ?? Date.now();
+	const phoneStored = await encrypt(deps.cipher, args.phoneE164);
+	await deps.db
+		.prepare(
+			"INSERT INTO wa_optin_proofs(user_id, phone_e164, opted_in_at, method, source_url, ip_hash, user_agent, revoked_at, revoke_reason) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL) ON CONFLICT(user_id) DO UPDATE SET phone_e164 = excluded.phone_e164, opted_in_at = excluded.opted_in_at, method = excluded.method, source_url = excluded.source_url, ip_hash = excluded.ip_hash, user_agent = excluded.user_agent, revoked_at = NULL, revoke_reason = NULL",
+		)
+		.bind(
+			args.userId,
+			phoneStored,
+			ts,
+			args.method,
+			args.sourceUrl ?? null,
+			args.ipHash ?? null,
+			args.userAgent ?? null,
+		)
+		.run();
+}
+
+export async function revokeOptIn(
+	deps: OptInDeps,
+	userId: string,
+	reason: string,
+): Promise<void> {
+	const ts = deps.now?.() ?? Date.now();
+	await deps.db
+		.prepare(
+			"UPDATE wa_optin_proofs SET revoked_at = ?, revoke_reason = ? WHERE user_id = ?",
+		)
+		.bind(ts, reason, userId)
+		.run();
+}
+
+export async function isOptedIn(deps: OptInDeps, userId: string): Promise<boolean> {
+	const row = await deps.db
+		.prepare(
+			"SELECT revoked_at FROM wa_optin_proofs WHERE user_id = ?",
+		)
+		.bind(userId)
+		.first<{ revoked_at: number | null }>();
+	if (!row) return false;
+	return row.revoked_at === null;
+}
+
+export async function getOptInProof(deps: OptInDeps, userId: string): Promise<OptInProof | null> {
+	const row = await deps.db
+		.prepare(
+			"SELECT user_id, phone_e164, opted_in_at, method, source_url, ip_hash, user_agent, revoked_at, revoke_reason FROM wa_optin_proofs WHERE user_id = ?",
+		)
+		.bind(userId)
+		.first<RawRow>();
+	if (!row) return null;
+	return {
+		userId: row.user_id,
+		phoneE164: await decrypt(deps.cipher, row.phone_e164),
+		optedInAt: row.opted_in_at,
+		method: row.method,
+		sourceUrl: row.source_url ?? undefined,
+		ipHash: row.ip_hash ?? undefined,
+		userAgent: row.user_agent ?? undefined,
+		revokedAt: row.revoked_at ?? undefined,
+		revokeReason: row.revoke_reason ?? undefined,
+	};
+}

--- a/packages/notify/src/adapters/whatsapp/phone.ts
+++ b/packages/notify/src/adapters/whatsapp/phone.ts
@@ -1,0 +1,38 @@
+import { WhatsAppPhoneFormatError } from "./errors";
+
+/**
+ * E.164: leading `+`, country code (1–3 digits), then 4–14 more digits
+ * (total 8–15 digits). No spaces, dashes, or parens.
+ */
+const E164_RE = /^\+[1-9]\d{7,14}$/;
+
+export function assertE164(value: string): string {
+	const trimmed = value.trim();
+	if (!E164_RE.test(trimmed)) throw new WhatsAppPhoneFormatError(value);
+	return trimmed;
+}
+
+export function isE164(value: string): boolean {
+	return E164_RE.test(value.trim());
+}
+
+/**
+ * Optional cipher hook for storing phone numbers at rest. Caller supplies
+ * AES-GCM (or any symmetric cipher) `encrypt`/`decrypt` callbacks. The
+ * default is identity — phones stored as plain E.164. Switching to a real
+ * cipher later does not require a schema migration since the column is
+ * declared TEXT (Base64-friendly).
+ */
+export interface PhoneCipher {
+	encrypt(plain: string): Promise<string>;
+	decrypt(cipher: string): Promise<string>;
+}
+
+export const identityCipher: PhoneCipher = {
+	async encrypt(plain) {
+		return plain;
+	},
+	async decrypt(cipher) {
+		return cipher;
+	},
+};

--- a/packages/notify/src/adapters/whatsapp/provider.ts
+++ b/packages/notify/src/adapters/whatsapp/provider.ts
@@ -1,0 +1,76 @@
+import type { WebhookEvent } from "../../types";
+
+export type WhatsAppCategory = "marketing" | "transactional" | "authentication";
+
+export interface WaTemplateRef {
+	name: string;
+	language: string; // BCP-47, e.g., "en", "hi", "en_US"
+	variables?: ReadonlyArray<string>;
+	category?: WhatsAppCategory;
+}
+
+export interface WaMediaRef {
+	mediaId: string;
+	mimeType?: string;
+}
+
+export interface WaSendArgs {
+	toE164: string;
+	template?: WaTemplateRef;
+	sessionText?: string;
+	media?: WaMediaRef;
+}
+
+export interface WaSendResult {
+	providerId: string;
+}
+
+export interface WaUploadArgs {
+	bytes: Uint8Array;
+	mimeType: string;
+	filename?: string;
+}
+
+/**
+ * Inbound message events parsed from a webhook. The adapter inspects the
+ * text body for STOP keywords and the type for quality-rating updates.
+ */
+export interface WaInboundMessage {
+	from: string;
+	text?: string;
+	at: number;
+	raw?: unknown;
+}
+
+export interface WaQualityAlert {
+	level: "low" | "medium" | "high" | "flagged";
+	at: number;
+	raw?: unknown;
+}
+
+/**
+ * Provider events: a union of delivery `WebhookEvent`s (mapped to the
+ * notify-core webhook shape), inbound messages, and account-quality
+ * alerts. The adapter routes each variant.
+ */
+export type WaProviderEvent =
+	| { kind: "delivery"; event: WebhookEvent }
+	| { kind: "inbound"; message: WaInboundMessage }
+	| { kind: "quality"; alert: WaQualityAlert };
+
+/**
+ * Pluggable provider interface. `metaWaProvider` is the reference impl;
+ * `twilioWaProvider` and `gupshupWaProvider` are stubs.
+ */
+export interface WaProvider {
+	readonly name: "meta" | "twilio" | "gupshup";
+	send(args: WaSendArgs): Promise<WaSendResult>;
+	uploadMedia(args: WaUploadArgs): Promise<WaMediaRef>;
+	parseWebhook(req: Request): Promise<WaProviderEvent[]>;
+	verifySignature(req: Request, secret: string): Promise<boolean>;
+	/**
+	 * Meta requires a one-shot `GET ?hub.mode=subscribe&hub.challenge=…&hub.verify_token=…`
+	 * handshake on webhook setup. Providers that don't need this can return null.
+	 */
+	handleVerificationChallenge(req: Request, verifyToken: string): Response | null;
+}

--- a/packages/notify/src/adapters/whatsapp/providers/gupshup.ts
+++ b/packages/notify/src/adapters/whatsapp/providers/gupshup.ts
@@ -1,0 +1,32 @@
+import type { WaProvider } from "../provider";
+
+export interface GupshupWaProviderOptions {
+	apiKey: string;
+	appName: string;
+	apiUrl?: string;
+}
+
+const NOT_IMPLEMENTED =
+	"gupshupWaProvider is not implemented yet — see github.com/beeeku/workkit/issues/29 (community contribution welcome)";
+
+/** Stub. Provider interface is stable. */
+export function gupshupWaProvider(_options: GupshupWaProviderOptions): WaProvider {
+	return {
+		name: "gupshup",
+		async send() {
+			throw new Error(NOT_IMPLEMENTED);
+		},
+		async uploadMedia() {
+			throw new Error(NOT_IMPLEMENTED);
+		},
+		async parseWebhook() {
+			throw new Error(NOT_IMPLEMENTED);
+		},
+		async verifySignature() {
+			throw new Error(NOT_IMPLEMENTED);
+		},
+		handleVerificationChallenge() {
+			return null;
+		},
+	};
+}

--- a/packages/notify/src/adapters/whatsapp/providers/meta.ts
+++ b/packages/notify/src/adapters/whatsapp/providers/meta.ts
@@ -1,0 +1,284 @@
+import type { WebhookEvent } from "../../../types";
+import { TemplateNotApprovedError, WhatsAppWebhookSignatureError } from "../errors";
+import type {
+	WaInboundMessage,
+	WaProvider,
+	WaProviderEvent,
+	WaQualityAlert,
+	WaSendArgs,
+	WaSendResult,
+	WaUploadArgs,
+} from "../provider";
+
+const DEFAULT_GRAPH_URL = "https://graph.facebook.com";
+const DEFAULT_GRAPH_VERSION = "v20.0";
+
+export interface MetaWaProviderOptions {
+	accessToken: string; // Meta system user token
+	phoneNumberId: string;
+	apiUrl?: string;
+	graphVersion?: string;
+}
+
+export function metaWaProvider(options: MetaWaProviderOptions): WaProvider {
+	const apiUrl = options.apiUrl ?? DEFAULT_GRAPH_URL;
+	const version = options.graphVersion ?? DEFAULT_GRAPH_VERSION;
+	const sendUrl = `${apiUrl}/${version}/${options.phoneNumberId}/messages`;
+	const mediaUrl = `${apiUrl}/${version}/${options.phoneNumberId}/media`;
+
+	return {
+		name: "meta" as const,
+		async send(args: WaSendArgs): Promise<WaSendResult> {
+			const body: Record<string, unknown> = {
+				messaging_product: "whatsapp",
+				to: args.toE164,
+				recipient_type: "individual",
+			};
+			if (args.template) {
+				body.type = "template";
+				body.template = {
+					name: args.template.name,
+					language: { code: args.template.language },
+					components:
+						args.template.variables && args.template.variables.length > 0
+							? [
+									{
+										type: "body",
+										parameters: args.template.variables.map((v) => ({ type: "text", text: v })),
+									},
+								]
+							: undefined,
+				};
+			} else if (args.media) {
+				body.type = args.media.mimeType?.startsWith("image/")
+					? "image"
+					: args.media.mimeType?.startsWith("video/")
+						? "video"
+						: "document";
+				body[body.type as string] = { id: args.media.mediaId };
+			} else if (args.sessionText) {
+				body.type = "text";
+				body.text = { body: args.sessionText };
+			} else {
+				throw new TemplateNotApprovedError("WaSendArgs requires template, media, or sessionText");
+			}
+
+			const resp = await fetch(sendUrl, {
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+					authorization: `Bearer ${options.accessToken}`,
+				},
+				body: JSON.stringify(body),
+			});
+			const json = (await resp.json().catch(() => null)) as {
+				messages?: { id: string }[];
+				error?: { message?: string; code?: number; type?: string };
+			} | null;
+			if (!resp.ok) {
+				const message = json?.error?.message ?? `Meta WA HTTP ${resp.status} ${resp.statusText}`;
+				if (
+					json?.error?.code === 132000 ||
+					json?.error?.code === 132001 ||
+					/template/i.test(message)
+				) {
+					throw new TemplateNotApprovedError(message);
+				}
+				throw new Error(message);
+			}
+			const id = json?.messages?.[0]?.id;
+			if (!id) throw new Error("Meta WA response missing messages[0].id");
+			return { providerId: id };
+		},
+
+		async uploadMedia(args: WaUploadArgs) {
+			const form = new FormData();
+			form.append("messaging_product", "whatsapp");
+			form.append("type", args.mimeType);
+			form.append("file", new Blob([args.bytes], { type: args.mimeType }), args.filename ?? "file");
+			const resp = await fetch(mediaUrl, {
+				method: "POST",
+				headers: { authorization: `Bearer ${options.accessToken}` },
+				body: form,
+			});
+			const json = (await resp.json().catch(() => null)) as {
+				id?: string;
+				error?: { message?: string };
+			} | null;
+			if (!resp.ok || !json?.id) {
+				throw new Error(json?.error?.message ?? `Meta WA media upload HTTP ${resp.status}`);
+			}
+			return { mediaId: json.id, mimeType: args.mimeType };
+		},
+
+		async parseWebhook(req: Request): Promise<WaProviderEvent[]> {
+			const raw = await req.clone().text();
+			let parsed: unknown;
+			try {
+				parsed = JSON.parse(raw);
+			} catch {
+				return [];
+			}
+			return mapMetaWebhookPayload(parsed);
+		},
+
+		async verifySignature(req: Request, secret: string): Promise<boolean> {
+			const header = req.headers.get("x-hub-signature-256");
+			if (!header || !header.startsWith("sha256=")) return false;
+			const expectedHex = header.slice("sha256=".length).toLowerCase();
+			const rawBody = await req.text();
+			try {
+				const key = await crypto.subtle.importKey(
+					"raw",
+					new TextEncoder().encode(secret),
+					{ name: "HMAC", hash: "SHA-256" },
+					false,
+					["sign"],
+				);
+				const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(rawBody));
+				const actualHex = bufferToHex(new Uint8Array(sig));
+				return constantTimeEqualHex(expectedHex, actualHex);
+			} catch {
+				throw new WhatsAppWebhookSignatureError("HMAC computation failed");
+			}
+		},
+
+		handleVerificationChallenge(req: Request, verifyToken: string): Response | null {
+			if (req.method !== "GET") return null;
+			const url = new URL(req.url);
+			const mode = url.searchParams.get("hub.mode");
+			const challenge = url.searchParams.get("hub.challenge");
+			const token = url.searchParams.get("hub.verify_token");
+			if (mode !== "subscribe") return null;
+			if (token !== verifyToken) {
+				return new Response("forbidden", { status: 403 });
+			}
+			return new Response(challenge ?? "", {
+				status: 200,
+				headers: { "content-type": "text/plain" },
+			});
+		},
+	};
+}
+
+interface MetaWebhookPayload {
+	entry?: Array<{
+		changes?: Array<{
+			field?: string;
+			value?: {
+				messages?: Array<{
+					from?: string;
+					id?: string;
+					text?: { body?: string };
+					timestamp?: string;
+				}>;
+				statuses?: Array<{
+					id?: string;
+					recipient_id?: string;
+					status?: string;
+					timestamp?: string;
+				}>;
+				messaging_product?: string;
+			};
+		}>;
+	}>;
+}
+
+function mapMetaWebhookPayload(parsed: unknown): WaProviderEvent[] {
+	const out: WaProviderEvent[] = [];
+	const root = parsed as MetaWebhookPayload & {
+		entry?: Array<{
+			changes?: Array<{
+				field?: string;
+				value?: { event?: string; current_limit?: string; quality_score?: { score?: string } };
+			}>;
+		}>;
+	};
+	for (const entry of root.entry ?? []) {
+		for (const change of entry.changes ?? []) {
+			const v = change.value as
+				| { messages?: unknown[]; statuses?: unknown[]; quality_score?: { score?: string } }
+				| undefined;
+			if (!v) continue;
+
+			// Quality alert (account_update.phone_quality)
+			if (change.field === "account_update" && v.quality_score) {
+				const level = (v.quality_score.score ?? "").toLowerCase();
+				if (level === "low" || level === "medium" || level === "high" || level === "flagged") {
+					const alert: WaQualityAlert = { level, at: Date.now(), raw: change };
+					out.push({ kind: "quality", alert });
+				}
+				continue;
+			}
+
+			// Inbound messages
+			interface InboundMsgShape {
+				from?: string;
+				text?: { body?: string };
+				timestamp?: string;
+			}
+			const messages = (v.messages as InboundMsgShape[] | undefined) ?? [];
+			for (const msg of messages) {
+				if (!msg?.from) continue;
+				const inbound: WaInboundMessage = {
+					from: msg.from,
+					text: msg.text?.body,
+					at: msg.timestamp ? Number(msg.timestamp) * 1000 : Date.now(),
+					raw: msg,
+				};
+				out.push({ kind: "inbound", message: inbound });
+			}
+
+			// Delivery statuses
+			interface StatusShape {
+				id?: string;
+				recipient_id?: string;
+				status?: string;
+				timestamp?: string;
+			}
+			const statuses = (v.statuses as StatusShape[] | undefined) ?? [];
+			for (const status of statuses) {
+				if (!status?.id) continue;
+				const mapped = mapStatus(status.status);
+				if (!mapped) continue;
+				const event: WebhookEvent = {
+					channel: "whatsapp",
+					providerId: status.id,
+					status: mapped,
+					at: status.timestamp ? Number(status.timestamp) * 1000 : Date.now(),
+					raw: status,
+				};
+				out.push({ kind: "delivery", event });
+			}
+		}
+	}
+	return out;
+}
+
+function mapStatus(s: string | undefined): WebhookEvent["status"] | undefined {
+	switch (s) {
+		case "delivered":
+			return "delivered";
+		case "read":
+			return "read";
+		case "failed":
+			return "failed";
+		case "sent":
+			return "delivered"; // closest mapping; Meta's "sent" means provider-accepted
+		default:
+			return undefined;
+	}
+}
+
+function bufferToHex(bytes: Uint8Array): string {
+	let s = "";
+	for (let i = 0; i < bytes.length; i++) s += bytes[i]!.toString(16).padStart(2, "0");
+	return s;
+}
+
+function constantTimeEqualHex(a: string, b: string): boolean {
+	if (a.length !== b.length) return false;
+	let diff = 0;
+	for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+	return diff === 0;
+}

--- a/packages/notify/src/adapters/whatsapp/providers/meta.ts
+++ b/packages/notify/src/adapters/whatsapp/providers/meta.ts
@@ -60,7 +60,10 @@ export function metaWaProvider(options: MetaWaProviderOptions): WaProvider {
 				body.type = "text";
 				body.text = { body: args.sessionText };
 			} else {
-				throw new TemplateNotApprovedError("WaSendArgs requires template, media, or sessionText");
+				// Programmer error — not a template-approval issue. Throwing
+				// TemplateNotApprovedError would mislead callers that handle
+				// it specially.
+				throw new TypeError("WaSendArgs requires one of: template, media, or sessionText");
 			}
 
 			const resp = await fetch(sendUrl, {
@@ -264,7 +267,9 @@ function mapStatus(s: string | undefined): WebhookEvent["status"] | undefined {
 		case "failed":
 			return "failed";
 		case "sent":
-			return "delivered"; // closest mapping; Meta's "sent" means provider-accepted
+			// Meta's "sent" means provider-accepted, not user-delivered. Drop
+			// it so we don't mark a delivery row "delivered" prematurely.
+			return undefined;
 		default:
 			return undefined;
 	}

--- a/packages/notify/src/adapters/whatsapp/providers/twilio.ts
+++ b/packages/notify/src/adapters/whatsapp/providers/twilio.ts
@@ -1,0 +1,36 @@
+import type { WaProvider } from "../provider";
+
+export interface TwilioWaProviderOptions {
+	accountSid: string;
+	authToken: string;
+	fromNumber: string;
+	apiUrl?: string;
+}
+
+const NOT_IMPLEMENTED =
+	"twilioWaProvider is not implemented yet — see github.com/beeeku/workkit/issues/29 (community contribution welcome)";
+
+/**
+ * Stub. The provider interface is fixed so a real implementation can drop
+ * in without touching the adapter or any caller code.
+ */
+export function twilioWaProvider(_options: TwilioWaProviderOptions): WaProvider {
+	return {
+		name: "twilio",
+		async send() {
+			throw new Error(NOT_IMPLEMENTED);
+		},
+		async uploadMedia() {
+			throw new Error(NOT_IMPLEMENTED);
+		},
+		async parseWebhook() {
+			throw new Error(NOT_IMPLEMENTED);
+		},
+		async verifySignature() {
+			throw new Error(NOT_IMPLEMENTED);
+		},
+		handleVerificationChallenge() {
+			return null;
+		},
+	};
+}

--- a/packages/notify/src/adapters/whatsapp/schema.ts
+++ b/packages/notify/src/adapters/whatsapp/schema.ts
@@ -22,7 +22,7 @@ CREATE INDEX IF NOT EXISTS idx_wa_optin_phone ON wa_optin_proofs(phone_e164);
 
 export const WA_MEDIA_CACHE_MIGRATION_SQL: string = `
 CREATE TABLE IF NOT EXISTS wa_media_cache (
-	cache_key TEXT PRIMARY KEY,      -- 'r2://<r2Key>:<etag>'
+	cache_key TEXT PRIMARY KEY,      -- '<provider>://<r2Key>:<etag>' (e.g. 'meta://reports/u/r.pdf:etag1')
 	provider TEXT NOT NULL,          -- 'meta' | 'twilio' | 'gupshup'
 	media_id TEXT NOT NULL,
 	mime_type TEXT,

--- a/packages/notify/src/adapters/whatsapp/schema.ts
+++ b/packages/notify/src/adapters/whatsapp/schema.ts
@@ -1,0 +1,48 @@
+/**
+ * D1 schema for `@workkit/notify/whatsapp`. Run alongside `ALL_MIGRATIONS`
+ * from `@workkit/notify` and `INAPP_MIGRATION_SQL` from
+ * `@workkit/notify/inapp`.
+ */
+
+export const WA_OPTIN_MIGRATION_SQL: string = `
+CREATE TABLE IF NOT EXISTS wa_optin_proofs (
+	user_id TEXT NOT NULL,
+	phone_e164 TEXT NOT NULL,        -- ciphertext if cipher hook is wired
+	opted_in_at INTEGER NOT NULL,
+	method TEXT NOT NULL,            -- 'checkbox-signup' | 'click-to-chat' | 'ivr' | …
+	source_url TEXT,
+	ip_hash TEXT,
+	user_agent TEXT,
+	revoked_at INTEGER,
+	revoke_reason TEXT,
+	PRIMARY KEY (user_id)
+);
+CREATE INDEX IF NOT EXISTS idx_wa_optin_phone ON wa_optin_proofs(phone_e164);
+`.trim();
+
+export const WA_MEDIA_CACHE_MIGRATION_SQL: string = `
+CREATE TABLE IF NOT EXISTS wa_media_cache (
+	cache_key TEXT PRIMARY KEY,      -- 'r2://<r2Key>:<etag>'
+	provider TEXT NOT NULL,          -- 'meta' | 'twilio' | 'gupshup'
+	media_id TEXT NOT NULL,
+	mime_type TEXT,
+	bytes INTEGER,
+	uploaded_at INTEGER NOT NULL,
+	expires_at INTEGER               -- nullable; populated by adapter (default 30d for Meta)
+);
+CREATE INDEX IF NOT EXISTS idx_wa_media_expires ON wa_media_cache(expires_at);
+`.trim();
+
+export const WA_INBOUND_LOG_MIGRATION_SQL: string = `
+CREATE TABLE IF NOT EXISTS wa_inbound_log (
+	user_id TEXT PRIMARY KEY,
+	last_inbound_at INTEGER NOT NULL,
+	last_text TEXT
+);
+`.trim();
+
+export const WA_ALL_MIGRATIONS: ReadonlyArray<string> = [
+	WA_OPTIN_MIGRATION_SQL,
+	WA_MEDIA_CACHE_MIGRATION_SQL,
+	WA_INBOUND_LOG_MIGRATION_SQL,
+];

--- a/packages/notify/src/adapters/whatsapp/session-window.ts
+++ b/packages/notify/src/adapters/whatsapp/session-window.ts
@@ -41,4 +41,4 @@ export async function withinSessionWindow(
 	return now - row.last_inbound_at < TWENTY_FOUR_HOURS_MS;
 }
 
-export const SESSION_WINDOW_MS = TWENTY_FOUR_HOURS_MS;
+export const SESSION_WINDOW_MS: number = TWENTY_FOUR_HOURS_MS;

--- a/packages/notify/src/adapters/whatsapp/session-window.ts
+++ b/packages/notify/src/adapters/whatsapp/session-window.ts
@@ -1,0 +1,44 @@
+import type { NotifyD1 } from "../../types";
+
+const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
+
+export interface SessionWindowDeps {
+	db: NotifyD1;
+	now?: () => number;
+}
+
+/**
+ * Record an inbound message — used to determine whether the recipient is
+ * inside the WhatsApp 24h customer-service window.
+ */
+export async function recordInbound(
+	deps: SessionWindowDeps,
+	args: { userId: string; at?: number; text?: string },
+): Promise<void> {
+	const at = args.at ?? deps.now?.() ?? Date.now();
+	await deps.db
+		.prepare(
+			"INSERT INTO wa_inbound_log(user_id, last_inbound_at, last_text) VALUES (?, ?, ?) ON CONFLICT(user_id) DO UPDATE SET last_inbound_at = excluded.last_inbound_at, last_text = excluded.last_text",
+		)
+		.bind(args.userId, at, args.text ?? null)
+		.run();
+}
+
+/**
+ * True iff the most recent inbound message from `userId` is within the WA
+ * 24h window. Returns false when no inbound has been recorded.
+ */
+export async function withinSessionWindow(
+	deps: SessionWindowDeps,
+	userId: string,
+): Promise<boolean> {
+	const row = await deps.db
+		.prepare("SELECT last_inbound_at FROM wa_inbound_log WHERE user_id = ?")
+		.bind(userId)
+		.first<{ last_inbound_at: number }>();
+	if (!row) return false;
+	const now = deps.now?.() ?? Date.now();
+	return now - row.last_inbound_at < TWENTY_FOUR_HOURS_MS;
+}
+
+export const SESSION_WINDOW_MS = TWENTY_FOUR_HOURS_MS;

--- a/packages/notify/src/adapters/whatsapp/session-window.ts
+++ b/packages/notify/src/adapters/whatsapp/session-window.ts
@@ -16,9 +16,12 @@ export async function recordInbound(
 	args: { userId: string; at?: number; text?: string },
 ): Promise<void> {
 	const at = args.at ?? deps.now?.() ?? Date.now();
+	// Use MAX(existing, incoming) so out-of-order webhook deliveries can never
+	// move `last_inbound_at` backwards (which would prematurely close the 24h
+	// session window). `last_text` only updates when the timestamp advances.
 	await deps.db
 		.prepare(
-			"INSERT INTO wa_inbound_log(user_id, last_inbound_at, last_text) VALUES (?, ?, ?) ON CONFLICT(user_id) DO UPDATE SET last_inbound_at = excluded.last_inbound_at, last_text = excluded.last_text",
+			"INSERT INTO wa_inbound_log(user_id, last_inbound_at, last_text) VALUES (?, ?, ?) ON CONFLICT(user_id) DO UPDATE SET last_inbound_at = CASE WHEN excluded.last_inbound_at > wa_inbound_log.last_inbound_at THEN excluded.last_inbound_at ELSE wa_inbound_log.last_inbound_at END, last_text = CASE WHEN excluded.last_inbound_at > wa_inbound_log.last_inbound_at THEN excluded.last_text ELSE wa_inbound_log.last_text END",
 		)
 		.bind(args.userId, at, args.text ?? null)
 		.run();

--- a/packages/notify/tests/adapters/whatsapp/_d1.ts
+++ b/packages/notify/tests/adapters/whatsapp/_d1.ts
@@ -1,0 +1,64 @@
+import Database from "better-sqlite3";
+import {
+	WA_INBOUND_LOG_MIGRATION_SQL,
+	WA_MEDIA_CACHE_MIGRATION_SQL,
+	WA_OPTIN_MIGRATION_SQL,
+} from "../../../src/adapters/whatsapp/schema";
+import type { NotifyD1, NotifyPreparedStatement } from "../../../src/types";
+
+export function createWaDb(): NotifyD1 & { __raw: Database.Database } {
+	const db = new Database(":memory:");
+	for (const migration of [
+		WA_OPTIN_MIGRATION_SQL,
+		WA_MEDIA_CACHE_MIGRATION_SQL,
+		WA_INBOUND_LOG_MIGRATION_SQL,
+	]) {
+		for (const stmt of split(migration)) db.exec(stmt);
+	}
+	const wrapped = wrap(db) as NotifyD1 & { __raw: Database.Database };
+	wrapped.__raw = db;
+	return wrapped;
+}
+
+function split(sql: string): string[] {
+	return sql
+		.split(/;\s*\n+/)
+		.map((s) => s.trim())
+		.filter(Boolean);
+}
+
+function wrap(db: Database.Database): NotifyD1 {
+	return {
+		prepare(query: string): NotifyPreparedStatement {
+			return new Stmt(db, query, []);
+		},
+		async batch() {
+			throw new Error("batch not supported");
+		},
+	};
+}
+
+class Stmt implements NotifyPreparedStatement {
+	constructor(
+		private db: Database.Database,
+		private query: string,
+		private values: unknown[],
+	) {}
+	bind(...values: unknown[]): NotifyPreparedStatement {
+		return new Stmt(this.db, this.query, values);
+	}
+	async first<T = Record<string, unknown>>(): Promise<T | null> {
+		return (this.db.prepare(this.query).get(...sanitize(this.values)) as T | null) ?? null;
+	}
+	async all<T = Record<string, unknown>>(): Promise<{ results?: T[] }> {
+		return { results: this.db.prepare(this.query).all(...sanitize(this.values)) as T[] };
+	}
+	async run(): Promise<{ success?: boolean; meta?: { changes?: number } }> {
+		const result = this.db.prepare(this.query).run(...sanitize(this.values));
+		return { success: true, meta: { changes: Number(result.changes ?? 0) } };
+	}
+}
+
+function sanitize(values: unknown[]): unknown[] {
+	return values.map((v) => (v === undefined ? null : v));
+}

--- a/packages/notify/tests/adapters/whatsapp/adapter.test.ts
+++ b/packages/notify/tests/adapters/whatsapp/adapter.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	type WhatsAppPayload,
+	type WhatsAppTemplateRef,
+	whatsappAdapter,
+} from "../../../src/adapters/whatsapp/adapter";
+import { MarketingPauseRegistry } from "../../../src/adapters/whatsapp/marketing-pause";
+import { recordOptIn } from "../../../src/adapters/whatsapp/opt-in";
+import type {
+	WaProvider,
+	WaProviderEvent,
+	WaSendResult,
+} from "../../../src/adapters/whatsapp/provider";
+// (no error imports needed; we assert on string fragments)
+import { gupshupWaProvider } from "../../../src/adapters/whatsapp/providers/gupshup";
+import { twilioWaProvider } from "../../../src/adapters/whatsapp/providers/twilio";
+import { recordInbound } from "../../../src/adapters/whatsapp/session-window";
+import type { AdapterSendArgs, ChannelTemplate } from "../../../src/types";
+import { createWaDb } from "./_d1";
+
+function fakeProvider(opts: { send?: WaSendResult; throwOnSend?: Error } = {}): WaProvider & {
+	calls: { send: number; uploadMedia: number };
+} {
+	const calls = { send: 0, uploadMedia: 0 };
+	const provider: WaProvider & { calls: typeof calls } = {
+		name: "meta" as const,
+		calls,
+		async send(): Promise<WaSendResult> {
+			calls.send += 1;
+			if (opts.throwOnSend) throw opts.throwOnSend;
+			return opts.send ?? { providerId: "wamid.fake" };
+		},
+		async uploadMedia() {
+			calls.uploadMedia += 1;
+			return { mediaId: "mid_fake", mimeType: "image/png" };
+		},
+		async parseWebhook(): Promise<WaProviderEvent[]> {
+			return [];
+		},
+		async verifySignature() {
+			return true;
+		},
+		handleVerificationChallenge() {
+			return null;
+		},
+	};
+	return provider;
+}
+
+function args(
+	template: ChannelTemplate<WhatsAppPayload>,
+	address = "+919999999999",
+): AdapterSendArgs<WhatsAppPayload> {
+	return {
+		userId: "u1",
+		notificationId: "pre-market-brief",
+		channel: "whatsapp",
+		address,
+		template,
+		payload: {},
+		deliveryId: "d1",
+		mode: "live",
+	};
+}
+
+const transactionalTpl: WhatsAppTemplateRef = {
+	name: "pre_market_brief_v2",
+	language: "en",
+	category: "transactional",
+};
+const marketingTpl: WhatsAppTemplateRef = { ...transactionalTpl, category: "marketing" };
+
+describe("whatsappAdapter() — opt-in + phone validation", () => {
+	it("rejects malformed phone numbers", async () => {
+		const db = createWaDb();
+		const adapter = whatsappAdapter({ provider: fakeProvider(), db });
+		const r = await adapter.send(args({ template: transactionalTpl }, "919999999999"));
+		expect(r.status).toBe("failed");
+		expect(r.error).toContain("not E.164");
+	});
+
+	it("rejects sends when opt-in is missing", async () => {
+		const db = createWaDb();
+		const adapter = whatsappAdapter({ provider: fakeProvider(), db });
+		const r = await adapter.send(args({ template: transactionalTpl }));
+		expect(r.status).toBe("failed");
+		expect(r.error).toContain("opt-in proof required");
+	});
+
+	it("sends successfully when opted in", async () => {
+		const db = createWaDb();
+		await recordOptIn({ db }, { userId: "u1", phoneE164: "+919999999999", method: "x" });
+		const provider = fakeProvider();
+		const adapter = whatsappAdapter({ provider, db });
+		const r = await adapter.send(args({ template: transactionalTpl }));
+		expect(r.status).toBe("sent");
+		expect(r.providerId).toBe("wamid.fake");
+		expect(provider.calls.send).toBe(1);
+	});
+});
+
+describe("whatsappAdapter() — 24h session window", () => {
+	it("refuses to send a session message outside the window without a template", async () => {
+		const db = createWaDb();
+		await recordOptIn({ db }, { userId: "u1", phoneE164: "+919999999999", method: "x" });
+		const adapter = whatsappAdapter({ provider: fakeProvider(), db });
+		const r = await adapter.send(
+			args({
+				/* no template */
+			}),
+		);
+		expect(r.status).toBe("failed");
+		expect(r.error).toContain("24h");
+	});
+
+	it("permits a session message inside the window without a template", async () => {
+		const db = createWaDb();
+		await recordOptIn({ db }, { userId: "u1", phoneE164: "+919999999999", method: "x" });
+		await recordInbound({ db }, { userId: "u1", at: Date.now() });
+		const provider = fakeProvider();
+		const adapter = whatsappAdapter({ provider, db });
+		const r = await adapter.send(args({}));
+		// Inside window + no template → adapter calls provider.send (which our
+		// fake accepts) → sent. The "outside-24h" early-return must NOT fire.
+		expect(r.status).toBe("sent");
+		expect(provider.calls.send).toBe(1);
+	});
+});
+
+describe("whatsappAdapter() — DND + marketing pause", () => {
+	it("invokes dndCheck only for marketing templates and skips on true", async () => {
+		const db = createWaDb();
+		await recordOptIn({ db }, { userId: "u1", phoneE164: "+919999999999", method: "x" });
+		const dnd = vi.fn().mockResolvedValue(true);
+		const adapter = whatsappAdapter({ provider: fakeProvider(), db, dndCheck: dnd });
+		const r = await adapter.send(args({ template: marketingTpl }));
+		expect(dnd).toHaveBeenCalledWith("+919999999999");
+		expect(r.status).toBe("failed");
+		expect(r.error).toContain("dnd-india");
+	});
+
+	it("does NOT invoke dndCheck for transactional templates", async () => {
+		const db = createWaDb();
+		await recordOptIn({ db }, { userId: "u1", phoneE164: "+919999999999", method: "x" });
+		const dnd = vi.fn().mockResolvedValue(true);
+		const adapter = whatsappAdapter({ provider: fakeProvider(), db, dndCheck: dnd });
+		await adapter.send(args({ template: transactionalTpl }));
+		expect(dnd).not.toHaveBeenCalled();
+	});
+
+	it("refuses marketing sends when the pause registry is paused", async () => {
+		const db = createWaDb();
+		await recordOptIn({ db }, { userId: "u1", phoneE164: "+919999999999", method: "x" });
+		const pauseRegistry = new MarketingPauseRegistry();
+		await pauseRegistry.pause("test");
+		const adapter = whatsappAdapter({ provider: fakeProvider(), db, pauseRegistry });
+		const r = await adapter.send(args({ template: marketingTpl }));
+		expect(r.status).toBe("failed");
+		expect(r.error).toContain("marketing");
+	});
+
+	it("transactional sends are NOT blocked by the pause registry", async () => {
+		const db = createWaDb();
+		await recordOptIn({ db }, { userId: "u1", phoneE164: "+919999999999", method: "x" });
+		const pauseRegistry = new MarketingPauseRegistry();
+		await pauseRegistry.pause("test");
+		const adapter = whatsappAdapter({ provider: fakeProvider(), db, pauseRegistry });
+		const r = await adapter.send(args({ template: transactionalTpl }));
+		expect(r.status).toBe("sent");
+	});
+});
+
+describe("whatsappAdapter() — inbound STOP handling", () => {
+	it("revokes opt-in + invokes optOutHook when an inbound STOP arrives", async () => {
+		const db = createWaDb();
+		await recordOptIn({ db }, { userId: "u1", phoneE164: "+919999999999", method: "x" });
+		const optOutHook = vi.fn().mockResolvedValue(undefined);
+		const provider = fakeProvider();
+		// Override parseWebhook to inject an inbound STOP.
+		provider.parseWebhook = async () => [
+			{
+				kind: "inbound" as const,
+				message: { from: "+919999999999", text: "STOP", at: Date.now() },
+			},
+		];
+		const adapter = whatsappAdapter({
+			provider,
+			db,
+			optOutHook,
+			userIdFromPhone: async () => "u1",
+		});
+		await adapter.parseWebhook!(new Request("https://example.com/wh", { method: "POST" }));
+		expect(optOutHook).toHaveBeenCalledWith("u1", "whatsapp", null, "inbound-stop");
+	});
+
+	it("does NOT revoke on a non-stop inbound message", async () => {
+		const db = createWaDb();
+		await recordOptIn({ db }, { userId: "u1", phoneE164: "+919999999999", method: "x" });
+		const optOutHook = vi.fn().mockResolvedValue(undefined);
+		const provider = fakeProvider();
+		provider.parseWebhook = async () => [
+			{
+				kind: "inbound" as const,
+				message: { from: "+919999999999", text: "thanks!", at: Date.now() },
+			},
+		];
+		const adapter = whatsappAdapter({
+			provider,
+			db,
+			optOutHook,
+			userIdFromPhone: async () => "u1",
+		});
+		await adapter.parseWebhook!(new Request("https://example.com/wh", { method: "POST" }));
+		expect(optOutHook).not.toHaveBeenCalled();
+	});
+});
+
+describe("whatsappAdapter() — quality-rating pause", () => {
+	it("flips the marketing-pause flag on a 'low' quality alert", async () => {
+		const db = createWaDb();
+		const pauseRegistry = new MarketingPauseRegistry();
+		const provider = fakeProvider();
+		provider.parseWebhook = async () => [
+			{ kind: "quality" as const, alert: { level: "low" as const, at: Date.now() } },
+		];
+		const adapter = whatsappAdapter({ provider, db, pauseRegistry });
+		await adapter.parseWebhook!(new Request("https://example.com/wh", { method: "POST" }));
+		expect(pauseRegistry.isPaused()).toBe(true);
+	});
+
+	it("ignores 'high' quality alerts", async () => {
+		const db = createWaDb();
+		const pauseRegistry = new MarketingPauseRegistry();
+		const provider = fakeProvider();
+		provider.parseWebhook = async () => [
+			{ kind: "quality" as const, alert: { level: "high" as const, at: Date.now() } },
+		];
+		const adapter = whatsappAdapter({ provider, db, pauseRegistry });
+		await adapter.parseWebhook!(new Request("https://example.com/wh", { method: "POST" }));
+		expect(pauseRegistry.isPaused()).toBe(false);
+	});
+});
+
+describe("provider stubs", () => {
+	it("twilioWaProvider throws on every call", async () => {
+		const p = twilioWaProvider({ accountSid: "x", authToken: "y", fromNumber: "+1" });
+		await expect(p.send({ toE164: "+1", sessionText: "x" })).rejects.toThrow(/not implemented/i);
+		await expect(p.uploadMedia({ bytes: new Uint8Array(0), mimeType: "x/y" })).rejects.toThrow();
+	});
+
+	it("gupshupWaProvider throws on every call", async () => {
+		const p = gupshupWaProvider({ apiKey: "x", appName: "y" });
+		await expect(p.send({ toE164: "+1", sessionText: "x" })).rejects.toThrow(/not implemented/i);
+	});
+});

--- a/packages/notify/tests/adapters/whatsapp/adapter.test.ts
+++ b/packages/notify/tests/adapters/whatsapp/adapter.test.ts
@@ -113,17 +113,38 @@ describe("whatsappAdapter() — 24h session window", () => {
 		expect(r.error).toContain("24h");
 	});
 
-	it("permits a session message inside the window without a template", async () => {
+	it("permits a session message inside the window when body is provided", async () => {
 		const db = createWaDb();
 		await recordOptIn({ db }, { userId: "u1", phoneE164: "+919999999999", method: "x" });
 		await recordInbound({ db }, { userId: "u1", at: Date.now() });
 		const provider = fakeProvider();
 		const adapter = whatsappAdapter({ provider, db });
-		const r = await adapter.send(args({}));
-		// Inside window + no template → adapter calls provider.send (which our
-		// fake accepts) → sent. The "outside-24h" early-return must NOT fire.
+		const r = await adapter.send(args({ body: () => "hi" }));
 		expect(r.status).toBe("sent");
 		expect(provider.calls.send).toBe(1);
+	});
+
+	it("rejects a session message inside the window when no body or media is provided", async () => {
+		const db = createWaDb();
+		await recordOptIn({ db }, { userId: "u1", phoneE164: "+919999999999", method: "x" });
+		await recordInbound({ db }, { userId: "u1", at: Date.now() });
+		const adapter = whatsappAdapter({ provider: fakeProvider(), db });
+		const r = await adapter.send(args({}));
+		expect(r.status).toBe("failed");
+		expect(r.error).toContain("session message requires");
+	});
+});
+
+describe("whatsappAdapter() — constructor invariants", () => {
+	it("throws if optOutHook is supplied without userIdFromPhone", () => {
+		const db = createWaDb();
+		expect(() =>
+			whatsappAdapter({
+				provider: fakeProvider(),
+				db,
+				optOutHook: async () => undefined,
+			}),
+		).toThrow(/userIdFromPhone/);
 	});
 });
 

--- a/packages/notify/tests/adapters/whatsapp/forget.test.ts
+++ b/packages/notify/tests/adapters/whatsapp/forget.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { forgetWhatsAppUser } from "../../../src/adapters/whatsapp/forget";
+import { recordOptIn } from "../../../src/adapters/whatsapp/opt-in";
+import { recordInbound } from "../../../src/adapters/whatsapp/session-window";
+import { createWaDb } from "./_d1";
+
+describe("forgetWhatsAppUser()", () => {
+	it("deletes only the supplied user's opt-in proof + inbound log rows", async () => {
+		const db = createWaDb();
+		await recordOptIn({ db }, { userId: "u1", phoneE164: "+91999", method: "x" });
+		await recordOptIn({ db }, { userId: "u2", phoneE164: "+91888", method: "x" });
+		await recordInbound({ db }, { userId: "u1", at: 100 });
+		await recordInbound({ db }, { userId: "u2", at: 100 });
+
+		const r = await forgetWhatsAppUser(db, "u1");
+		expect(r.optInRowsDeleted).toBe(1);
+		expect(r.inboundLogRowsDeleted).toBe(1);
+		expect(r.mediaCacheRowsDeleted).toBe(0);
+
+		const survivors = db.__raw.prepare("SELECT user_id FROM wa_optin_proofs").all() as {
+			user_id: string;
+		}[];
+		expect(survivors).toEqual([{ user_id: "u2" }]);
+	});
+});

--- a/packages/notify/tests/adapters/whatsapp/forget.test.ts
+++ b/packages/notify/tests/adapters/whatsapp/forget.test.ts
@@ -7,8 +7,8 @@ import { createWaDb } from "./_d1";
 describe("forgetWhatsAppUser()", () => {
 	it("deletes only the supplied user's opt-in proof + inbound log rows", async () => {
 		const db = createWaDb();
-		await recordOptIn({ db }, { userId: "u1", phoneE164: "+91999", method: "x" });
-		await recordOptIn({ db }, { userId: "u2", phoneE164: "+91888", method: "x" });
+		await recordOptIn({ db }, { userId: "u1", phoneE164: "+919999999999", method: "x" });
+		await recordOptIn({ db }, { userId: "u2", phoneE164: "+918888888888", method: "x" });
 		await recordInbound({ db }, { userId: "u1", at: 100 });
 		await recordInbound({ db }, { userId: "u2", at: 100 });
 

--- a/packages/notify/tests/adapters/whatsapp/keywords.test.ts
+++ b/packages/notify/tests/adapters/whatsapp/keywords.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { defaultStopKeywords, isStopKeyword } from "../../../src/adapters/whatsapp/keywords";
+
+describe("isStopKeyword()", () => {
+	it("matches case-insensitively across English keywords", () => {
+		expect(isStopKeyword("STOP")).toBe(true);
+		expect(isStopKeyword("stop")).toBe(true);
+		expect(isStopKeyword("UnSubScRiBe")).toBe(true);
+	});
+
+	it("matches Hindi keywords (Devanagari + transliteration)", () => {
+		expect(isStopKeyword("बंद")).toBe(true);
+		expect(isStopKeyword("rok")).toBe(true);
+	});
+
+	it("matches Spanish + French keywords", () => {
+		expect(isStopKeyword("alto")).toBe(true);
+		expect(isStopKeyword("baja")).toBe(true);
+		expect(isStopKeyword("arrêt")).toBe(true);
+		expect(isStopKeyword("arret")).toBe(true);
+	});
+
+	it("does NOT match substrings — body must equal the keyword", () => {
+		expect(isStopKeyword("please stop sending these")).toBe(false);
+		expect(isStopKeyword("stop now")).toBe(false);
+	});
+
+	it("trims surrounding whitespace before comparing", () => {
+		expect(isStopKeyword("   stop  \n")).toBe(true);
+	});
+
+	it("ignores empty/whitespace-only input", () => {
+		expect(isStopKeyword("")).toBe(false);
+		expect(isStopKeyword("   ")).toBe(false);
+	});
+
+	it("respects extraKeywords", () => {
+		expect(isStopKeyword("opt out", { extraKeywords: ["opt out"] })).toBe(true);
+		expect(isStopKeyword("opt out")).toBe(false);
+	});
+
+	it("exposes the default keyword list for tests/inspection", () => {
+		const list = defaultStopKeywords();
+		expect(list).toContain("stop");
+		expect(list.length).toBeGreaterThan(5);
+	});
+});

--- a/packages/notify/tests/adapters/whatsapp/marketing-pause.test.ts
+++ b/packages/notify/tests/adapters/whatsapp/marketing-pause.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { MarketingPauseRegistry } from "../../../src/adapters/whatsapp/marketing-pause";
+
+describe("MarketingPauseRegistry", () => {
+	it("starts unpaused", () => {
+		const r = new MarketingPauseRegistry();
+		expect(r.isPaused()).toBe(false);
+	});
+
+	it("pause()/resume() flip the flag and emit audit events", async () => {
+		const audit = vi.fn();
+		const r = new MarketingPauseRegistry({ auditHook: audit });
+		await r.pause("meta-quality:low");
+		expect(r.isPaused()).toBe(true);
+		expect(r.pauseReason()).toBe("meta-quality:low");
+		expect(audit).toHaveBeenCalledTimes(1);
+		expect(audit.mock.calls[0]![0]).toMatchObject({ state: "paused", reason: "meta-quality:low" });
+
+		await r.resume("operator-cleared");
+		expect(r.isPaused()).toBe(false);
+		expect(audit).toHaveBeenCalledTimes(2);
+		expect(audit.mock.calls[1]![0]).toMatchObject({ state: "resumed" });
+	});
+
+	it("repeated pause/resume calls do nothing (no audit double-fire)", async () => {
+		const audit = vi.fn();
+		const r = new MarketingPauseRegistry({ auditHook: audit });
+		await r.pause("a");
+		await r.pause("b");
+		expect(audit).toHaveBeenCalledTimes(1);
+		await r.resume("a");
+		await r.resume("b");
+		expect(audit).toHaveBeenCalledTimes(2);
+	});
+});

--- a/packages/notify/tests/adapters/whatsapp/media-cache.test.ts
+++ b/packages/notify/tests/adapters/whatsapp/media-cache.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+	cacheKey,
+	getCached,
+	purgeExpiredMedia,
+	putCached,
+} from "../../../src/adapters/whatsapp/media-cache";
+import { createWaDb } from "./_d1";
+
+describe("media-cache", () => {
+	it("cacheKey is `<provider>://<r2Key>:<etag>`", () => {
+		expect(cacheKey("meta", "reports/u1/r1.pdf", "abc123")).toBe("meta://reports/u1/r1.pdf:abc123");
+	});
+
+	it("put + get round-trips", async () => {
+		const db = createWaDb();
+		const key = cacheKey("meta", "k", "etag1");
+		await putCached({ db, now: () => 1000 }, key, {
+			provider: "meta",
+			mediaId: "mid_1",
+			mimeType: "image/png",
+			bytes: 42,
+		});
+		const cached = await getCached({ db, now: () => 1000 }, key);
+		expect(cached?.mediaId).toBe("mid_1");
+		expect(cached?.mimeType).toBe("image/png");
+		expect(cached?.bytes).toBe(42);
+	});
+
+	it("returns null when expired (via TTL)", async () => {
+		const db = createWaDb();
+		const key = cacheKey("meta", "k", "etag1");
+		await putCached({ db, now: () => 1000 }, key, {
+			provider: "meta",
+			mediaId: "mid_1",
+			ttlMs: 100,
+		});
+		// 1000 + 100 = 1100; at t=2000 we're past expiry.
+		expect(await getCached({ db, now: () => 2000 }, key)).toBeNull();
+	});
+
+	it("purgeExpiredMedia removes rows past their expiry", async () => {
+		const db = createWaDb();
+		await putCached({ db, now: () => 0 }, cacheKey("meta", "a", "1"), {
+			provider: "meta",
+			mediaId: "x",
+			ttlMs: 100,
+		});
+		await putCached({ db, now: () => 0 }, cacheKey("meta", "b", "1"), {
+			provider: "meta",
+			mediaId: "y",
+			ttlMs: 100_000,
+		});
+		const r = await purgeExpiredMedia({ db, now: () => 5000 });
+		expect(r.deleted).toBe(1);
+	});
+});

--- a/packages/notify/tests/adapters/whatsapp/meta.test.ts
+++ b/packages/notify/tests/adapters/whatsapp/meta.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TemplateNotApprovedError } from "../../../src/adapters/whatsapp/errors";
+import { metaWaProvider } from "../../../src/adapters/whatsapp/providers/meta";
+
+const ORIGINAL_FETCH = globalThis.fetch;
+beforeEach(() => {
+	globalThis.fetch = vi.fn() as unknown as typeof fetch;
+});
+afterEach(() => {
+	globalThis.fetch = ORIGINAL_FETCH;
+	vi.restoreAllMocks();
+});
+
+describe("metaWaProvider().send()", () => {
+	it("posts a template body to Meta and returns the message id", async () => {
+		(globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+			new Response(JSON.stringify({ messages: [{ id: "wamid.X" }] }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			}),
+		);
+		const p = metaWaProvider({ accessToken: "tok", phoneNumberId: "PNID" });
+		const r = await p.send({
+			toE164: "+919999999999",
+			template: { name: "pre_market_brief_v2", language: "en", variables: ["NIFTY", "+1.2%"] },
+		});
+		expect(r.providerId).toBe("wamid.X");
+		const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+		const [url, init] = fetchMock.mock.calls[0]!;
+		expect(String(url)).toContain("/PNID/messages");
+		const body = JSON.parse((init as RequestInit).body as string);
+		expect(body.to).toBe("+919999999999");
+		expect(body.template.name).toBe("pre_market_brief_v2");
+		expect(body.template.language.code).toBe("en");
+		expect(body.template.components[0].parameters).toHaveLength(2);
+	});
+
+	it("posts a session text message when no template is supplied", async () => {
+		(globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+			new Response(JSON.stringify({ messages: [{ id: "wamid.Y" }] }), { status: 200 }),
+		);
+		const p = metaWaProvider({ accessToken: "tok", phoneNumberId: "PNID" });
+		await p.send({ toE164: "+91999", sessionText: "hello" });
+		const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+		const body = JSON.parse((fetchMock.mock.calls[0]![1] as RequestInit).body as string);
+		expect(body.type).toBe("text");
+		expect(body.text.body).toBe("hello");
+	});
+
+	it("throws TemplateNotApprovedError on Meta error code 132000", async () => {
+		(globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+			new Response(JSON.stringify({ error: { message: "template not approved", code: 132000 } }), {
+				status: 400,
+			}),
+		);
+		const p = metaWaProvider({ accessToken: "tok", phoneNumberId: "PNID" });
+		await expect(
+			p.send({ toE164: "+91999", template: { name: "x", language: "en" } }),
+		).rejects.toBeInstanceOf(TemplateNotApprovedError);
+	});
+});
+
+describe("metaWaProvider().handleVerificationChallenge()", () => {
+	const p = metaWaProvider({ accessToken: "tok", phoneNumberId: "PNID" });
+
+	it("returns 200 with the challenge when verify_token matches", async () => {
+		const req = new Request(
+			"https://example.com/wh?hub.mode=subscribe&hub.challenge=42&hub.verify_token=secret",
+		);
+		const res = p.handleVerificationChallenge(req, "secret");
+		expect(res?.status).toBe(200);
+		expect(await res?.text()).toBe("42");
+	});
+
+	it("returns 403 when verify_token does not match", async () => {
+		const req = new Request(
+			"https://example.com/wh?hub.mode=subscribe&hub.challenge=42&hub.verify_token=wrong",
+		);
+		const res = p.handleVerificationChallenge(req, "secret");
+		expect(res?.status).toBe(403);
+	});
+
+	it("returns null when not a GET subscribe handshake", async () => {
+		const req = new Request("https://example.com/wh", { method: "POST" });
+		expect(p.handleVerificationChallenge(req, "secret")).toBeNull();
+	});
+});
+
+describe("metaWaProvider().verifySignature()", () => {
+	const SECRET = "app_secret";
+	const body = JSON.stringify({ entry: [] });
+
+	async function buildSig(secret: string, raw: string): Promise<string> {
+		const key = await crypto.subtle.importKey(
+			"raw",
+			new TextEncoder().encode(secret),
+			{ name: "HMAC", hash: "SHA-256" },
+			false,
+			["sign"],
+		);
+		const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(raw));
+		return [...new Uint8Array(sig)].map((b) => b.toString(16).padStart(2, "0")).join("");
+	}
+
+	it("accepts a valid sha256= header", async () => {
+		const expected = await buildSig(SECRET, body);
+		const req = new Request("https://example.com/wh", {
+			method: "POST",
+			headers: { "x-hub-signature-256": `sha256=${expected}` },
+			body,
+		});
+		const p = metaWaProvider({ accessToken: "tok", phoneNumberId: "PNID" });
+		expect(await p.verifySignature(req, SECRET)).toBe(true);
+	});
+
+	it("rejects a missing header", async () => {
+		const req = new Request("https://example.com/wh", { method: "POST", body });
+		const p = metaWaProvider({ accessToken: "tok", phoneNumberId: "PNID" });
+		expect(await p.verifySignature(req, SECRET)).toBe(false);
+	});
+
+	it("rejects a tampered signature", async () => {
+		const expected = await buildSig(SECRET, body);
+		// Flip the first hex char to a non-equal value. `slice(0,-1) + "0"` is
+		// a no-op when the original sig already ends in "0".
+		const flipped = (expected[0] === "0" ? "1" : "0") + expected.slice(1);
+		const req = new Request("https://example.com/wh", {
+			method: "POST",
+			headers: { "x-hub-signature-256": `sha256=${flipped}` },
+			body,
+		});
+		const p = metaWaProvider({ accessToken: "tok", phoneNumberId: "PNID" });
+		expect(await p.verifySignature(req, SECRET)).toBe(false);
+	});
+});
+
+describe("metaWaProvider().parseWebhook()", () => {
+	const p = metaWaProvider({ accessToken: "tok", phoneNumberId: "PNID" });
+
+	it("maps delivery statuses to delivery events", async () => {
+		const body = JSON.stringify({
+			entry: [
+				{
+					changes: [
+						{
+							field: "messages",
+							value: {
+								statuses: [
+									{ id: "wamid.A", status: "delivered", timestamp: "1700000000" },
+									{ id: "wamid.B", status: "read", timestamp: "1700000001" },
+									{ id: "wamid.C", status: "failed", timestamp: "1700000002" },
+								],
+							},
+						},
+					],
+				},
+			],
+		});
+		const req = new Request("https://example.com/wh", { method: "POST", body });
+		const events = await p.parseWebhook(req);
+		expect(events).toHaveLength(3);
+		const statuses = events.flatMap((e) => (e.kind === "delivery" ? [e.event.status] : []));
+		expect(statuses).toEqual(["delivered", "read", "failed"]);
+	});
+
+	it("emits inbound events for incoming messages", async () => {
+		const body = JSON.stringify({
+			entry: [
+				{
+					changes: [
+						{
+							field: "messages",
+							value: {
+								messages: [
+									{ from: "+919999999999", text: { body: "stop" }, timestamp: "1700000000" },
+								],
+							},
+						},
+					],
+				},
+			],
+		});
+		const req = new Request("https://example.com/wh", { method: "POST", body });
+		const events = await p.parseWebhook(req);
+		const inbound = events.find((e) => e.kind === "inbound");
+		expect(inbound?.kind).toBe("inbound");
+		if (inbound?.kind === "inbound") {
+			expect(inbound.message.from).toBe("+919999999999");
+			expect(inbound.message.text).toBe("stop");
+		}
+	});
+
+	it("emits quality alerts for account_update events", async () => {
+		const body = JSON.stringify({
+			entry: [
+				{
+					changes: [
+						{
+							field: "account_update",
+							value: { quality_score: { score: "low" } },
+						},
+					],
+				},
+			],
+		});
+		const req = new Request("https://example.com/wh", { method: "POST", body });
+		const events = await p.parseWebhook(req);
+		expect(events[0]?.kind).toBe("quality");
+		if (events[0]?.kind === "quality") {
+			expect(events[0].alert.level).toBe("low");
+		}
+	});
+
+	it("returns [] on bad JSON", async () => {
+		const req = new Request("https://example.com/wh", { method: "POST", body: "{not-json" });
+		expect(await p.parseWebhook(req)).toEqual([]);
+	});
+});

--- a/packages/notify/tests/adapters/whatsapp/opt-in.test.ts
+++ b/packages/notify/tests/adapters/whatsapp/opt-in.test.ts
@@ -25,7 +25,10 @@ describe("opt-in proof helpers", () => {
 
 	it("revokeOptIn marks revoked_at; isOptedIn returns false after", async () => {
 		const db = createWaDb();
-		await recordOptIn({ db }, { userId: "u1", phoneE164: "+91999", method: "checkbox-signup" });
+		await recordOptIn(
+			{ db },
+			{ userId: "u1", phoneE164: "+919999999999", method: "checkbox-signup" },
+		);
 		await revokeOptIn({ db }, "u1", "inbound-stop");
 		expect(await isOptedIn({ db }, "u1")).toBe(false);
 		const proof = await getOptInProof({ db }, "u1");
@@ -35,9 +38,9 @@ describe("opt-in proof helpers", () => {
 
 	it("re-recordOptIn after revoke clears revoked_at", async () => {
 		const db = createWaDb();
-		await recordOptIn({ db }, { userId: "u1", phoneE164: "+91999", method: "x" });
+		await recordOptIn({ db }, { userId: "u1", phoneE164: "+919999999999", method: "x" });
 		await revokeOptIn({ db }, "u1", "test");
-		await recordOptIn({ db }, { userId: "u1", phoneE164: "+91999", method: "x" });
+		await recordOptIn({ db }, { userId: "u1", phoneE164: "+919999999999", method: "x" });
 		expect(await isOptedIn({ db }, "u1")).toBe(true);
 	});
 

--- a/packages/notify/tests/adapters/whatsapp/opt-in.test.ts
+++ b/packages/notify/tests/adapters/whatsapp/opt-in.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+	getOptInProof,
+	isOptedIn,
+	recordOptIn,
+	revokeOptIn,
+} from "../../../src/adapters/whatsapp/opt-in";
+import type { PhoneCipher } from "../../../src/adapters/whatsapp/phone";
+import { createWaDb } from "./_d1";
+
+describe("opt-in proof helpers", () => {
+	it("recordOptIn + isOptedIn round-trip", async () => {
+		const db = createWaDb();
+		await recordOptIn(
+			{ db },
+			{
+				userId: "u1",
+				phoneE164: "+919999999999",
+				method: "checkbox-signup",
+			},
+		);
+		expect(await isOptedIn({ db }, "u1")).toBe(true);
+		expect(await isOptedIn({ db }, "u2")).toBe(false);
+	});
+
+	it("revokeOptIn marks revoked_at; isOptedIn returns false after", async () => {
+		const db = createWaDb();
+		await recordOptIn({ db }, { userId: "u1", phoneE164: "+91999", method: "checkbox-signup" });
+		await revokeOptIn({ db }, "u1", "inbound-stop");
+		expect(await isOptedIn({ db }, "u1")).toBe(false);
+		const proof = await getOptInProof({ db }, "u1");
+		expect(proof?.revokedAt).toBeGreaterThan(0);
+		expect(proof?.revokeReason).toBe("inbound-stop");
+	});
+
+	it("re-recordOptIn after revoke clears revoked_at", async () => {
+		const db = createWaDb();
+		await recordOptIn({ db }, { userId: "u1", phoneE164: "+91999", method: "x" });
+		await revokeOptIn({ db }, "u1", "test");
+		await recordOptIn({ db }, { userId: "u1", phoneE164: "+91999", method: "x" });
+		expect(await isOptedIn({ db }, "u1")).toBe(true);
+	});
+
+	it("encrypts the phone number when a cipher is supplied", async () => {
+		const db = createWaDb();
+		const cipher: PhoneCipher = {
+			async encrypt(plain) {
+				return `ENC(${plain})`;
+			},
+			async decrypt(c) {
+				return c.replace(/^ENC\(([^)]+)\)$/, "$1");
+			},
+		};
+		await recordOptIn(
+			{ db, cipher },
+			{
+				userId: "u1",
+				phoneE164: "+919999999999",
+				method: "checkbox-signup",
+			},
+		);
+		const proof = await getOptInProof({ db, cipher }, "u1");
+		expect(proof?.phoneE164).toBe("+919999999999");
+		// Raw row should hold ciphertext.
+		const raw = db.__raw
+			.prepare("SELECT phone_e164 FROM wa_optin_proofs WHERE user_id = ?")
+			.get("u1") as { phone_e164: string };
+		expect(raw.phone_e164).toBe("ENC(+919999999999)");
+	});
+});

--- a/packages/notify/tests/adapters/whatsapp/phone.test.ts
+++ b/packages/notify/tests/adapters/whatsapp/phone.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { WhatsAppPhoneFormatError } from "../../../src/adapters/whatsapp/errors";
+import { assertE164, isE164 } from "../../../src/adapters/whatsapp/phone";
+
+describe("isE164() / assertE164()", () => {
+	it("accepts well-formed E.164 numbers", () => {
+		expect(isE164("+919999999999")).toBe(true);
+		expect(isE164("+14155552671")).toBe(true);
+		expect(isE164("+442071838750")).toBe(true);
+	});
+
+	it("rejects numbers without + prefix", () => {
+		expect(isE164("919999999999")).toBe(false);
+		expect(() => assertE164("919999999999")).toThrow(WhatsAppPhoneFormatError);
+	});
+
+	it("rejects numbers with spaces, dashes, or parens", () => {
+		expect(isE164("+91 99999 99999")).toBe(false);
+		expect(isE164("+1 (415) 555-2671")).toBe(false);
+	});
+
+	it("rejects too-short or too-long numbers", () => {
+		expect(isE164("+1234567")).toBe(false);
+		expect(isE164("+1234567890123456")).toBe(false);
+	});
+
+	it("rejects leading zero in country code", () => {
+		expect(isE164("+0123456789")).toBe(false);
+	});
+
+	it("trims whitespace before validating", () => {
+		expect(assertE164("  +919999999999\n")).toBe("+919999999999");
+	});
+});

--- a/packages/notify/tests/adapters/whatsapp/session-window.test.ts
+++ b/packages/notify/tests/adapters/whatsapp/session-window.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+	SESSION_WINDOW_MS,
+	recordInbound,
+	withinSessionWindow,
+} from "../../../src/adapters/whatsapp/session-window";
+import { createWaDb } from "./_d1";
+
+describe("session window", () => {
+	it("withinSessionWindow returns false when no inbound recorded", async () => {
+		const db = createWaDb();
+		expect(await withinSessionWindow({ db }, "u1")).toBe(false);
+	});
+
+	it("returns true within 24h of the last inbound", async () => {
+		const db = createWaDb();
+		const t = 1_700_000_000_000;
+		await recordInbound({ db }, { userId: "u1", at: t });
+		expect(await withinSessionWindow({ db, now: () => t + 1000 }, "u1")).toBe(true);
+		expect(await withinSessionWindow({ db, now: () => t + SESSION_WINDOW_MS - 1 }, "u1")).toBe(
+			true,
+		);
+	});
+
+	it("returns false when the last inbound is older than 24h", async () => {
+		const db = createWaDb();
+		const t = 1_700_000_000_000;
+		await recordInbound({ db }, { userId: "u1", at: t });
+		expect(await withinSessionWindow({ db, now: () => t + SESSION_WINDOW_MS + 1 }, "u1")).toBe(
+			false,
+		);
+	});
+
+	it("recordInbound upserts and last_inbound_at advances", async () => {
+		const db = createWaDb();
+		await recordInbound({ db }, { userId: "u1", at: 1, text: "hi" });
+		await recordInbound({ db }, { userId: "u1", at: 2, text: "again" });
+		const row = db.__raw
+			.prepare("SELECT last_inbound_at, last_text FROM wa_inbound_log WHERE user_id = ?")
+			.get("u1") as { last_inbound_at: number; last_text: string };
+		expect(row.last_inbound_at).toBe(2);
+		expect(row.last_text).toBe("again");
+	});
+});


### PR DESCRIPTION
## Summary

Adds **WhatsApp** transport adapter as a subpath import of `@workkit/notify` (`@workkit/notify/whatsapp`). Provider-pluggable: **Meta WhatsApp Business Cloud API** is the reference impl; Twilio and Gupshup are stubs.

Closes #29.

### Provider strategy

| Provider | Status | Notes |
|---|---|---|
| Meta WA Cloud API | ✅ Reference impl | Free 1k conversations/mo, no BSP markup, global |
| Twilio | 🟡 Stub | Throws `not implemented`; community contribution |
| Gupshup | 🟡 Stub | Throws `not implemented`; community contribution |

### Adapter (`whatsappAdapter`)

- **Opt-in proof required pre-send** via `wa_optin_proofs` (`OptInRequiredError`).
- **24h session window** auto-routed from `wa_inbound_log`. Override with `forceTemplate: true`.
- **DND India callback** invoked only for `category: "marketing"` templates.
- **`MarketingPauseRegistry`** flips on Meta `account_update.phone_quality` low/flagged alerts; transactional sends unaffected.
- **Multi-locale STOP keywords** (EN/HI/ES/FR; extensible) auto-trigger opt-out hook.
- **E.164 enforcement** + optional `phoneCipher` for at-rest encryption.
- **R2 etag → media-id cache** (D1-backed, 30d TTL).
- **Meta GET-handshake** + **`X-Hub-Signature-256`** verify.

### D1 schema

`wa_optin_proofs`, `wa_media_cache`, `wa_inbound_log` — exported via `WA_ALL_MIGRATIONS`.

### Tests

**58 new unit tests** across:
- `keywords` (8) — multi-locale STOP matching
- `phone` (6) — E.164 validation
- `opt-in` (4) — proof storage, revoke, cipher round-trip
- `session-window` (4) — 24h boundary + upsert
- `marketing-pause` (3) — flag + audit hook
- `media-cache` (4) — TTL + purge
- `meta` (12) — send (template + text), webhook parse, signature verify, GET-handshake
- `adapter` (12) — opt-in/phone/window/dnd/marketing-pause/inbound-stop/quality-pause + provider stubs
- `forget` (1) — cascade

Total notify package: **152 → 210 unit tests** all green.

### LOC

WhatsApp subpath: ~880 source LOC across 13 files including JSDoc. Over the 700 budget — driver was the orchestrator + Meta provider's send/parse/verify/handshake breadth + opt-in/cache/pause/keywords primitives. Trimming would mean dropping security defaults the issue mandated. Calling out for review.

### Stacking + restructure note

Originally branched off `feature/006-notify-adapters` while #39 was in review; rebased onto master after #39 merged. Includes the same `@workkit/notify` subpath structure as email/inapp.

## Test plan

- [x] `bun --filter @workkit/notify test` — 210/210
- [x] `bun --filter @workkit/notify typecheck` — clean
- [x] `bun --filter @workkit/notify build` — clean (4 dist entries: index, email, inapp, whatsapp)
- [x] `bunx biome check packages/notify` — clean
- [x] `maina verify` — clean
- [ ] CI green
- [ ] CodeRabbit / Copilot re-review
- [ ] Smoke: `import "@workkit/notify/whatsapp"` from a consumer

## Reviewer notes

- **Provider as object, not class** — easier to swap and test. Twilio + Gupshup stubs return providers whose every method throws with a "see #29" pointer.
- **Single-isolate marketing-pause** — multi-isolate fan-out belongs to a future Durable-Object-backed pause registry. Acceptable for v1 because Meta's quality metric is slow-moving (a 30s propagation gap across isolates won't matter).
- **Opt-out hook contract**: webhook payloads carry phone-number-as-userId only. The adapter's `userIdFromPhone` callback resolves to the consumer's internal id; the `optOutHook` is called with that resolved id.
- **Phone cipher is optional** — default identity (plain E.164). Switching to a real AES-GCM cipher later doesn't require schema migration since the column is `TEXT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added WhatsApp messaging adapter available at `@workkit/notify/whatsapp` subpath
  * Supports Meta WhatsApp Business Cloud API with Twilio and Gupshup provider stubs
  * Enforces opt-in proof, 24-hour session window routing, and quality-driven marketing pause
  * Multi-locale STOP/UNSUBSCRIBE keyword recognition, E.164 phone validation, and media upload caching
  * Includes webhook signature verification and verification challenge handling for Meta

* **Documentation**
  * Added WhatsApp adapter section to README with usage examples and configuration guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->