### PR TITLE
docs: guides for browser, pdf, agents, notifications + architecture entries

### DIFF
--- a/apps/docs/src/content/docs/architecture.md
+++ b/apps/docs/src/content/docs/architecture.md
@@ -49,7 +49,11 @@ These build on Layer 1 for higher-level patterns:
 | `@workkit/ratelimit` | Fixed window, sliding window, token bucket, composite rate limiting (KV-backed) |
 | `@workkit/ai` | Workers AI client, streaming, fallback chains, retry, token estimation |
 | `@workkit/ai-gateway` | Multi-provider AI gateway (Workers AI, OpenAI, Anthropic, custom), routing, cost tracking, caching |
+| `@workkit/agent` | Agent loop primitives — typed tools (Standard Schema), handoffs, streaming events, hooks. Provider-agnostic via `@workkit/ai-gateway` |
 | `@workkit/api` | API definition, routing, OpenAPI generation, validation |
+| `@workkit/browser` | Cloudflare Browser Rendering primitive — session/page lifecycle, font loading, normalized errors |
+| `@workkit/pdf` | HTML → PDF rendering via `@workkit/browser`, R2 storage, presign helpers, header/footer composer |
+| `@workkit/notify` | Unified notification dispatch — preferences, opt-out, quiet hours, idempotency, fallback chains. Adapters via subpath imports (`/email`, `/inapp`, `/whatsapp`) |
 
 ### Layer 3: Integrations
 

--- a/apps/docs/src/content/docs/guides/agents.md
+++ b/apps/docs/src/content/docs/guides/agents.md
@@ -1,0 +1,136 @@
+---
+title: "Agents"
+---
+
+# Agents
+
+`@workkit/agent` is a thin agent-loop primitive on top of [`@workkit/ai-gateway`](/workkit/guides/ai-integration/). Typed tools (Standard Schema), multi-turn loops with mandatory budgets, multi-agent handoffs, typed streaming events, lifecycle hooks. Provider-agnostic.
+
+It's not a framework — there's no state graph, no DSL. Just composable primitives.
+
+## Install
+
+```bash
+bun add @workkit/agent @workkit/ai-gateway zod
+```
+
+## Quick start
+
+```ts
+import { z } from "zod";
+import { createGateway } from "@workkit/ai-gateway";
+import { defineAgent, tool, handoff } from "@workkit/agent";
+
+const gateway = createGateway({
+  providers: { ai: { type: "workers-ai", binding: env.AI } },
+  defaultProvider: "ai",
+});
+
+const getQuote = tool({
+  name: "get_quote",
+  description: "Get the latest price for a stock",
+  input: z.object({ symbol: z.string() }),
+  output: z.object({ price: z.number() }),
+  handler: async ({ symbol }) => ({ price: 100 }),
+});
+
+const analyst = defineAgent({
+  name: "market-analyst",
+  model: "@cf/meta/llama-3.1-8b-instruct",
+  provider: gateway,
+  instructions: "You are a market analyst. Use tools to answer.",
+  tools: [getQuote],
+  stopWhen: { maxSteps: 5, maxTokens: 50_000 },
+});
+
+const result = await analyst.run({
+  messages: [{ role: "user", content: "What's NIFTY?" }],
+});
+console.log(result.text, result.stopReason, result.usage);
+```
+
+## Streaming
+
+```ts
+for await (const event of analyst.stream({
+  messages: [{ role: "user", content: "..." }],
+})) {
+  if (event.type === "text-delta") process.stdout.write(event.delta);
+  if (event.type === "tool-end") console.log(event.call.name, "→", event.result);
+}
+```
+
+Event union: `step-start | text-delta | tool-start | tool-end | handoff | step-complete | error | done`.
+
+## Handoffs
+
+```ts
+import { handoff } from "@workkit/agent";
+
+const fundamentalsAnalyst = defineAgent({ /* ... */ });
+const technicalAnalyst = defineAgent({ /* ... */ });
+
+const desk = defineAgent({
+  name: "research-desk",
+  model: "@cf/meta/llama-3.1-8b-instruct",
+  provider: gateway,
+  tools: [
+    handoff(fundamentalsAnalyst, { when: "valuation, earnings" }),
+    handoff(technicalAnalyst, { when: "price action, levels" }),
+  ],
+});
+```
+
+`handoff()` returns a synthetic tool the model invokes to switch agents. Cycle detection rejects after `HANDOFF_HOP_LIMIT` (default 3) re-entries with `HandoffCycleError`.
+
+## API
+
+### `tool({ name, description, input, output?, handler, timeoutMs? })`
+
+- Standard Schema validates `input` before the handler runs.
+- Optional `output` schema validated on handler return.
+- Per-tool timeout default 30s. Aborted via `AbortSignal`.
+- Tool name must match `/^[a-zA-Z_][a-zA-Z0-9_-]*$/`.
+
+### `defineAgent({ name, model, provider, instructions?, tools?, stopWhen?, hooks? })`
+
+- `provider` — `Gateway` from `@workkit/ai-gateway`.
+- `stopWhen.maxSteps` — default `10`. Mandatory cap; loop never runs forever.
+- `stopWhen.maxTokens` — checked against cumulative `usage.totalTokens` after each step.
+- `hooks.beforeModel(ctx)` — fires before each provider call.
+- `hooks.afterTool(call, result, ctx)` — fires after each tool resolution.
+- `hooks.onError({ kind, toolName?, error }, ctx)` — fires on tool/provider/hook errors. Return `{ abort: true }` to escalate; otherwise loop continues.
+
+### `agent.run({ messages, context? })`
+
+Returns `{ text, messages, usage, stopReason }`. `stopReason ∈ stop | max_steps | max_tokens | abort | error`.
+
+### `agent.stream({ messages, context? })`
+
+Async iterator of typed `AgentEvent`s.
+
+### `handoff(targetAgent, { when?, description? })`
+
+Synthetic handoff tool. Pass the **full** agent (not just `{ name }`) so collision detection can transit through target tools.
+
+## Security defaults
+
+- **Tool input validated** before the handler runs. Bad input → `ToolValidationError` becomes a tool-error message to the model.
+- **Tool handler errors do not silently swallow.** They surface as tool-error messages and as `onError` hook calls.
+- **Per-tool timeout** (default 30s) with abort propagation into handler bodies.
+- **Abort signal** propagates to the provider call AND in-flight tool handlers.
+- **Handoff cycles capped** at 3 re-entries; raises `HandoffCycleError`.
+- **Tool name collisions rejected at `defineAgent` time** including against handoff target tools.
+- **Provider failures rethrow by default.** `onError` must explicitly return `{ abort: false }` to recover with `stopReason:'stop'`.
+
+## Out of scope (v1 — follow-ups)
+
+- `@modelcontextprotocol/sdk` MCP client integration.
+- `bindToAgent` Durable Object helper.
+- Scratchpad compaction strategies.
+- `maxCostUSD` budget (depends on per-provider pricing surface unification).
+
+## See also
+
+- [AI Integration](/workkit/guides/ai-integration/) — `@workkit/ai-gateway` primer.
+- [Notifications](/workkit/guides/notifications/) — agents often produce notifications as side effects.

--- a/apps/docs/src/content/docs/guides/browser-rendering.md
+++ b/apps/docs/src/content/docs/guides/browser-rendering.md
@@ -1,0 +1,100 @@
+---
+title: "Browser Rendering"
+---
+
+# Browser Rendering
+
+`@workkit/browser` is a thin primitive over Cloudflare Browser Rendering — session/page lifecycle, font loading, and normalized errors. It's the shared base for `@workkit/pdf` and any future screenshot/OG packages.
+
+## Install
+
+```bash
+bun add @workkit/browser @cloudflare/puppeteer
+```
+
+`@cloudflare/puppeteer` is an optional peer — bring your own version. Without it you have a Browser Rendering binding but no methods to call on it.
+
+## Quick start
+
+```ts
+import puppeteer from "@cloudflare/puppeteer";
+import { browser, withPage, loadFonts } from "@workkit/browser";
+
+export default {
+  async fetch(req: Request, env: Env) {
+    const session = await browser(env.BROWSER, { puppeteer });
+
+    const bytes = await withPage(session, async (page) => {
+      await (page as any).setContent("<h1>Hello</h1>", { waitUntil: "networkidle2" });
+      await loadFonts(page, [
+        { family: "Inter", url: "https://fonts.example.com/Inter.woff2" },
+      ]);
+      return (page as any).pdf({ format: "A4" });
+    });
+
+    return new Response(bytes, { headers: { "content-type": "application/pdf" } });
+  },
+};
+```
+
+## API
+
+### `browser(binding, options?)`
+
+Acquires a Cloudflare Browser Rendering session.
+
+- `binding` — `env.BROWSER`
+- `options.puppeteer` — `@cloudflare/puppeteer` instance (recommended)
+- `options.keepAlive` — `number` (ms) — keep session alive between renders. Off by default; opt-in carries a state-leak risk.
+- `options.launch` — extra options forwarded to `puppeteer.launch`
+
+### `withPage(session, fn, options?)`
+
+Runs `fn(page)` with guaranteed `page.close()` on success, throw, or abort.
+
+- `options.js` — `boolean` (default `false`). Untrusted HTML can execute scripts when `true`.
+- `options.timeoutMs` — per-page operation timeout. Default `15000`. Override globally via `WORKKIT_BROWSER_TIMEOUT_MS`.
+- `options.signal` — `AbortSignal`. On abort the page closes and the promise rejects with the abort reason.
+- `options.autoDismissDialogs` — auto-dismiss `alert`/`confirm`/`prompt`/`beforeunload`. Default `true`.
+
+### `loadFonts(page, fonts, options?)`
+
+Injects `@font-face` declarations and waits for them to be ready.
+
+- `fonts` — `Array<{ family, url, weight?, style?, display? }>`. URLs must be HTTPS.
+- `options.timeoutMs` — default `5000`.
+- `options.verifyAvailable` — default `true` (no silent fallback). Throws `FontLoadError` if the registered font isn't actually available after load.
+
+## Security defaults
+
+- **JS off by default.** Untrusted HTML cannot execute scripts unless you opt in with `js: true`.
+- **No URL navigation helper.** Use `page.setContent(html)` for trusted templated rendering. If you need to navigate to URLs, write your own SSRF guard at the call site — we don't ship one because the right policy is consumer-specific.
+- **`keepAlive` leaks state.** Cookies, storage, and JS state persist when sharing a session. Only use for trusted, non-PII workloads.
+- **Font URLs are HTTPS-only.** `loadFonts` rejects `http://`, `data:`, `file://` and characters that could break out of the `url("…")` token (quotes, parens, control chars, backslash). Same guard for family names.
+- **Dialogs auto-dismissed by default.** Prevents stuck pages on `beforeunload`/`confirm` from untrusted templates.
+
+## Errors
+
+All failures normalize through `@workkit/errors`:
+
+| Condition | Error |
+|---|---|
+| Browser binding 429 (with `Retry-After`) | `RateLimitError` (carries `retryAfterMs`; case-insensitive header lookup) |
+| Browser binding 502/503/504 | `ServiceUnavailableError` |
+| Operation timeout | `TimeoutError` |
+| Font registered but unavailable | `FontLoadError` (extends `ValidationError`) |
+| Non-HTTPS or unsafe font URL | `FontLoadError` |
+
+## Cost monitoring
+
+Browser Rendering is priced per session. Recommended pattern:
+
+1. Wire `@workkit/ratelimit` per user before calling any render function.
+2. Increment an Analytics Engine counter on every session acquisition.
+3. Alert at **50,000 sessions / month** as a sanity ceiling.
+4. If you cross the threshold consistently, evaluate `@react-pdf/renderer` for templated content where Browser Rendering's full layout engine isn't needed.
+
+## See also
+
+- [PDF Rendering](/workkit/guides/pdf-rendering/) — `@workkit/pdf` builds on `@workkit/browser`.
+- [Cloudflare Browser Rendering docs](https://developers.cloudflare.com/browser-rendering/)

--- a/apps/docs/src/content/docs/guides/notifications.md
+++ b/apps/docs/src/content/docs/guides/notifications.md
@@ -1,0 +1,239 @@
+---
+title: "Notifications"
+---
+
+# Notifications
+
+`@workkit/notify` is a unified notification dispatch primitive for Cloudflare Workers. One API, pluggable transport adapters that ship as **subpath imports** of the same package — bring the runtime cost of an adapter only when you import it.
+
+| Subpath | Adapter | Optional peer |
+|---|---|---|
+| `@workkit/notify/email` | Resend HTTP API + React Email | `@react-email/render` |
+| `@workkit/notify/inapp` | D1-backed feed + SSE streaming | — |
+| `@workkit/notify/whatsapp` | Meta WA Cloud API (default) + Twilio/Gupshup stubs | — |
+
+Cross-cutting concerns — recipient resolution, channel preferences, opt-out registry, quiet hours, idempotency, fallback chains, delivery records, test mode — live in core. Adapters stay thin.
+
+## Install
+
+```bash
+bun add @workkit/notify @workkit/queue @workkit/d1 @workkit/errors zod
+# Optional: only if you use React Email components
+bun add @react-email/render
+```
+
+## D1 schema
+
+Run the SQL in `ALL_MIGRATIONS` once during your migration setup. Add `INAPP_MIGRATION_SQL` and `WA_ALL_MIGRATIONS` for those adapters.
+
+```ts
+import { ALL_MIGRATIONS } from "@workkit/notify";
+import { INAPP_MIGRATION_SQL } from "@workkit/notify/inapp";
+import { WA_ALL_MIGRATIONS } from "@workkit/notify/whatsapp";
+
+for (const sql of [...ALL_MIGRATIONS, INAPP_MIGRATION_SQL, ...WA_ALL_MIGRATIONS]) {
+  await env.DB.exec(sql);
+}
+```
+
+## Define a notification
+
+```ts
+import { z } from "zod";
+import { define } from "@workkit/notify";
+
+const preMarketBrief = define(
+  {
+    id: "pre-market-brief",
+    schema: z.object({
+      reportId: z.string(),
+      instrument: z.string(),
+      summary: z.string(),
+      pdfR2Key: z.string(),
+    }),
+    channels: {
+      whatsapp: { template: "pre_market_brief_v2" },
+      email:    { template: "PreMarketBriefEmail" },
+      inApp:    {
+        title: (p) => `${p.instrument} — Pre-Market Brief`,
+        body: (p) => p.summary,
+        deepLink: (p) => `/briefs/${p.reportId}`,
+      },
+    },
+    fallback: ["whatsapp", "email", "inApp"],
+    priority: "high",
+  },
+  { enqueue: (job) => env.QUEUE.send(job) },
+);
+
+await preMarketBrief.send(
+  { reportId: "r1", instrument: "NIFTY", summary: "...", pdfR2Key: "reports/u1/r1.pdf" },
+  { userId: "u1" },
+);
+```
+
+## Wire the queue consumer
+
+```ts
+import { createNotifyConsumer } from "@workkit/notify";
+import { emailAdapter } from "@workkit/notify/email";
+import { inAppAdapter } from "@workkit/notify/inapp";
+import { whatsappAdapter, metaWaProvider } from "@workkit/notify/whatsapp";
+
+export const queue = createNotifyConsumer(
+  {
+    db: env.DB,
+    adapters: {
+      email: emailAdapter({ /* ... */ }),
+      inApp: inAppAdapter({ db: env.DB }),
+      whatsapp: whatsappAdapter({
+        provider: metaWaProvider({
+          accessToken: env.WA_ACCESS_TOKEN,
+          phoneNumberId: env.WA_PHONE_NUMBER_ID,
+        }),
+        db: env.DB,
+        userIdFromPhone: async (e164) => /* lookup */ null,
+      }),
+    },
+    resolver: async (userId) => /* lookup verified addresses */ null,
+    config: {
+      priorityAllowlist: ["pre-market-brief"],
+      deliveryRetentionDays: 90,
+    },
+  },
+  (id) =>
+    id === "pre-market-brief"
+      ? { template: preMarketBrief.channels, fallback: preMarketBrief.fallback }
+      : undefined,
+);
+```
+
+## Email adapter
+
+```ts
+import { emailAdapter } from "@workkit/notify/email";
+import { optOut } from "@workkit/notify";
+
+const email = emailAdapter({
+  apiKey: env.RESEND_API_KEY,
+  from: "Reports <reports@entryexit.ai>",
+  bucket: env.REPORTS,                              // for attachments
+  webhook: { maxAgeMs: 5 * 60 * 1000 },
+  autoOptOut: {
+    enabled: true,
+    hook: async (emailAddress, _channel, _notificationId, reason) => {
+      const userId = await lookupUserIdByEmail(emailAddress);
+      if (userId) await optOut(env.DB, userId, "email", null, reason);
+    },
+  },
+  markUnsubscribable: ["pre-market-brief"],         // attaches List-Unsubscribe headers
+});
+```
+
+- Direct `fetch` to Resend (no SDK).
+- Optional `@react-email/render` peer for React Email components.
+- Plain-text fallback auto-generated.
+- Svix-format webhook verification (`v1,<base64>` HMAC-SHA256), 5-min replay window.
+- Hard bounce + complaint → automatic opt-out via injected hook (configurable, default on).
+- Attachment cap default 40MB; bounded R2 fetch concurrency 4.
+
+## In-app adapter
+
+```ts
+import { inAppAdapter, SseRegistry, createSseHandler, feed, markRead } from "@workkit/notify/inapp";
+
+const registry = new SseRegistry();
+const inApp = inAppAdapter({ db: env.DB, registry });
+
+const sse = createSseHandler({
+  db: env.DB,
+  registry,
+  auth: async (req) => /* return { userId } | null */ null,
+  originAllowlist: ["https://app.example.com"],
+  maxConnPerUser: 5,
+});
+
+// UI calls these from your API routes
+const page = await feed(env.DB, { userId, cursor, limit: 20 });
+await markRead(env.DB, { userId, ids: ["..."] });
+```
+
+- `feed/markRead/dismiss/unreadCount` query helpers (single-round-trip batched updates).
+- Composite `(created_at, id)` opaque cursor; ownership-checked queries block cross-user enumeration.
+- SSE handler **requires** an `auth` callback (no anonymous default).
+- Per-user connection cap (default 5), origin allowlist, 30s heartbeat, dead-subscriber cleanup on push errors.
+- `safeLink` rejects `javascript:`/`data:`/`file:` schemes.
+- `forgetInAppUser(db, userId, registry?)` cascades + drops active SSE subs.
+- **Single-isolate scope.** Multi-isolate fan-out belongs to a future Durable-Object-backed adapter.
+
+## WhatsApp adapter
+
+```ts
+import { whatsappAdapter, metaWaProvider, recordOptIn, MarketingPauseRegistry } from "@workkit/notify/whatsapp";
+
+const provider = metaWaProvider({
+  accessToken: env.WA_ACCESS_TOKEN,
+  phoneNumberId: env.WA_PHONE_NUMBER_ID,
+});
+const pauseRegistry = new MarketingPauseRegistry();
+
+const whatsapp = whatsappAdapter({
+  provider,
+  db: env.DB,
+  bucket: env.MEDIA,
+  pauseRegistry,
+  dndCheck: async (e164) => /* TRAI lookup */ false,
+  optOutHook: async (userId, channel, _notificationId, reason) => { /* notify-core's optOut */ },
+  userIdFromPhone: async (e164) => /* resolve internal id */ null,
+});
+
+// Persist opt-in proof when the user clicks the WhatsApp opt-in button.
+await recordOptIn({ db: env.DB }, {
+  userId: "u1",
+  phoneE164: "+919999999999",
+  method: "checkbox-signup",
+  sourceUrl: "https://app.example.com/onboarding",
+});
+
+// Mount the webhook GET-handshake (Meta requires it for setup).
+app.get("/wa/webhook", (req) =>
+  provider.handleVerificationChallenge(req.raw, env.WA_WEBHOOK_VERIFY_TOKEN) ??
+  new Response("not a verification challenge", { status: 400 }),
+);
+```
+
+- **Provider-pluggable**: Meta is the reference impl; `twilioWaProvider` and `gupshupWaProvider` are stubs.
+- **Opt-in proof required pre-send** — `OptInRequiredError` if missing/revoked.
+- **24h session window** auto-routed; outside the window forces template send.
+- **DND callback** invoked only for `category: "marketing"` templates.
+- **Marketing-pause registry** flips on Meta `account_update.phone_quality` low/flagged webhooks; transactional sends unaffected.
+- **Multi-locale STOP keywords** (EN/HI/ES/FR; extensible) auto-trigger opt-out hook. Out-of-order webhook deliveries can't move the inbound timestamp backwards.
+- **E.164 enforcement** (validates at both opt-in record and send time) + optional `phoneCipher` for at-rest encryption.
+- **R2 etag → media-id cache** (D1-backed, default 30d TTL).
+- **Meta webhook GET-handshake** + `X-Hub-Signature-256` HMAC-SHA256 verify.
+- **`optOutHook` requires `userIdFromPhone`** — adapter throws at construction otherwise (prevents mis-keyed opt-outs).
+
+## Pipeline (race-safe)
+
+The dispatch pipeline runs INSIDE the queue consumer, not at enqueue time. This makes opt-out, quiet-hours, and idempotency race-safe:
+
+1. Idempotency check (UNIQUE on `idempotency_key`)
+2. Resolve recipient
+3. Reserve a single delivery row (siblings short-circuit)
+4. Read prefs (channels + quiet-hours)
+5. Quiet-hours bypass restricted to `priorityAllowlist` + `priority:'high'`
+6. **Re-check opt-out** (race-safe vs enqueue time)
+7. Walk channels: try adapter; on success update row; on failure continue fallback
+8. Final disposition: `sent` / `delivered` / `read` / `skipped` / `failed`
+
+## Compliance
+
+- **`forgetUser(db, userId)`** — cascade delete prefs + opt-outs + delivery records for GDPR / India DPDP. Queue draining is left to the caller.
+- **Webhook signature verified per adapter** (refuses without `secret`).
+- **`mode: "test"`** validated at the very last step before adapter dispatch.
+- **No HTML body content logged.**
+
+## See also
+
+- [PDF Rendering](/workkit/guides/pdf-rendering/) — produce PDF attachments for the email channel.
+- [Queues and Crons](/workkit/guides/queues-and-crons/) — `@workkit/queue` powers the dispatcher.

--- a/apps/docs/src/content/docs/guides/pdf-rendering.md
+++ b/apps/docs/src/content/docs/guides/pdf-rendering.md
@@ -1,0 +1,113 @@
+---
+title: "PDF Rendering"
+---
+
+# PDF Rendering
+
+`@workkit/pdf` renders HTML to PDF in Cloudflare Workers via [`@workkit/browser`](/workkit/guides/browser-rendering/). It owns the PDF-specific concerns (page presets, header/footer composition, R2 storage + presign) and delegates browser lifecycle to its base.
+
+## Install
+
+```bash
+bun add @workkit/pdf @workkit/browser @cloudflare/puppeteer
+```
+
+## Quick start
+
+```ts
+import puppeteer from "@cloudflare/puppeteer";
+import { browser } from "@workkit/browser";
+import { renderPDF, storedPDF, raw } from "@workkit/pdf";
+
+export default {
+  async fetch(req: Request, env: Env) {
+    const session = await browser(env.BROWSER, { puppeteer });
+
+    // Pure render
+    const bytes = await renderPDF(session, "<h1>Brief</h1>", {
+      header: { title: "NIFTY", right: new Date().toISOString() },
+      footer: { disclaimer: "Not investment advice", pageNumbers: true },
+      disclaimerRequired: true,
+    });
+
+    // Render + R2 + presign in one call
+    const { r2Key, url } = await storedPDF(session, "<h1>Brief</h1>", {
+      bucket: env.REPORTS,
+      key: ["reports", "user-1", `${Date.now()}.pdf`],
+      metadata: { userId: "u1", reportId: "r1" },
+      presignTtl: 3600,
+    });
+
+    return new Response(JSON.stringify({ r2Key, url, bytes: bytes.byteLength }));
+  },
+};
+```
+
+## API
+
+### `renderPDF(session, html, options?)`
+
+Returns `Promise<Uint8Array>`. Inherits JS-off, dialog auto-dismiss, abort propagation, and guaranteed page close from `@workkit/browser`'s `withPage`.
+
+Key options:
+- `page` — `pageSize.A4 | Letter | Legal`. Default `A4`.
+- `margin` — `string | Partial<PageMargin> | PageMargin`. String applies to all sides.
+- `header` / `footer` — composed via `composeHeaderFooter()`.
+- `disclaimerRequired: true` — fails fast if `footer.disclaimer` is empty.
+- `fonts` — `FontDescriptor[]` preloaded via `@workkit/browser`'s `loadFonts`.
+- `signal`, `js`, `timeoutMs`, `waitUntil`, `printBackground`, `scale`.
+
+### `storedPDF(session, html, options)`
+
+Render → R2 upload → presign in one call. Returns `{ r2Key, bytes, url }`.
+
+Additional options:
+- `bucket` — `R2Bucket`-shaped binding.
+- `key` — `string` or `string[]` (joined via `safeKey()`).
+- `metadata` — `Record<string,string>` forwarded to `customMetadata`.
+- `readPolicy` — `"presigned"` (default) or `"private"` (returns `url: null`).
+- `presignTtl` — seconds. Default 3600. **Hard cap 86400 (24h)** — exceeding throws `ValidationError`.
+- `contentDisposition` — overrides the stored object's header.
+
+### Header / footer composition
+
+```ts
+import { composeHeaderFooter, raw, escapeHtml } from "@workkit/pdf";
+
+composeHeaderFooter({
+  header: {
+    logo: raw('<img src="https://cdn.example.com/logo.png" />'),  // raw HTML
+    title: "NIFTY",                                                // auto-escaped
+    right: new Date().toISOString(),                               // auto-escaped
+  },
+  footer: {
+    disclaimer: "Not investment advice. SEBI Reg No: …",
+    pageNumbers: true,
+  },
+  disclaimerRequired: true,
+});
+```
+
+**Plain strings auto-escape**. Use `raw()` only for HTML you produced yourself.
+
+### `safeKey(...parts)`
+
+Joins parts with `/` after rejecting `..`, `.`, `\`, control chars, and components that reduce to empty after slash trim. Throws `ValidationError` rather than silently sanitizing.
+
+## Security defaults
+
+- **Header/footer values escape by default** — only `raw()` opt-in passes through unescaped.
+- **R2 keys validated** — `safeKey()` rejects path traversal explicitly.
+- **Presigned URL TTL capped at 24h** — bearer-token blast radius.
+- **JS off by default** — inherited from `@workkit/browser`.
+- **`disclaimerRequired` compliance hook** — fails before render, not after.
+- **No HTML body content logged.**
+
+## Cost monitoring
+
+Browser Rendering is priced per session. See [Browser Rendering — Cost monitoring](/workkit/guides/browser-rendering/#cost-monitoring) for the recommended pattern (per-user rate limit + Analytics Engine counter + 50k/mo alert).
+
+## See also
+
+- [Browser Rendering](/workkit/guides/browser-rendering/) — the underlying primitive.
+- [Notifications](/workkit/guides/notifications/) — `@workkit/notify`'s email adapter accepts PDFs as attachments.

--- a/bun.lock
+++ b/bun.lock
@@ -476,6 +476,14 @@
       "name": "@workkit/tsconfig",
       "version": "0.0.0",
     },
+    "tooling/vitest": {
+      "name": "@workkit/vitest-config",
+      "version": "0.0.0",
+      "peerDependencies": {
+        "vite": "*",
+        "vitest": "*",
+      },
+    },
   },
   "overrides": {
     "defu": "^6.1.7",
@@ -796,7 +804,7 @@
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
-    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -1199,6 +1207,8 @@
     "@workkit/turnstile": ["@workkit/turnstile@workspace:packages/turnstile"],
 
     "@workkit/types": ["@workkit/types@workspace:packages/types"],
+
+    "@workkit/vitest-config": ["@workkit/vitest-config@workspace:tooling/vitest"],
 
     "@workkit/workflow": ["@workkit/workflow@workspace:packages/workflow"],
 
@@ -2452,15 +2462,17 @@
 
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 
-    "@napi-rs/wasm-runtime/@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
+    "@oxc-minify/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
+
+    "@oxc-resolver/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
+
+    "@oxc-transform/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
 
     "@puppeteer/browsers/debug": ["debug@4.3.4", "", { "dependencies": { "ms": "2.1.2" } }, "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ=="],
 
     "@puppeteer/browsers/yargs": ["yargs@17.7.1", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw=="],
 
     "@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
-
-    "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
@@ -2616,7 +2628,11 @@
 
     "@expressive-code/plugin-shiki/shiki/@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
 
-    "@napi-rs/wasm-runtime/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg=="],
+    "@oxc-minify/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
+
+    "@oxc-resolver/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
+
+    "@oxc-transform/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
 
     "@puppeteer/browsers/debug/ms": ["ms@2.1.2", "", {}, "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="],
 
@@ -2777,6 +2793,12 @@
     "@astrojs/tailwind/astro/shiki/@shikijs/themes": ["@shikijs/themes@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA=="],
 
     "@astrojs/tailwind/astro/shiki/@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
+
+    "@oxc-minify/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg=="],
+
+    "@oxc-resolver/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg=="],
+
+    "@oxc-transform/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg=="],
 
     "@workkit/docs/astro/@astrojs/markdown-remark/@astrojs/prism": ["@astrojs/prism@3.3.0", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ=="],
 

--- a/tooling/vitest/package.json
+++ b/tooling/vitest/package.json
@@ -1,0 +1,18 @@
+{
+	"name": "@workkit/vitest-config",
+	"version": "0.0.0",
+	"private": true,
+	"type": "module",
+	"main": "./index.js",
+	"types": "./index.d.ts",
+	"exports": {
+		".": {
+			"types": "./index.d.ts",
+			"default": "./index.js"
+		}
+	},
+	"peerDependencies": {
+		"vite": "*",
+		"vitest": "*"
+	}
+}


### PR DESCRIPTION
## Summary

Adds Starlight guide pages for the four new packages from this roadmap, plus architecture-page entries.

| Page | Covers |
|---|---|
| `guides/browser-rendering.md` | `@workkit/browser` — `browser()` / `withPage()` / `loadFonts()`, security defaults (JS off, no URL helper, keepAlive risk), error mapping, cost monitoring |
| `guides/pdf-rendering.md` | `@workkit/pdf` — `renderPDF` / `storedPDF`, header/footer composition with `raw()` / `escapeHtml()` distinction, `safeKey()` path guard, presign TTL cap |
| `guides/agents.md` | `@workkit/agent` — `tool()` / `defineAgent()` / `handoff()`, streaming events, hooks, v1 out-of-scope (MCP, DO binding, compaction, maxCostUSD) |
| `guides/notifications.md` | `@workkit/notify` core + `/email` + `/inapp` + `/whatsapp` subpath adapters, D1 schema setup, dispatch pipeline race-safety story, per-adapter security/compliance highlights |

`architecture.md` picks up Layer-2 entries for agent, browser, pdf, notify.

Sidebar autogenerates from `guides/` so no `astro.config.mjs` change needed.

## Test plan

- [x] `bun --filter @workkit/docs build` — 22 pages built, indexed 3024 words, zero errors
- [ ] CI green
- [ ] Visual review of rendered guides on the staging deploy

## Reviewer notes

- Guides intentionally **mirror the package READMEs** but with cross-links into other guides and a narrative-first structure suited for Starlight. Some duplication is OK — readers land on the docs site without the package context.
- `api-reference.md` not touched in this PR — it carries per-export tables that would balloon the diff. Follow-up issue if we want to keep it comprehensive.
- All four new packages live under one mental model in the architecture page: "Layer 2: Application" alongside `@workkit/api`, `@workkit/auth`, etc. They build on Layer 1 + Layer 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
