### PR TITLE
fix(ci): release workflow needs Node 22 for node:sqlite

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.8"


### PR DESCRIPTION
One-line follow-up to #49. The release workflow runs `bun run test` without `setup-node`, so it falls back to ambient Node 20 which lacks `node:sqlite` — causing the first post-merge release run to fail. Same fix already applied to `ci.yml` and `maina-ci.yml`.

Release #49's merge produced run [24605280769](https://github.com/beeeku/workkit/actions/runs/24605280769) which failed at `bun run test` with this root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)