### PR TITLE
feat(notify): provider-pluggable email adapter with Cloudflare send_email as default

### DIFF
--- a/.changeset/cf-email-default.md
+++ b/.changeset/cf-email-default.md
@@ -1,0 +1,30 @@
+---
+"@workkit/notify": minor
+"@workkit/testing": minor
+"@workkit/mail": patch
+---
+
+**Cloudflare `send_email` is now the default email transport.** `@workkit/notify`'s email adapter is refactored to be provider-pluggable (matching the WhatsApp provider pattern), with `cloudflareEmailProvider` as the default and `resendEmailProvider` as the first-class alternative. Closes #52.
+
+**Breaking — `emailAdapter` options shape (pre-1.0).** The `{ apiKey, from, ... }` shape is removed. Callers must explicitly pass a provider:
+
+```diff
+- emailAdapter({ apiKey: env.RESEND_API_KEY, from: "noreply@x.com", autoOptOut: { hook } })
++ emailAdapter({ provider: resendEmailProvider({ apiKey: env.RESEND_API_KEY, from: "noreply@x.com", autoOptOut: { hook } }) })
+```
+
+Or switch to the new zero-config default:
+
+```ts
+emailAdapter({ provider: cloudflareEmailProvider({ binding: env.SEND_EMAIL, from: "noreply@x.com" }) })
+```
+
+`autoOptOut` now lives on the Resend provider (where webhook events originate); the Cloudflare provider has no delivery webhooks and no `autoOptOut` — bounce synthesis from inbound DSN is tracked in the roadmap (#53 / #54).
+
+**`@workkit/mail` added as optional peerDependency on `@workkit/notify`.** Only users of `cloudflareEmailProvider` install it.
+
+**`@workkit/testing` gains `createMockSendEmail` and `createMockForwardableEmail`** — promoted from a private helper in `@workkit/mail`. Matches the `createMockKV` / `createMockD1` / `createMockR2` pattern. `@workkit/mail` tests migrated to consume these.
+
+**`WebhookSignatureError`** takes a `provider: "resend" | "cloudflare"` arg; error messages now indicate which provider failed verification.
+
+Follow-ups filed: #53 (parseBounceDSN), #54 (createBounceRoute), #55 (retry strategy in AdapterSendResult), #56 (docs positioning), #57 (SES/Postmark provider stubs).

--- a/.maina/features/009-cf-email-default/plan.md
+++ b/.maina/features/009-cf-email-default/plan.md
@@ -1,0 +1,59 @@
+# Implementation Plan
+
+> HOW only — see spec.md for WHAT and WHY.
+
+## Architecture
+
+What is the technical approach? How does it fit into existing architecture?
+Where are the integration points with existing code?
+
+- Pattern: [NEEDS CLARIFICATION]
+- Integration points: [NEEDS CLARIFICATION]
+
+## Key Technical Decisions
+
+What libraries, patterns, or approaches? WHY these and not alternatives?
+
+- [NEEDS CLARIFICATION]
+
+## Files
+
+| File | Purpose | New/Modified |
+|------|---------|-------------|
+| [NEEDS CLARIFICATION] | | |
+
+## Tasks
+
+TDD: every implementation task must have a preceding test task.
+
+- [ ] [NEEDS CLARIFICATION] Break down into small, testable tasks.
+
+## Failure Modes
+
+What can go wrong? How do we handle it gracefully?
+
+- [NEEDS CLARIFICATION]
+
+## Testing Strategy
+
+Unit tests, integration tests, or both? What mocks are needed?
+
+- [NEEDS CLARIFICATION]
+
+
+## Wiki Context
+
+### Related Modules
+
+- **src** (69 entities) — `modules/src.md`
+- **cluster-17** (16 entities) — `modules/cluster-17.md`
+- **cluster-43** (5 entities) — `modules/cluster-43.md`
+- **cluster-35** (3 entities) — `modules/cluster-35.md`
+- **cluster-129** (2 entities) — `modules/cluster-129.md`
+- **cluster-110** (2 entities) — `modules/cluster-110.md`
+- **cluster-134** (2 entities) — `modules/cluster-134.md`
+
+### Suggestions
+
+- Module 'src' already has 69 entities — consider extending it
+- Module 'cluster-17' already has 16 entities — consider extending it

--- a/.maina/features/009-cf-email-default/plan.md
+++ b/.maina/features/009-cf-email-default/plan.md
@@ -2,44 +2,115 @@
 
 > HOW only — see spec.md for WHAT and WHY.
 
+Tracking issue: [#52](https://github.com/beeeku/workkit/issues/52)
+
 ## Architecture
 
-What is the technical approach? How does it fit into existing architecture?
-Where are the integration points with existing code?
+**Pattern**: Provider-pluggable adapter, mirroring `WaProvider` (`packages/notify/src/adapters/whatsapp/provider.ts:65`).
 
-- Pattern: [NEEDS CLARIFICATION]
-- Integration points: [NEEDS CLARIFICATION]
+**Integration points**:
+- `@workkit/notify/email` gains a `provider.ts` module + two provider factories.
+- `@workkit/notify/email/adapter.ts` — refactored to accept `{ provider }` instead of `{ apiKey, from, ... }`. Delegates `send` / `parseWebhook` / `verifySignature` through to the provider.
+- `@workkit/mail` is imported only inside `cloudflareEmailProvider` — scoped so tree-shaking keeps it out for Resend-only users.
+- `@workkit/testing` gains two new mock factories; `@workkit/mail` tests migrate to consume them.
+
+**Dependency direction**: `notify → mail → (cf types)`. One-way. No reverse edges introduced.
 
 ## Key Technical Decisions
 
-What libraries, patterns, or approaches? WHY these and not alternatives?
+See spec.md §Design Decisions for rationale. Summary:
 
-- [NEEDS CLARIFICATION]
+| Decision | Choice |
+|---|---|
+| Where does the provider interface live? | `@workkit/notify` (D1) |
+| Default provider | Cloudflare (D2) |
+| API break on `emailAdapter` | Hard break (D3) |
+| `@workkit/mail` dependency shape | Optional peerDependency (D4) |
+| Mock promotion | In this ticket (D5) |
+| CF provider error handling | Catch + convert, never throw (D6) |
+| Webhook error message | Templated by provider (D7) |
 
 ## Files
 
 | File | Purpose | New/Modified |
 |------|---------|-------------|
-| [NEEDS CLARIFICATION] | | |
+| `packages/notify/src/adapters/email/provider.ts` | `EmailProvider` interface + shared provider types | **New** |
+| `packages/notify/src/adapters/email/providers/cloudflare.ts` | `cloudflareEmailProvider({ binding, from, replyTo? })` | **New** |
+| `packages/notify/src/adapters/email/providers/resend.ts` | `resendEmailProvider({ apiKey, from, apiUrl?, webhook? })` — logic extracted from `adapter.ts` | **New** |
+| `packages/notify/src/adapters/email/adapter.ts` | Refactor: `emailAdapter({ provider, bucket?, attachments?, autoOptOut?, markUnsubscribable? })`; delegate send/webhook/signature to provider | Modified |
+| `packages/notify/src/adapters/email/errors.ts` | `WebhookSignatureError` takes `provider` arg | Modified |
+| `packages/notify/src/adapters/email/webhook.ts` | Update signature-verification call site to pass `provider` to `WebhookSignatureError` | Modified |
+| `packages/notify/src/adapters/email/index.ts` | Export `EmailProvider`, `cloudflareEmailProvider`, `resendEmailProvider` | Modified |
+| `packages/notify/package.json` | Add `@workkit/mail` to `peerDependencies` (optional); add `cloudflare-email` keyword | Modified |
+| `packages/notify/README.md` | CF as default example; Resend as alternative | Modified |
+| `packages/testing/src/email.ts` | `createMockSendEmail` + `createMockForwardableEmail` | **New** |
+| `packages/testing/src/index.ts` | Export the two new mocks | Modified |
+| `packages/mail/tests/helpers/mock-email.ts` | **Delete** — migrated to testing | Removed |
+| `packages/mail/tests/sender.test.ts` | Update import: `@workkit/testing` | Modified |
+| `packages/notify/tests/adapters/email/adapter.test.ts` | Rewrite setup to use `{ provider }`; split into provider-agnostic + Resend-specific + CF-specific | Modified |
+| `packages/notify/tests/adapters/email/provider.test.ts` | Contract suite — both providers pass | **New** |
+| `packages/notify/tests/adapters/email/providers/cloudflare.test.ts` | CF provider unit tests (delegates to mail, error conversion) | **New** |
+| `packages/notify/tests/adapters/email/providers/resend.test.ts` | Resend provider unit tests (lifted from current adapter.test) | **New** |
+| `.changeset/cf-email-default.md` | Minor bump for notify + testing; patch for mail | **New** |
 
 ## Tasks
 
-TDD: every implementation task must have a preceding test task.
+TDD — every implementation task has a preceding test task. Detailed sequencing in tasks.md.
 
-- [ ] [NEEDS CLARIFICATION] Break down into small, testable tasks.
+High-level phases:
+
+1. **Testing package mocks** (lowest blast radius, unblocks mail + notify tests).
+2. **Mail test migration** (proves the mock promotion end-to-end).
+3. **Provider interface + Resend provider extraction** (no behavior change — pure refactor with regression tests).
+4. **Cloudflare provider** (new surface, depends on mail + testing).
+5. **Adapter refactor** (breaking API change, depends on both providers).
+6. **Error message templating** (small, last).
+7. **Docs + changeset** (tail).
 
 ## Failure Modes
 
-What can go wrong? How do we handle it gracefully?
-
-- [NEEDS CLARIFICATION]
+| Failure | How we handle it |
+|---|---|
+| User forgets `@workkit/mail` peerDep when importing `cloudflareEmailProvider` | Runtime import error — standard peerDep UX. Document in the CF provider JSDoc + README. |
+| `binding.send` throws (mail's `DeliveryError`) | CF provider catches, returns `{status: "failed", error: err.message}`. |
+| Invalid `from` address reaches CF provider | Mail throws `InvalidAddressError` → CF provider catches → returns `{status: "failed", error}`. |
+| User passes `emailAdapter({})` without a `provider` | Constructor throws `ConfigError` at import time (fail fast). |
+| User migrating from `{ apiKey, from }` hits runtime TypeError | Changelog has the 1-line diff; error message on the old-shape call points them at the migration note. |
+| Resend webhook signature fails with the templated message | Error message includes provider name so users grep-find correctly. |
+| Build pipeline can't resolve `@workkit/mail` | Workspace declaration `workspace:*` handles local; published notify resolves via the optional peer. |
 
 ## Testing Strategy
 
-Unit tests, integration tests, or both? What mocks are needed?
+**Unit tests** for each provider — both pass a shared contract suite.
 
-- [NEEDS CLARIFICATION]
+**Contract suite** (runs against both providers):
+- `provider.name` is defined.
+- `send({ from, to, subject, html, text })` returns `AdapterSendResult`.
+- Provider never throws from `send`.
+- Optional `parseWebhook` / `verifySignature` either both present or both absent.
 
+**Cloudflare-specific**:
+- `send` invokes `@workkit/mail`'s `mail()` exactly once with the composed args.
+- Catches `DeliveryError` → returns `{status: "failed", ...}`.
+- Catches `InvalidAddressError` → returns `{status: "failed", ...}`.
+- `parseWebhook` / `verifySignature` are `undefined`.
+
+**Resend-specific regression**:
+- Existing `adapter.test.ts` + `webhook.test.ts` pass without behavior modifications (only setup changes to use `resendEmailProvider`).
+
+**`@workkit/testing`**:
+- `createMockSendEmail` records sent payloads; provides `_sent` inspection.
+- `createMockForwardableEmail` constructs a valid MIME ReadableStream consumable by mail's parser.
+
+**Integration**:
+- `emailAdapter({ provider })` end-to-end with each provider via dispatch pipeline.
+- `emailAdapter({})` throws at construction.
+
+**Constitution gate**:
+- `bun run constitution:check -- --diff-only` passes.
+- Changeset present; `console.log`-free; single index per package.
+
+Mocks needed: `createMockSendEmail` (from testing), `fetch` mock for Resend (existing), `D1` mock (existing for dispatch).
 
 ## Wiki Context
 

--- a/.maina/features/009-cf-email-default/spec-tests.ts
+++ b/.maina/features/009-cf-email-default/spec-tests.ts
@@ -1,0 +1,4 @@
+import { describe, expect, it } from "bun:test";
+
+describe("Feature: cf-email-default", () => {
+});

--- a/.maina/features/009-cf-email-default/spec-tests.ts
+++ b/.maina/features/009-cf-email-default/spec-tests.ts
@@ -1,4 +1,0 @@
-import { describe, expect, it } from "bun:test";
-
-describe("Feature: cf-email-default", () => {
-});

--- a/.maina/features/009-cf-email-default/spec.md
+++ b/.maina/features/009-cf-email-default/spec.md
@@ -1,0 +1,45 @@
+# Feature: [Name]
+
+## Problem Statement
+
+What specific problem does this solve? Who experiences it? What happens if we don't solve it?
+
+- [NEEDS CLARIFICATION] Define the problem clearly.
+
+## Target User
+
+Who benefits? What is their current workflow? What frustrates them about it?
+
+- Primary: [NEEDS CLARIFICATION]
+- Secondary: [NEEDS CLARIFICATION]
+
+## User Stories
+
+- As a [role], I want [capability] so that [benefit].
+
+## Success Criteria
+
+How do we know this works? Every criterion must be testable — if you can't write
+an assertion for it, the requirement isn't clear enough.
+
+- [ ] [NEEDS CLARIFICATION] Define measurable, testable criteria.
+
+## Scope
+
+### In Scope
+
+- [NEEDS CLARIFICATION] What this feature does.
+
+### Out of Scope
+
+- [NEEDS CLARIFICATION] What this feature explicitly does NOT do (prevents over-building).
+
+## Design Decisions
+
+Key choices made and WHY. Record tradeoffs — future you will thank you.
+
+- [NEEDS CLARIFICATION] What alternatives were considered? Why was this one chosen?
+
+## Open Questions
+
+- [NEEDS CLARIFICATION] List ambiguities. Every question here must be resolved before implementation.

--- a/.maina/features/009-cf-email-default/spec.md
+++ b/.maina/features/009-cf-email-default/spec.md
@@ -1,45 +1,126 @@
-# Feature: [Name]
+# Feature: Cloudflare send_email as default email transport
+
+Tracking issue: [#52](https://github.com/beeeku/workkit/issues/52)
 
 ## Problem Statement
 
-What specific problem does this solve? Who experiences it? What happens if we don't solve it?
+`@workkit/notify`'s email adapter is hardcoded to Resend — `packages/notify/src/adapters/email/adapter.ts` POSTs to `api.resend.com/emails` via `fetch`. This forces every workkit user to sign up for an external service, manage a `RESEND_API_KEY` secret, and take on a runtime HTTP dependency, even though Cloudflare now ships a native `send_email` binding (transactional email beta) that covers the transactional-email path with zero config.
 
-- [NEEDS CLARIFICATION] Define the problem clearly.
+The email adapter also stands out as the only notify adapter that **isn't** provider-pluggable. WhatsApp already ships `metaWaProvider` / `twilioWaProvider` / `gupshupWaProvider` behind a `WaProvider` interface (`packages/notify/src/adapters/whatsapp/provider.ts:65`). Email should match that shape.
+
+Who experiences the gap: anyone deploying workkit on Cloudflare for transactional email — their default path today is "pick a third-party provider," not "use the platform primitive."
+
+If we don't solve this: workkit stays mis-positioned against its own thesis ("Worker-native toolkit"), and each new email provider added later (SES, Postmark) requires re-inventing the adapter.
 
 ## Target User
 
-Who benefits? What is their current workflow? What frustrates them about it?
-
-- Primary: [NEEDS CLARIFICATION]
-- Secondary: [NEEDS CLARIFICATION]
+- **Primary**: workkit consumers building notification flows on Cloudflare Workers who want zero-config transactional email.
+- **Secondary**: contributors adding new email providers (SES, Postmark, Mailgun) — they get a stable interface instead of forking the adapter.
 
 ## User Stories
 
-- As a [role], I want [capability] so that [benefit].
+- As a workkit user, I want the email adapter to work with just the `[[send_email]]` binding so that I don't need a third-party account to send transactional mail.
+- As a workkit user on Resend, I want a one-line migration so that bumping to the new adapter doesn't force me off Resend.
+- As a contributor, I want the email adapter to match the WhatsApp provider shape so that adding SES / Postmark is a single-file addition.
+- As a test author, I want `createMockSendEmail` exported from `@workkit/testing` so that I don't reach into another package's private test helpers.
 
 ## Success Criteria
 
-How do we know this works? Every criterion must be testable — if you can't write
-an assertion for it, the requirement isn't clear enough.
+Every item is testable.
 
-- [ ] [NEEDS CLARIFICATION] Define measurable, testable criteria.
+- [ ] `emailAdapter({ provider: cloudflareEmailProvider({ binding, from }) })` sends via `@workkit/mail`'s `mail()` with no additional setup.
+- [ ] `emailAdapter({ provider: resendEmailProvider({ apiKey, from }) })` preserves 100% of current Resend adapter behavior (regression suite unchanged).
+- [ ] Calling `emailAdapter({ provider })` without a `provider` arg throws at construction.
+- [ ] `EmailProvider` conforms structurally to the same shape as `WaProvider` minus `handleVerificationChallenge`.
+- [ ] `@workkit/testing` exports `createMockSendEmail` and `createMockForwardableEmail`.
+- [ ] `@workkit/mail`'s private `tests/helpers/mock-email.ts` is removed; mail tests import from testing.
+- [ ] `WebhookSignatureError` message is templated by provider name; no literal `"Resend"` in the error path once a non-Resend provider exists.
+- [ ] CF provider's `send` catches `DeliveryError` / `InvalidAddressError` from `@workkit/mail` and returns `{status: "failed", error}` — never throws.
+- [ ] `@workkit/mail` is an optional peerDependency of `@workkit/notify` — installing notify without `@workkit/mail` succeeds and only fails when a user imports `cloudflareEmailProvider`.
+- [ ] `bun run constitution:check -- --diff-only` passes.
+- [ ] Changesets present for `@workkit/notify` (minor), `@workkit/testing` (minor), `@workkit/mail` (patch).
 
 ## Scope
 
 ### In Scope
 
-- [NEEDS CLARIFICATION] What this feature does.
+- `EmailProvider` interface in `@workkit/notify/email`.
+- `cloudflareEmailProvider` (default) + `resendEmailProvider` (existing logic extracted).
+- `emailAdapter({ provider, ... })` — hard break on `{ apiKey, from }`.
+- `@workkit/mail` as optional peerDependency on notify.
+- `WebhookSignatureError` message templated by provider.
+- `createMockSendEmail` / `createMockForwardableEmail` promoted to `@workkit/testing`.
+- `@workkit/mail` tests refactored to consume from testing.
+- Docs: notify/email README updated; CF as default example; Resend as alternative.
+- Changesets for all three packages.
 
-### Out of Scope
+### Out of Scope (follow-up issues already filed)
 
-- [NEEDS CLARIFICATION] What this feature explicitly does NOT do (prevents over-building).
+- DSN bounce synthesis on Cloudflare transport — **#53** (`parseBounceDSN`) + **#54** (`createBounceRoute`).
+- Preserving retry strategy through `AdapterSendResult` — **#55**.
+- Docs positioning pass (mail vs notify) — **#56**.
+- SES / Postmark provider stubs — **#57**.
+- Complaint feedback-loop (FBL) handling on any provider.
+- Idempotency keys on send (CF MTA handles retry internally).
 
 ## Design Decisions
 
-Key choices made and WHY. Record tradeoffs — future you will thank you.
+### D1. Provider abstraction lives in `@workkit/notify`, not `@workkit/mail`
 
-- [NEEDS CLARIFICATION] What alternatives were considered? Why was this one chosen?
+**Decision**: The `EmailProvider` interface lives in notify. `@workkit/mail` stays focused on CF primitives.
+
+**Alternatives considered**:
+- *Transport interface in `@workkit/mail`* — rejected. Creates bidirectional coupling: mail would own the "how to ship bytes" abstraction, but notify owns the webhook/event shape. Two owners of one interface.
+- *Transport interface in a new `@workkit/transport` package* — rejected. Premature; only one consumer (notify's email adapter) needs it.
+
+**Why**: Providers differ on exactly the axes notify cares about (signatures, webhooks, bounce events). Mail stays the thin CF primitive.
+
+### D2. Cloudflare is the default, Resend is the first-class alternative
+
+**Decision**: All docs/examples use `cloudflareEmailProvider` by default.
+
+**Alternatives**: keep Resend as default. Rejected — contradicts workkit's Worker-native positioning.
+
+**Tradeoff**: CF binding has no delivery webhooks → `autoOptOut` is a documented no-op on CF. Accepted for v1; follow-up **#54** closes the gap via inbound DSN routing.
+
+### D3. Hard break on `emailAdapter({ apiKey, from })` shape
+
+**Decision**: Pre-1.0 break. Migration is a 1-line diff.
+
+**Alternatives**:
+- *Soft overload* (accept both shapes) — rejected. Backwards-compat shims violate project convention; notify is pre-1.0 and can break cleanly.
+- *Deprecation + soft removal* — rejected. Same reasoning; users get one hop, not two.
+
+### D4. `@workkit/mail` as optional peerDependency, not hard dependency
+
+**Decision**: Follow the `@react-email/render` precedent. Users who don't use `cloudflareEmailProvider` don't pay.
+
+**Why**: Constitution Rule 1 (zero runtime overhead). Adding a mandatory dep for a feature you might not use compounds badly across consumers.
+
+### D5. `createMockSendEmail` promoted to `@workkit/testing`
+
+**Decision**: Move the private helper to testing as a first-class export.
+
+**Why**: Constitution Rule 3 (every package wires `@workkit/testing`). Without this, every consumer writing email tests either reaches into mail's private helpers or reinvents the mock. Pattern already exists for KV / D1 / R2 / Queue / DO.
+
+### D6. CF provider never throws; catches mail errors and converts
+
+**Decision**: CF provider's `send` returns `AdapterSendResult` and never throws — matches Resend provider's existing contract.
+
+**Why**: Uniform provider surface. The `AdapterSendResult.error` losing retry metadata is a pre-existing gap; tracked separately in **#55**, not fixed in this ticket (would balloon scope).
+
+### D7. `WebhookSignatureError` takes a provider arg
+
+**Decision**: Constructor takes `provider: "resend" | "cloudflare"`; message templated.
+
+**Why**: Today's message literally says `"Resend webhook signature verification failed"` (`errors.ts:21`). Becomes wrong the moment a non-Resend provider exists.
 
 ## Open Questions
 
-- [NEEDS CLARIFICATION] List ambiguities. Every question here must be resolved before implementation.
+All resolved during brainstorming. None blocking implementation.
+
+- ~~Should the CF provider synthesize bounce webhooks from inbound DSN parsing?~~ No — split to **#53** + **#54**. Keeps v1 zero-config.
+- ~~Hard break or soft overload on `emailAdapter` shape?~~ Hard break (D3).
+- ~~Where does provider abstraction live?~~ In notify (D1).
+- ~~Hard dep or optional peer for `@workkit/mail`?~~ Optional peer (D4).
+- ~~Promote test mocks in this ticket or a prerequisite?~~ This ticket (user confirmed).

--- a/.maina/features/009-cf-email-default/tasks.md
+++ b/.maina/features/009-cf-email-default/tasks.md
@@ -1,0 +1,23 @@
+# Task Breakdown
+
+## Tasks
+
+Each task should be completable in one commit. Test tasks precede implementation tasks.
+
+- [ ] [NEEDS CLARIFICATION] Define tasks.
+
+## Dependencies
+
+Which tasks block which? Draw the critical path.
+
+- [NEEDS CLARIFICATION]
+
+## Definition of Done
+
+How do we know this feature is complete?
+
+- [ ] All tests pass
+- [ ] Biome lint clean
+- [ ] TypeScript compiles
+- [ ] maina analyze shows no errors
+- [ ] [NEEDS CLARIFICATION] Feature-specific criteria

--- a/.maina/features/009-cf-email-default/tasks.md
+++ b/.maina/features/009-cf-email-default/tasks.md
@@ -1,23 +1,94 @@
 # Task Breakdown
 
+Tracking issue: [#52](https://github.com/beeeku/workkit/issues/52)
+
+Each task is completable in one commit. Test tasks precede implementation tasks (TDD).
+
 ## Tasks
 
-Each task should be completable in one commit. Test tasks precede implementation tasks.
+### Phase 1 — Testing package mocks (unblocks mail + notify tests)
 
-- [ ] [NEEDS CLARIFICATION] Define tasks.
+- [ ] **T1.1 (test)** — `packages/testing/tests/email.test.ts`: smoke tests for `createMockSendEmail` (records `_sent`) and `createMockForwardableEmail` (produces valid MIME stream).
+- [ ] **T1.2 (impl)** — `packages/testing/src/email.ts`: port `createMockSendEmail` + `createMockForwardableEmail` from `packages/mail/tests/helpers/mock-email.ts` verbatim. Export from `packages/testing/src/index.ts`.
+
+### Phase 2 — Mail test migration
+
+- [ ] **T2.1 (refactor)** — `packages/mail/tests/sender.test.ts`: replace imports from the private helper with imports from `@workkit/testing`. Tests still pass.
+- [ ] **T2.2 (cleanup)** — Delete `packages/mail/tests/helpers/mock-email.ts`.
+- [ ] **T2.3 (devdep)** — Confirm `@workkit/mail`'s `devDependencies` has `@workkit/testing` (constitution Rule 3). Add if missing.
+
+### Phase 3 — Provider interface + Resend extraction
+
+- [ ] **T3.1 (test)** — `packages/notify/tests/adapters/email/provider.test.ts`: write the contract suite against a dummy provider (no impl yet — establishes the interface shape).
+- [ ] **T3.2 (impl)** — `packages/notify/src/adapters/email/provider.ts`: define `EmailProvider` interface + shared types (`EmailProviderSendArgs` derived from current `ResendSendBody`-equivalent).
+- [ ] **T3.3 (test)** — `packages/notify/tests/adapters/email/providers/resend.test.ts`: lift relevant cases from current `adapter.test.ts` — `send` happy path, `send` error paths, `parseWebhook`, `verifySignature`, auto-opt-out.
+- [ ] **T3.4 (impl)** — `packages/notify/src/adapters/email/providers/resend.ts`: extract existing Resend logic (from `adapter.ts`) behind `resendEmailProvider({ apiKey, from, apiUrl?, webhook? })`. `name: "resend"`. Passes the contract suite.
+- [ ] **T3.5 (lint)** — No Resend-specific code remains in `adapter.ts` after this phase.
+
+### Phase 4 — Cloudflare provider
+
+- [ ] **T4.1 (test)** — `packages/notify/tests/adapters/email/providers/cloudflare.test.ts`: test that `send` invokes `@workkit/mail`'s `mail()` once with composed args; catches `DeliveryError` → `{status: "failed"}`; catches `InvalidAddressError` → `{status: "failed"}`; `parseWebhook` + `verifySignature` are `undefined`; contract suite passes.
+- [ ] **T4.2 (impl)** — `packages/notify/src/adapters/email/providers/cloudflare.ts`: `cloudflareEmailProvider({ binding, from, replyTo? })` — delegates to `mail(binding)` and converts mail's errors. `name: "cloudflare"`.
+- [ ] **T4.3 (peerdep)** — `packages/notify/package.json`: add `@workkit/mail` to `peerDependencies` with `peerDependenciesMeta.optional: true`.
+
+### Phase 5 — Adapter refactor
+
+- [ ] **T5.1 (test)** — Rewrite `packages/notify/tests/adapters/email/adapter.test.ts` around `emailAdapter({ provider })`. Tests: missing `provider` throws; adapter delegates `send` to provider; adapter delegates `parseWebhook` / `verifySignature` to provider when defined; attachments flow unchanged; `markUnsubscribable` header logic unchanged.
+- [ ] **T5.2 (impl)** — Refactor `packages/notify/src/adapters/email/adapter.ts`: new `EmailAdapterOptions` shape `{ provider, bucket?, attachments?, autoOptOut?, markUnsubscribable? }`. Delegate lifecycle methods to provider. Keep attachment loading + `markUnsubscribable` header assembly in the adapter (cross-cutting, not provider-specific).
+- [ ] **T5.3 (export)** — `packages/notify/src/adapters/email/index.ts`: export `EmailProvider`, `cloudflareEmailProvider`, `resendEmailProvider`. Remove exports that relied on old shape.
+
+### Phase 6 — Error message templating
+
+- [ ] **T6.1 (test)** — `packages/notify/tests/adapters/email/errors.test.ts`: `WebhookSignatureError` message includes the provider name for both providers.
+- [ ] **T6.2 (impl)** — `packages/notify/src/adapters/email/errors.ts`: `WebhookSignatureError` constructor takes `provider: "resend" | "cloudflare"`.
+- [ ] **T6.3 (callsite)** — `packages/notify/src/adapters/email/webhook.ts` (and any other Resend-specific call sites): pass `"resend"` to the error.
+
+### Phase 7 — Docs + changeset
+
+- [ ] **T7.1 (docs)** — `packages/notify/README.md`: CF provider as default example; Resend as alternative. Migration snippet at top of "Email adapter" section.
+- [ ] **T7.2 (changeset)** — `.changeset/cf-email-default.md`: minor bump for `@workkit/notify` + `@workkit/testing`; patch for `@workkit/mail`. Include the 1-line migration diff in the body.
+- [ ] **T7.3 (keywords)** — Add `"cloudflare-email"` to `packages/notify/package.json` keywords.
+
+### Phase 8 — Verification gate
+
+- [ ] **T8.1** — `bun run constitution:check -- --diff-only` passes.
+- [ ] **T8.2** — `turbo test` passes across all touched packages.
+- [ ] **T8.3** — `turbo typecheck` passes.
+- [ ] **T8.4** — `biome check .` passes.
+- [ ] **T8.5** — `maina verify` → `maina slop` → `maina review` — all green.
 
 ## Dependencies
 
-Which tasks block which? Draw the critical path.
+Critical path:
 
-- [NEEDS CLARIFICATION]
+```
+T1.1 → T1.2 ─┬─► T2.1 → T2.2 → T2.3
+             └─► T4.1
+
+T3.1 → T3.2 ─┬─► T3.3 → T3.4 → T3.5
+             │
+             └─► T4.1 → T4.2 → T4.3 ──┐
+                                      ├─► T5.1 → T5.2 → T5.3 → T6.1 → T6.2 → T6.3 → T7.* → T8.*
+                                      │
+                             T3.5 ────┘
+```
+
+In words:
+- Testing mocks (Phase 1) unblock both mail migration (Phase 2) and CF provider tests (Phase 4).
+- Provider interface (Phase 3) must land before the two provider impls.
+- Both providers must exist before the adapter refactor (Phase 5) — so the adapter can exercise them.
+- Error templating (Phase 6) follows the adapter refactor because it changes a call-site touched by Phase 5.
+- Docs + changeset (Phase 7) come last.
+- Phase 8 is the verification gate — nothing merges without it.
 
 ## Definition of Done
 
-How do we know this feature is complete?
-
-- [ ] All tests pass
-- [ ] Biome lint clean
-- [ ] TypeScript compiles
-- [ ] maina analyze shows no errors
-- [ ] [NEEDS CLARIFICATION] Feature-specific criteria
+- [ ] All acceptance criteria from spec.md §Success Criteria met.
+- [ ] All tests pass (`turbo test`).
+- [ ] Biome clean (`biome check .`).
+- [ ] TypeScript compiles (`turbo typecheck`).
+- [ ] Constitution check passes (`bun run constitution:check -- --diff-only`).
+- [ ] `maina verify` / `maina slop` / `maina review` green.
+- [ ] Changesets present: notify (minor), testing (minor), mail (patch).
+- [ ] PR links to #52 and references #53 / #54 / #55 / #56 / #57 as follow-ups.
+- [ ] CodeRabbit + Copilot review feedback addressed.

--- a/adr/0002-email-provider-interface-and-cloudflare-send-email-as-default.md
+++ b/adr/0002-email-provider-interface-and-cloudflare-send-email-as-default.md
@@ -1,0 +1,318 @@
+# 0002. EmailProvider interface and Cloudflare send_email as default
+
+Date: 2026-04-18
+
+Tracking issue: [#52](https://github.com/beeeku/workkit/issues/52)
+Feature: `.maina/features/009-cf-email-default/`
+
+## Status
+
+Proposed
+
+## Context
+
+`@workkit/notify`'s email adapter (`packages/notify/src/adapters/email/adapter.ts`) is hardcoded to Resend — it POSTs to `api.resend.com/emails` via `fetch` and bakes Resend's webhook format (Svix signatures) into its validation path. The adapter is the only notify channel that is **not** provider-pluggable; whatsapp already ships `metaWaProvider` / `twilioWaProvider` / `gupshupWaProvider` behind a `WaProvider` interface (`packages/notify/src/adapters/whatsapp/provider.ts:65`).
+
+Meanwhile, Cloudflare has released transactional email (beta) via the `send_email` binding. `@workkit/mail` already wraps this binding and exposes a typed `mail(binding).send(...)` API. But `@workkit/notify` — the layer users actually reach for in multi-channel flows — ignores the platform primitive in favor of an external HTTP provider.
+
+Two things push us to act now:
+
+1. **Positioning drift.** workkit is marketed as a Worker-native toolkit; the default email path should be the platform primitive, not a third-party service.
+2. **Architectural inconsistency.** Adding a second email provider (even a native one) today would require forking the adapter. Whatsapp solved this with a provider interface; email should match.
+
+This ADR records the design decisions for introducing that interface and making Cloudflare the default.
+
+## Decision
+
+Introduce `EmailProvider` in `@workkit/notify/email`, mirroring `WaProvider`. Ship two providers — `cloudflareEmailProvider` (default) and `resendEmailProvider` (existing logic extracted). Refactor `emailAdapter` to accept `{ provider, ... }` and delegate send / webhook-parse / signature-verify to the provider. Break the old `{ apiKey, from }` shape (pre-1.0). Promote the private `createMockSendEmail` / `createMockForwardableEmail` helpers to `@workkit/testing` so all downstream test code has a shared mock surface.
+
+Seven design decisions stand behind this:
+
+### D1. The provider abstraction lives in `@workkit/notify`, not `@workkit/mail`
+
+`@workkit/mail` stays a thin wrapper around CF primitives. `@workkit/notify` owns the provider interface because providers differ on exactly the axes notify cares about — webhook payload shapes, signature algorithms, bounce/complaint event taxonomies. Putting the interface in mail would create bidirectional coupling (mail owns "how to ship bytes," notify owns "how to parse events") with two owners of one concept.
+
+**Rejected alternatives**:
+- *Transport interface in `@workkit/mail`*: see above — wrong ownership.
+- *New `@workkit/transport` package*: premature; only one consumer (notify/email).
+
+### D2. Cloudflare is the default; Resend is the first-class alternative
+
+All docs, README examples, and quick-starts default to `cloudflareEmailProvider`. Resend moves to an "Alternative providers" section. This aligns workkit with its own positioning: zero-config on the platform, opt-in for advanced analytics / inbox placement.
+
+**Tradeoff**: CF `send_email` has no delivery webhooks. `autoOptOut` (bounce + complaint → opt-out) is a Resend-only feature for v1. Follow-up #54 closes the gap via inbound DSN parsing (depends on #53 `parseBounceDSN`).
+
+### D3. Hard break on `emailAdapter({ apiKey, from })`
+
+`@workkit/notify` is pre-1.0 (`0.1.0`). Migration is a 1-line diff:
+
+```diff
+- emailAdapter({ apiKey: env.RESEND_API_KEY, from: "noreply@x.com" })
++ emailAdapter({ provider: resendEmailProvider({ apiKey: env.RESEND_API_KEY, from: "noreply@x.com" }) })
+```
+
+**Rejected alternatives**:
+- *Soft overload* (accept both shapes): violates project convention against backwards-compat shims.
+- *Deprecation cycle*: two hops for users instead of one, with no real payoff pre-1.0.
+
+### D4. `@workkit/mail` is an **optional** peerDependency of `@workkit/notify`
+
+Follows the existing `@react-email/render` precedent. Only users who import `cloudflareEmailProvider` pay the `@workkit/mail` install cost. Preserves Constitution Rule 1 (zero runtime overhead for uninvolved consumers).
+
+```json
+"peerDependencies": {
+  "@react-email/render": ">=1.0.0",
+  "@workkit/mail": "workspace:*"
+},
+"peerDependenciesMeta": {
+  "@react-email/render": { "optional": true },
+  "@workkit/mail": { "optional": true }
+}
+```
+
+### D5. `createMockSendEmail` + `createMockForwardableEmail` promoted to `@workkit/testing`
+
+Currently these live as private test helpers at `packages/mail/tests/helpers/mock-email.ts`. Promoting them to `@workkit/testing` satisfies Constitution Rule 3 (every package wires testing) for all downstream consumers writing email tests, and matches the `createMockKV` / `createMockD1` / `createMockR2` / `createMockQueue` pattern.
+
+### D6. The Cloudflare provider never throws; it catches mail errors and converts
+
+Mail's `mail().send()` throws `DeliveryError` (retryable) or `InvalidAddressError` (terminal). The Resend provider's existing `send` returns `{status: "failed", error: string}` and never throws. For a uniform provider contract, CF provider catches and converts:
+
+```ts
+try {
+  await mail(binding, { defaultFrom: from }).send(args);
+  return { status: "sent", providerId: ... };
+} catch (err) {
+  return { status: "failed", error: err instanceof Error ? err.message : String(err) };
+}
+```
+
+The fact that `AdapterSendResult` flattens retry metadata (`retryable`, `defaultRetryStrategy`) into a string is a **pre-existing gap across all notify adapters** (email/Resend, whatsapp, inapp). Fixing it would balloon this ticket's scope and requires its own ADR. Tracked separately in #55.
+
+### D7. `WebhookSignatureError` message is templated by provider
+
+Today's error literally says `"Resend webhook signature verification failed"` (`packages/notify/src/adapters/email/errors.ts:21`). Once a non-Resend provider exists this is wrong. Constructor takes `provider: "resend" | "cloudflare"` and templates the message. CF provider does not verify signatures (no webhooks) so this only affects the Resend call site today, but the signature is future-proofed for SES / Postmark (#57).
+
+## Consequences
+
+### Positive
+
+- **Worker-native onboarding.** New users deploy transactional email with zero external accounts — just a `[[send_email]]` binding in `wrangler.toml`.
+- **Consistency across notify channels.** Email now matches the whatsapp provider shape; contributors get one mental model instead of two.
+- **Adding providers is a one-file change.** SES / Postmark stubs (#57) become trivial; community contributions are self-contained.
+- **Test ergonomics improve everywhere.** Shared mocks in `@workkit/testing` remove per-package duplication and lower the bar for downstream consumers to write email tests.
+- **Cleaner error taxonomy.** `WebhookSignatureError` stops lying about which provider it's verifying.
+- **Zero-cost for Resend-only users.** Optional peerDep means they don't pay for `@workkit/mail`.
+
+### Negative
+
+- **Breaking API change.** Every existing `emailAdapter({ apiKey, from })` call site must migrate. The migration is mechanical (1-line diff) and documented in the changeset, but it is still a break.
+- **Feature asymmetry between providers.** CF provider's `autoOptOut` is a no-op until #53 + #54 land; Resend provider supports it fully. Users need to understand this tradeoff when choosing a default. Mitigated by explicit docs.
+- **Indirect coupling: notify optionally depends on mail.** New dependency edge in the package graph (`notify → mail`), even if optional. Documented and matches constitution Rule 5.
+- **CF provider silently swallows `DeliveryError` retry metadata.** Acknowledged in D6; tracked as #55. Users on CF see failures as `{status: "failed", error: string}` and must rely on queue-level retry policy, not the mail error's own `defaultRetryStrategy`.
+
+### Neutral
+
+- **Test files reshuffle.** Existing `adapter.test.ts` splits into a provider-agnostic contract suite + per-provider suites. Same coverage, different file layout.
+- **Docs rewrite for notify/email README.** Aesthetic only; no new user-facing concepts beyond "choose a provider."
+- **`@workkit/mail` loses its private test helper.** Replaced by import from `@workkit/testing`; zero behavioral change.
+
+## High-Level Design
+
+### System Overview
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ User code                                                │
+│   emailAdapter({ provider: cloudflareEmailProvider(...)})│
+└────────────────────┬────────────────────────────────────┘
+                     │
+                     ▼
+┌─────────────────────────────────────────────────────────┐
+│ @workkit/notify/email/adapter.ts                         │
+│   - Cross-cutting: attachments, markUnsubscribable,      │
+│     autoOptOut wiring, delivery record integration       │
+│   - Delegates: send / parseWebhook / verifySignature     │
+└────────┬───────────────────────────┬────────────────────┘
+         │                           │
+         ▼                           ▼
+┌─────────────────┐      ┌─────────────────────────────┐
+│ cloudflare.ts   │      │ resend.ts                    │
+│ - delegates to  │      │ - fetch → api.resend.com     │
+│   @workkit/mail │      │ - Svix signature verify      │
+│ - catches mail  │      │ - bounce/complaint webhook   │
+│   errors        │      │   parsing                    │
+└────────┬────────┘      └──────────────────────────────┘
+         │
+         ▼
+┌─────────────────────────────────┐
+│ @workkit/mail                   │
+│   mail(binding).send(msg)       │
+│   → CF SendEmail binding        │
+└─────────────────────────────────┘
+```
+
+### Component Boundaries
+
+- **`@workkit/notify/email/adapter.ts`** — owns cross-cutting concerns (attachments from R2, `markUnsubscribable` header assembly, auto-opt-out invocation on webhook events). Doesn't know about providers beyond the `EmailProvider` shape.
+- **`@workkit/notify/email/providers/*.ts`** — each file owns one provider's wire format, signature algorithm, and webhook parsing. No shared state between providers.
+- **`@workkit/notify/email/provider.ts`** — pure type definitions.
+- **`@workkit/mail`** — CF primitives (MIME composition, address validation, binding invocation). Unchanged by this ADR except for the test helper migration.
+- **`@workkit/testing`** — shared mock surface. Adds two new mocks; no changes to existing mocks.
+
+### Data Flow
+
+**Send path**:
+1. User calls `notify.send(...)` (or direct `dispatch(...)`).
+2. Dispatch pipeline resolves user, checks prefs/opt-out/quiet-hours, looks up the email template.
+3. Pipeline calls `adapter.send(args)`.
+4. Adapter: loads attachments from R2 if template requires them; assembles `markUnsubscribable` headers if notification id matches.
+5. Adapter calls `provider.send(args)`.
+6. Provider (CF): delegates to `mail(binding).send({ from, to, subject, html, text, attachments, headers })`. Catches `DeliveryError` / `InvalidAddressError`, returns `AdapterSendResult`.
+7. Provider (Resend): POSTs to `api.resend.com/emails` with structured body. Returns `AdapterSendResult`.
+8. Adapter writes delivery record (idempotency key, status, providerId).
+
+**Webhook path** (Resend only in v1):
+1. User's webhook route calls `webhookHandler({ channel: "email", ... })`.
+2. Handler calls `adapter.verifySignature?(req, secret)` → delegates to `provider.verifySignature(...)`.
+3. Handler calls `adapter.parseWebhook?(req)` → delegates to `provider.parseWebhook(...)`.
+4. Handler updates delivery records idempotently; fires `autoOptOut` hook on hard-bounce / complaint.
+5. CF provider: both methods undefined → webhook handler returns 501 / no-op for that channel (user shouldn't be wiring this for CF transport).
+
+### External Dependencies
+
+- `@workkit/mail` — optional peer, required only for CF provider path.
+- `@workkit/errors` — existing hard dep, unchanged.
+- `@react-email/render` — existing optional peer, unchanged.
+- Cloudflare `SendEmail` / `ForwardableEmailMessage` types — platform types, already in mail's surface.
+
+## Low-Level Design
+
+### Interfaces & Types
+
+```ts
+// packages/notify/src/adapters/email/provider.ts
+import type { AdapterSendResult, WebhookEvent } from "../../types";
+
+export interface EmailProviderSendArgs {
+  readonly to: string;
+  readonly subject: string;
+  readonly html: string;
+  readonly text: string;
+  readonly attachments?: readonly EmailAttachmentWire[];
+  readonly headers?: Readonly<Record<string, string>>;
+  readonly replyTo?: string | readonly string[];
+  readonly notificationId: string;
+  readonly deliveryId: string;
+}
+
+export interface EmailAttachmentWire {
+  readonly filename: string;
+  readonly content: Uint8Array;
+  readonly contentType: string;
+}
+
+export interface EmailProvider {
+  readonly name: "cloudflare" | "resend";
+  send(args: EmailProviderSendArgs): Promise<AdapterSendResult>;
+  parseWebhook?(req: Request): Promise<WebhookEvent[]>;
+  verifySignature?(req: Request, secret: string): Promise<boolean>;
+}
+```
+
+### Function Signatures
+
+```ts
+// packages/notify/src/adapters/email/providers/cloudflare.ts
+export interface CloudflareEmailProviderOptions {
+  readonly binding: SendEmail;
+  readonly from: string;
+  readonly replyTo?: string | readonly string[];
+}
+export function cloudflareEmailProvider(opts: CloudflareEmailProviderOptions): EmailProvider;
+
+// packages/notify/src/adapters/email/providers/resend.ts
+export interface ResendEmailProviderOptions {
+  readonly apiKey: string;
+  readonly from: string;
+  readonly apiUrl?: string;
+  readonly webhook?: { maxAgeMs?: number };
+}
+export function resendEmailProvider(opts: ResendEmailProviderOptions): EmailProvider;
+
+// packages/notify/src/adapters/email/adapter.ts
+export interface EmailAdapterOptions {
+  readonly provider: EmailProvider;
+  readonly bucket?: R2BucketLike;
+  readonly attachments?: AttachmentLoadOptions;
+  readonly autoOptOut?: { enabled?: boolean; hook: EmailOptOutHook };
+  readonly markUnsubscribable?: ReadonlyArray<string>;
+}
+export function emailAdapter(opts: EmailAdapterOptions): Adapter<EmailPayload>;
+
+// packages/testing/src/email.ts (promoted)
+export function createMockSendEmail(): MockSendEmail;
+export function createMockForwardableEmail(opts?: MockEmailOptions): MockForwardableEmail;
+```
+
+### DB Schema Changes
+
+None. Delivery record schema unchanged.
+
+### Sequence of Operations
+
+```
+User                Adapter              Provider(CF)         mail()          Binding
+  │                    │                      │                  │                │
+  │ adapter.send(args) │                      │                  │                │
+  ├───────────────────▶│                      │                  │                │
+  │                    │ loadAttachments(R2)  │                  │                │
+  │                    │◀────────bytes────────┤                  │                │
+  │                    │                      │                  │                │
+  │                    │ provider.send(args)  │                  │                │
+  │                    ├─────────────────────▶│                  │                │
+  │                    │                      │ mail(binding).send(composed)     │
+  │                    │                      ├─────────────────▶│                │
+  │                    │                      │                  │ binding.send   │
+  │                    │                      │                  ├───────────────▶│
+  │                    │                      │                  │◀────ok─────────┤
+  │                    │                      │◀────messageId────┤                │
+  │                    │◀────{sent, id}───────┤                  │                │
+  │                    │                      │                  │                │
+  │                    │ insertDelivery(…)    │                  │                │
+  │◀──AdapterSendResult┤                      │                  │                │
+```
+
+Failure paths (CF provider catching mail errors):
+
+```
+provider.send(args)
+  ├─ try { mail(binding).send(composed) }
+  │    └─ throws DeliveryError → return { status: "failed", error: err.message }
+  │    └─ throws InvalidAddressError → return { status: "failed", error: err.message }
+  │    └─ throws unknown → return { status: "failed", error: String(err) }
+  └─ success → return { status: "sent", providerId: messageId }
+```
+
+### Error Handling
+
+| Source | Mail throws | CF provider returns | Resend provider returns |
+|---|---|---|---|
+| Invalid `from` | `InvalidAddressError` | `{status: "failed", error}` | (validated in ctor via `FromDomainError`) |
+| Invalid `to` | `InvalidAddressError` | `{status: "failed", error}` | Resend API rejects; `{status: "failed", error}` |
+| Binding rejects | `DeliveryError` (retryable) | `{status: "failed", error}` | N/A |
+| Resend 4xx/5xx | N/A | N/A | `{status: "failed", error}` |
+| Network failure | `DeliveryError` (retryable) | `{status: "failed", error}` | `{status: "failed", error}` |
+| Missing `provider` | N/A | N/A | Adapter ctor throws `ConfigError` |
+
+**Note on retry metadata**: The `AdapterSendResult.error` field is a flat string; `DeliveryError.retryable = true` does not propagate to the pipeline. This is a pre-existing gap across all notify adapters, not introduced by this ADR. Tracked in #55.
+
+### Edge Cases
+
+- **No `@workkit/mail` installed + user imports `cloudflareEmailProvider`** → standard peerDep missing-module error at import time. Documented in CF provider JSDoc.
+- **CF provider given a `SendEmail` binding that's null/undefined** → `@workkit/mail`'s `mail()` throws `BindingNotFoundError` from constructor. Wraps to `{status: "failed", error}` on first send.
+- **Resend provider called with missing `apiKey`** → `ConfigError` at provider construction (existing behavior).
+- **`emailAdapter({})` with no provider** → throws `ConfigError` at adapter construction (new behavior).
+- **Provider's `parseWebhook` / `verifySignature` missing but webhook arrives** → `webhookHandler` already guards for this (existing); returns a clear 501-style response. CF provider path.
+- **Attachment flow + CF provider** — attachments loaded by adapter from R2 as Uint8Array, passed to CF provider, which converts to mail's `MailAttachment` shape (`content: ArrayBuffer | Uint8Array | string`). No base64 encoding needed for CF (unlike Resend).
+- **`markUnsubscribable` + CF provider** — headers assembled by adapter, passed through to provider via `EmailProviderSendArgs.headers`. CF provider forwards to mail's `composeMessage({ headers })`. CF's MTA reliably ships `X-*` headers; `List-Unsubscribe*` may or may not survive (to be documented).

--- a/bun.lock
+++ b/bun.lock
@@ -341,10 +341,13 @@
         "mimetext": "^3.0.24",
         "postal-mime": "^2.4.1",
       },
+      "devDependencies": {
+        "@workkit/testing": "workspace:*",
+      },
     },
     "packages/mcp": {
       "name": "@workkit/mcp",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "dependencies": {
         "@workkit/errors": "workspace:*",
         "hono": "^4.7.10",
@@ -357,7 +360,7 @@
     },
     "packages/memory": {
       "name": "@workkit/memory",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "dependencies": {
         "@workkit/errors": "workspace:*",
       },
@@ -372,18 +375,22 @@
       "version": "0.1.0",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
-        "@workkit/errors": "^1.0.2",
+        "@workkit/errors": "^1.0.3",
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
+        "@workkit/mail": "workspace:*",
+        "@workkit/testing": "workspace:*",
         "better-sqlite3": "^12.9.0",
         "zod": "^3.23.0",
       },
       "peerDependencies": {
         "@react-email/render": ">=1.0.0",
+        "@workkit/mail": "workspace:*",
       },
       "optionalPeers": [
         "@react-email/render",
+        "@workkit/mail",
       ],
     },
     "packages/pdf": {

--- a/packages/mail/package.json
+++ b/packages/mail/package.json
@@ -38,6 +38,9 @@
     "mimetext": "^3.0.24",
     "postal-mime": "^2.4.1"
   },
+  "devDependencies": {
+    "@workkit/testing": "workspace:*"
+  },
   "keywords": [
     "cloudflare",
     "workers",

--- a/packages/mail/tests/receiver.test.ts
+++ b/packages/mail/tests/receiver.test.ts
@@ -1,6 +1,6 @@
+import { createMockForwardableEmail } from "@workkit/testing";
 import { describe, expect, it, vi } from "vitest";
 import { createEmailHandler } from "../src/receiver";
-import { createMockForwardableEmail } from "./helpers/mock-email";
 
 const ctx = { waitUntil: vi.fn(), passThroughOnException: vi.fn() } as any;
 

--- a/packages/mail/tests/router.test.ts
+++ b/packages/mail/tests/router.test.ts
@@ -1,6 +1,6 @@
+import { createMockForwardableEmail } from "@workkit/testing";
 import { describe, expect, it, vi } from "vitest";
 import { createEmailRouter } from "../src/router";
-import { createMockForwardableEmail } from "./helpers/mock-email";
 
 const ctx = { waitUntil: vi.fn(), passThroughOnException: vi.fn() } as any;
 

--- a/packages/mail/tests/sender.test.ts
+++ b/packages/mail/tests/sender.test.ts
@@ -1,8 +1,8 @@
 import { BindingNotFoundError } from "@workkit/errors";
+import { createMockSendEmail } from "@workkit/testing";
 import { beforeEach, describe, expect, it } from "vitest";
 import { DeliveryError, InvalidAddressError } from "../src/errors";
 import { mail } from "../src/sender";
-import { createMockSendEmail } from "./helpers/mock-email";
 
 describe("mail() factory", () => {
 	it("throws BindingNotFoundError for null binding", () => {

--- a/packages/notify/README.md
+++ b/packages/notify/README.md
@@ -142,33 +142,72 @@ Adapters are stateless objects. The dispatcher feeds them validated args; they r
 
 ### Email — `@workkit/notify/email`
 
+Provider-pluggable. **Cloudflare `send_email` is the default** (zero config, ships with every Worker deployment). Resend is the first-class alternative when you want delivery webhooks, hard/soft bounce tracking, and auto-opt-out.
+
+#### Default: Cloudflare `send_email` binding
+
+```toml
+# wrangler.toml
+[[send_email]]
+name = "SEND_EMAIL"
+```
+
 ```ts
-import { emailAdapter } from "@workkit/notify/email";
+import { emailAdapter, cloudflareEmailProvider } from "@workkit/notify/email";
+
+const email = emailAdapter({
+  provider: cloudflareEmailProvider({
+    binding: env.SEND_EMAIL,
+    from: "Reports <reports@entryexit.ai>",
+    replyTo: "support@entryexit.ai",                // optional
+  }),
+  bucket: env.REPORTS,                              // optional, only for attachments
+  markUnsubscribable: ["pre-market-brief"],         // attaches List-Unsubscribe headers
+});
+```
+
+- Delegates to `@workkit/mail`'s `mail()` — zero MIME duplication.
+- Requires `@workkit/mail` (optional peer dep) — `bun add @workkit/mail`.
+- No delivery webhooks on the binding → `autoOptOut` is not available on this provider; bounce synthesis from inbound DSN routing is tracked in the roadmap (#54).
+- Plain-text fallback auto-generated.
+- Attachments forwarded as raw bytes; attachment cap default 40MB; bounded R2 fetch concurrency 4.
+
+#### Alternative: Resend
+
+```ts
+import { emailAdapter, resendEmailProvider } from "@workkit/notify/email";
 import { optOut } from "@workkit/notify";
 
 const email = emailAdapter({
-  apiKey: env.RESEND_API_KEY,
-  from: "Reports <reports@entryexit.ai>",
-  bucket: env.REPORTS,                              // optional, only for attachments
-  webhook: { maxAgeMs: 5 * 60 * 1000 },
-  autoOptOut: {
-    enabled: true,
-    hook: async (emailAddress, channel, _notificationId, reason) => {
-      // Webhook payload doesn't carry your internal id — resolve it.
-      const userId = await lookupUserIdByEmail(emailAddress);
-      if (userId) await optOut(env.DB, userId, channel, null, reason);
+  provider: resendEmailProvider({
+    apiKey: env.RESEND_API_KEY,
+    from: "Reports <reports@entryexit.ai>",
+    webhook: { maxAgeMs: 5 * 60 * 1000 },
+    autoOptOut: {
+      enabled: true,
+      hook: async (emailAddress, channel, _notificationId, reason) => {
+        const userId = await lookupUserIdByEmail(emailAddress);
+        if (userId) await optOut(env.DB, userId, channel, null, reason);
+      },
     },
-  },
-  markUnsubscribable: ["pre-market-brief"],         // attaches List-Unsubscribe headers
+  }),
+  bucket: env.REPORTS,
+  markUnsubscribable: ["pre-market-brief"],
 });
 ```
 
 - Direct `fetch` to Resend (no SDK).
 - Optional `@react-email/render` for React Email components.
-- Plain-text fallback auto-generated.
 - Svix-format webhook verification (`v1,<base64>` HMAC-SHA256), 5-min replay window.
 - Hard bounce + complaint → auto opt-out (configurable, default on).
 - Attachment cap default 40MB; bounded R2 fetch concurrency 4.
+
+#### Migrating from the pre-provider shape
+
+```diff
+- emailAdapter({ apiKey: env.RESEND_API_KEY, from: "…", autoOptOut: { hook } })
++ emailAdapter({ provider: resendEmailProvider({ apiKey: env.RESEND_API_KEY, from: "…", autoOptOut: { hook } }) })
+```
 
 ### In-app — `@workkit/notify/inapp`
 

--- a/packages/notify/README.md
+++ b/packages/notify/README.md
@@ -6,7 +6,7 @@ Adapters ship as **subpath imports** in this same package — bring the runtime 
 
 | Subpath | Adapter | Optional peer |
 |---|---|---|
-| `@workkit/notify/email` | Resend HTTP API + React Email | `@react-email/render` |
+| `@workkit/notify/email` | Pluggable provider — Cloudflare `send_email` (default) or Resend HTTP API + React Email | `@workkit/mail`, `@react-email/render` |
 | `@workkit/notify/inapp` | D1-backed feed + SSE streaming | — |
 | `@workkit/notify/whatsapp` | Meta WA Cloud API (default) + Twilio/Gupshup stubs | — |
 

--- a/packages/notify/package.json
+++ b/packages/notify/package.json
@@ -57,15 +57,21 @@
 		"@workkit/errors": "^1.0.3"
 	},
 	"peerDependencies": {
-		"@react-email/render": ">=1.0.0"
+		"@react-email/render": ">=1.0.0",
+		"@workkit/mail": "workspace:*"
 	},
 	"peerDependenciesMeta": {
 		"@react-email/render": {
+			"optional": true
+		},
+		"@workkit/mail": {
 			"optional": true
 		}
 	},
 	"devDependencies": {
 		"@types/better-sqlite3": "^7.6.13",
+		"@workkit/mail": "workspace:*",
+		"@workkit/testing": "workspace:*",
 		"better-sqlite3": "^12.9.0",
 		"zod": "^3.23.0"
 	},
@@ -82,6 +88,7 @@
 		"meta",
 		"twilio",
 		"gupshup",
+		"cloudflare-email",
 		"workkit"
 	]
 }

--- a/packages/notify/src/adapters/email/adapter.ts
+++ b/packages/notify/src/adapters/email/adapter.ts
@@ -1,4 +1,4 @@
-import type { Adapter, AdapterSendArgs, AdapterSendResult, WebhookEvent } from "../../types";
+import type { Adapter, AdapterSendArgs, AdapterSendResult } from "../../types";
 import { type AttachmentLoadOptions, type AttachmentSpec, loadAttachments } from "./attachments";
 import { ProviderMissingError } from "./errors";
 import type { EmailAttachmentWire, EmailProvider } from "./provider";
@@ -86,20 +86,10 @@ export function emailAdapter(options: EmailAdapterOptions): Adapter<EmailPayload
 			});
 		},
 
-		...(provider.parseWebhook
-			? {
-					async parseWebhook(req: Request): Promise<WebhookEvent[]> {
-						return provider.parseWebhook!(req);
-					},
-				}
-			: {}),
+		...(provider.parseWebhook ? { parseWebhook: provider.parseWebhook.bind(provider) } : {}),
 
 		...(provider.verifySignature
-			? {
-					async verifySignature(req: Request, secret: string): Promise<boolean> {
-						return provider.verifySignature!(req, secret);
-					},
-				}
+			? { verifySignature: provider.verifySignature.bind(provider) }
 			: {}),
 	};
 }

--- a/packages/notify/src/adapters/email/adapter.ts
+++ b/packages/notify/src/adapters/email/adapter.ts
@@ -1,33 +1,12 @@
 import type { Adapter, AdapterSendArgs, AdapterSendResult, WebhookEvent } from "../../types";
 import { type AttachmentLoadOptions, type AttachmentSpec, loadAttachments } from "./attachments";
-import { FromDomainError } from "./errors";
+import { ProviderMissingError } from "./errors";
+import type { EmailAttachmentWire, EmailProvider } from "./provider";
 import { renderEmail } from "./render";
-import {
-	isComplaint,
-	isHardBounce,
-	parseResendEvents,
-	safeParseJson,
-	verifyResendSignature,
-} from "./webhook";
 
 export interface EmailPayload {
 	[key: string]: unknown;
 }
-
-/**
- * Auto opt-out hook — called when a webhook event indicates a hard bounce
- * or a complaint. **Always invoked with `notificationId: null`** (global
- * opt-out for the channel) because Resend's webhook payload does not carry
- * the originating notification id. The hook receives the recipient email
- * address as `userId` — your implementation must resolve it to your
- * internal id (typically via your user table).
- */
-export type EmailOptOutHook = (
-	emailAddress: string,
-	channel: "email",
-	notificationId: null,
-	reason: "hard-bounce" | "complaint",
-) => Promise<void>;
 
 interface R2BucketLike {
 	get(key: string): Promise<{
@@ -37,48 +16,26 @@ interface R2BucketLike {
 }
 
 export interface EmailAdapterOptions {
-	apiKey: string;
-	from: string;
-	replyTo?: string | string[];
-	apiUrl?: string;
+	/** Pluggable provider — `cloudflareEmailProvider` (default) or `resendEmailProvider`. */
+	provider: EmailProvider;
+	/** R2 bucket for loading attachments referenced by templates. */
 	bucket?: R2BucketLike;
 	attachments?: AttachmentLoadOptions;
-	webhook?: { maxAgeMs?: number };
-	autoOptOut?: { enabled?: boolean; hook: EmailOptOutHook };
 	/**
 	 * Notification ids that should carry an explicit unsubscribe header
 	 * (`List-Unsubscribe-Post: List-Unsubscribe=One-Click`). Resend does not
 	 * expose a public flag to disable open/click tracking, so the option
 	 * was renamed from `disableTrackingFor` to reflect what it actually
 	 * does. Callers wanting full tracking suppression should configure it
-	 * in the Resend dashboard.
+	 * in the Resend dashboard. The CF provider forwards `X-*` headers
+	 * reliably; `List-Unsubscribe*` survival depends on the MTA path.
 	 */
 	markUnsubscribable?: ReadonlyArray<string>;
 }
 
-const DEFAULT_API_URL = "https://api.resend.com/emails";
-const FROM_RE = /^(?:.+\s)?<?([^\s<>]+@[^\s<>]+)>?$/;
-
-interface ResendSendBody {
-	from: string;
-	to: string[];
-	subject: string;
-	html: string;
-	text: string;
-	reply_to?: string | string[];
-	attachments?: { filename: string; content: string; content_type: string }[];
-	headers?: Record<string, string>;
-}
-
-interface ResendSendResponse {
-	id?: string;
-	error?: { message?: string; statusCode?: number };
-}
-
 export function emailAdapter(options: EmailAdapterOptions): Adapter<EmailPayload> {
-	if (!FROM_RE.test(options.from)) throw new FromDomainError(options.from);
-	const apiUrl = options.apiUrl ?? DEFAULT_API_URL;
-	const autoOptOutEnabled = options.autoOptOut?.enabled !== false;
+	if (!options?.provider) throw new ProviderMissingError();
+	const provider = options.provider;
 
 	return {
 		async send(args: AdapterSendArgs<EmailPayload>): Promise<AdapterSendResult> {
@@ -93,7 +50,7 @@ export function emailAdapter(options: EmailAdapterOptions): Adapter<EmailPayload
 
 			const { html, text } = await renderEmail({ template: renderInput });
 
-			let attachments: ResendSendBody["attachments"] | undefined;
+			let attachments: EmailAttachmentWire[] | undefined;
 			if (tpl.attachments) {
 				const specs = tpl.attachments(args.payload);
 				if (!options.bucket) {
@@ -103,113 +60,46 @@ export function emailAdapter(options: EmailAdapterOptions): Adapter<EmailPayload
 					const blobs = await loadAttachments(options.bucket, specs, options.attachments);
 					attachments = blobs.map((b) => ({
 						filename: b.filename,
-						content: bytesToBase64(b.bytes),
-						content_type: b.contentType,
+						content: b.bytes,
+						contentType: b.contentType,
 					}));
 				} catch (err) {
 					return { status: "failed", error: err instanceof Error ? err.message : String(err) };
 				}
 			}
 
-			const body: ResendSendBody = {
-				from: options.from,
-				to: [args.address],
+			const headers: Record<string, string> = {};
+			if ((options.markUnsubscribable ?? []).includes(args.notificationId)) {
+				headers["X-Entity-Ref-ID"] = args.deliveryId;
+				headers["List-Unsubscribe-Post"] = "List-Unsubscribe=One-Click";
+			}
+
+			return provider.send({
+				to: args.address,
 				subject,
 				html,
 				text,
-				...(options.replyTo ? { reply_to: options.replyTo } : {}),
-				...(attachments && attachments.length > 0 ? { attachments } : {}),
-			};
-			if ((options.markUnsubscribable ?? []).includes(args.notificationId)) {
-				body.headers = {
-					...(body.headers ?? {}),
-					"X-Entity-Ref-ID": args.deliveryId,
-					"List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
-				};
-			}
+				...(attachments ? { attachments } : {}),
+				...(Object.keys(headers).length > 0 ? { headers } : {}),
+				notificationId: args.notificationId,
+				deliveryId: args.deliveryId,
+			});
+		},
 
-			let resp: Response;
-			try {
-				resp = await fetch(apiUrl, {
-					method: "POST",
-					headers: {
-						"content-type": "application/json",
-						authorization: `Bearer ${options.apiKey}`,
+		...(provider.parseWebhook
+			? {
+					async parseWebhook(req: Request): Promise<WebhookEvent[]> {
+						return provider.parseWebhook!(req);
 					},
-					body: JSON.stringify(body),
-				});
-			} catch (err) {
-				return { status: "failed", error: err instanceof Error ? err.message : String(err) };
-			}
-
-			let json: ResendSendResponse | null = null;
-			try {
-				json = (await resp.json()) as ResendSendResponse;
-			} catch {
-				json = null;
-			}
-			if (!resp.ok) {
-				return {
-					status: "failed",
-					error: json?.error?.message ?? `resend HTTP ${resp.status} ${resp.statusText}`,
-				};
-			}
-			if (!json?.id) {
-				return { status: "failed", error: "resend response missing id" };
-			}
-			return { status: "sent", providerId: json.id };
-		},
-
-		async parseWebhook(req: Request): Promise<WebhookEvent[]> {
-			// Read body via a clone so the secondary signature-verifier path does
-			// not consume the stream first.
-			const raw = await req.clone().text();
-			const events = parseResendEvents(raw);
-			if (autoOptOutEnabled && options.autoOptOut?.hook) {
-				const parsed = safeParseJson(raw);
-				if (parsed !== null) {
-					const arr = Array.isArray(parsed) ? parsed : [parsed];
-					for (const e of arr) await maybeAutoOptOut(e, options.autoOptOut.hook);
 				}
-			}
-			return events;
-		},
+			: {}),
 
-		async verifySignature(req: Request, secret: string): Promise<boolean> {
-			try {
-				await verifyResendSignature(req, secret, { maxAgeMs: options.webhook?.maxAgeMs });
-				return true;
-			} catch {
-				return false;
-			}
-		},
+		...(provider.verifySignature
+			? {
+					async verifySignature(req: Request, secret: string): Promise<boolean> {
+						return provider.verifySignature!(req, secret);
+					},
+				}
+			: {}),
 	};
-}
-
-async function maybeAutoOptOut(rawEvent: unknown, hook: EmailOptOutHook): Promise<void> {
-	const e = rawEvent as { data?: { to?: string[]; email_id?: string }; type?: string };
-	if (!e?.data?.to || e.data.to.length === 0) return;
-	const emailAddress = e.data.to[0]!;
-	if (isComplaint(rawEvent)) {
-		await hook(emailAddress, "email", null, "complaint");
-		return;
-	}
-	if (isHardBounce(rawEvent)) {
-		await hook(emailAddress, "email", null, "hard-bounce");
-	}
-}
-
-/**
- * Chunked Uint8Array → base64 to keep performance predictable on
- * attachment-cap-sized payloads (40 MB). The naive per-byte concatenation
- * is O(n²) in some JS engines and risks exhausting Worker CPU budgets.
- */
-function bytesToBase64(bytes: Uint8Array): string {
-	const chunkSize = 0x8000;
-	const parts: string[] = [];
-	for (let i = 0; i < bytes.length; i += chunkSize) {
-		const chunk = bytes.subarray(i, i + chunkSize);
-		parts.push(String.fromCharCode(...chunk));
-	}
-	return btoa(parts.join(""));
 }

--- a/packages/notify/src/adapters/email/errors.ts
+++ b/packages/notify/src/adapters/email/errors.ts
@@ -16,10 +16,24 @@ export class AttachmentTooLargeError extends ValidationError {
 	}
 }
 
+export type EmailProviderName = "resend" | "cloudflare";
+
 export class WebhookSignatureError extends ValidationError {
-	constructor(reason: string) {
-		super(`Resend webhook signature verification failed: ${reason}`, [
-			{ path: ["webhook"], message: reason },
+	constructor(providerOrReason: EmailProviderName | string, reason?: string) {
+		const [provider, detail] =
+			reason === undefined
+				? (["resend", providerOrReason] as const)
+				: ([providerOrReason as EmailProviderName, reason] as const);
+		super(`${provider} webhook signature verification failed: ${detail}`, [
+			{ path: ["webhook"], message: detail },
 		]);
+	}
+}
+
+export class ProviderMissingError extends ConfigError {
+	constructor() {
+		super(
+			"emailAdapter: `provider` is required — pass cloudflareEmailProvider() or resendEmailProvider()",
+		);
 	}
 }

--- a/packages/notify/src/adapters/email/errors.ts
+++ b/packages/notify/src/adapters/email/errors.ts
@@ -16,16 +16,12 @@ export class AttachmentTooLargeError extends ValidationError {
 	}
 }
 
-export type EmailProviderName = "resend" | "cloudflare";
+export type EmailProviderName = "resend" | "cloudflare" | (string & {});
 
 export class WebhookSignatureError extends ValidationError {
-	constructor(providerOrReason: EmailProviderName | string, reason?: string) {
-		const [provider, detail] =
-			reason === undefined
-				? (["resend", providerOrReason] as const)
-				: ([providerOrReason as EmailProviderName, reason] as const);
-		super(`${provider} webhook signature verification failed: ${detail}`, [
-			{ path: ["webhook"], message: detail },
+	constructor(provider: EmailProviderName, reason: string) {
+		super(`${provider} webhook signature verification failed: ${reason}`, [
+			{ path: ["webhook"], message: reason },
 		]);
 	}
 }

--- a/packages/notify/src/adapters/email/index.ts
+++ b/packages/notify/src/adapters/email/index.ts
@@ -1,5 +1,17 @@
 export { emailAdapter } from "./adapter";
-export type { EmailAdapterOptions, EmailOptOutHook, EmailPayload } from "./adapter";
+export type { EmailAdapterOptions, EmailPayload } from "./adapter";
+
+export type {
+	EmailProvider,
+	EmailProviderSendArgs,
+	EmailAttachmentWire,
+} from "./provider";
+
+export { cloudflareEmailProvider } from "./providers/cloudflare";
+export type { CloudflareEmailProviderOptions } from "./providers/cloudflare";
+
+export { resendEmailProvider } from "./providers/resend";
+export type { ResendEmailProviderOptions, EmailOptOutHook } from "./providers/resend";
 
 export { renderEmail, htmlToText } from "./render";
 
@@ -17,4 +29,5 @@ export {
 	AttachmentTooLargeError,
 	FromDomainError,
 	WebhookSignatureError,
+	ProviderMissingError,
 } from "./errors";

--- a/packages/notify/src/adapters/email/provider.ts
+++ b/packages/notify/src/adapters/email/provider.ts
@@ -1,0 +1,37 @@
+import type { AdapterSendResult, WebhookEvent } from "../../types";
+
+/** A single attachment passed from the adapter to the provider — raw bytes. */
+export interface EmailAttachmentWire {
+	readonly filename: string;
+	readonly content: Uint8Array;
+	readonly contentType: string;
+}
+
+/** Arguments the adapter passes to `provider.send` after template rendering + attachment loading. */
+export interface EmailProviderSendArgs {
+	readonly to: string;
+	readonly subject: string;
+	readonly html: string;
+	readonly text: string;
+	readonly attachments?: readonly EmailAttachmentWire[];
+	readonly headers?: Readonly<Record<string, string>>;
+	readonly notificationId: string;
+	readonly deliveryId: string;
+}
+
+/**
+ * Pluggable email provider. `cloudflareEmailProvider` is the default;
+ * `resendEmailProvider` is the first-class alternative. Mirrors the
+ * `WaProvider` shape (`adapters/whatsapp/provider.ts`) minus
+ * `handleVerificationChallenge` (email has no such handshake).
+ *
+ * Contract: `send` MUST return `AdapterSendResult` and MUST NOT throw —
+ * providers that delegate to libraries which throw (e.g., `@workkit/mail`)
+ * must catch and convert.
+ */
+export interface EmailProvider {
+	readonly name: "cloudflare" | "resend";
+	send(args: EmailProviderSendArgs): Promise<AdapterSendResult>;
+	parseWebhook?(req: Request): Promise<WebhookEvent[]>;
+	verifySignature?(req: Request, secret: string): Promise<boolean>;
+}

--- a/packages/notify/src/adapters/email/provider.ts
+++ b/packages/notify/src/adapters/email/provider.ts
@@ -30,7 +30,13 @@ export interface EmailProviderSendArgs {
  * must catch and convert.
  */
 export interface EmailProvider {
-	readonly name: "cloudflare" | "resend";
+	/**
+	 * Provider identifier. Known names: `"cloudflare"`, `"resend"`. The
+	 * `(string & {})` branch preserves autocomplete while letting community
+	 * / follow-up providers (SES, Postmark, etc.) implement this interface
+	 * without editing the core type.
+	 */
+	readonly name: "cloudflare" | "resend" | (string & {});
 	send(args: EmailProviderSendArgs): Promise<AdapterSendResult>;
 	parseWebhook?(req: Request): Promise<WebhookEvent[]>;
 	verifySignature?(req: Request, secret: string): Promise<boolean>;

--- a/packages/notify/src/adapters/email/providers/cloudflare.ts
+++ b/packages/notify/src/adapters/email/providers/cloudflare.ts
@@ -1,0 +1,66 @@
+import { mail } from "@workkit/mail";
+import type { AdapterSendResult } from "../../../types";
+import type { EmailAttachmentWire, EmailProvider, EmailProviderSendArgs } from "../provider";
+
+export interface CloudflareEmailProviderOptions {
+	/** The `SendEmail` binding from `[[send_email]]` in wrangler.toml */
+	binding: SendEmail;
+	from: string;
+	replyTo?: string | string[];
+}
+
+/**
+ * Default email provider — delegates to `@workkit/mail` which wraps
+ * Cloudflare's `send_email` binding (transactional email, beta).
+ *
+ * `parseWebhook` / `verifySignature` are intentionally omitted: the binding
+ * exposes no delivery-webhook surface. Bounce handling is a follow-up (see
+ * `createBounceRoute` in the roadmap — parses inbound DSN via Email Routing).
+ *
+ * Requires `@workkit/mail` as an optional peerDependency.
+ */
+export function cloudflareEmailProvider(options: CloudflareEmailProviderOptions): EmailProvider {
+	const client = mail(options.binding, { defaultFrom: options.from });
+
+	return {
+		name: "cloudflare",
+
+		async send(args: EmailProviderSendArgs): Promise<AdapterSendResult> {
+			try {
+				const { messageId } = await client.send({
+					to: args.to,
+					subject: args.subject,
+					text: args.text,
+					html: args.html,
+					...(options.replyTo ? { replyTo: toReplyTo(options.replyTo) } : {}),
+					...(args.attachments && args.attachments.length > 0
+						? { attachments: toMailAttachments(args.attachments) }
+						: {}),
+					...(args.headers && Object.keys(args.headers).length > 0
+						? { headers: args.headers }
+						: {}),
+				});
+				return { status: "sent", providerId: messageId };
+			} catch (err) {
+				return { status: "failed", error: err instanceof Error ? err.message : String(err) };
+			}
+		},
+	};
+}
+
+function toReplyTo(value: string | string[]): string {
+	// @workkit/mail's replyTo accepts a single string | MailAddress. If the
+	// caller passed an array, pick the first — Resend supports multiple but
+	// the CF binding only honors one.
+	return Array.isArray(value) ? (value[0] ?? "") : value;
+}
+
+function toMailAttachments(
+	attachments: readonly EmailAttachmentWire[],
+): { filename: string; content: Uint8Array; contentType: string }[] {
+	return attachments.map((a) => ({
+		filename: a.filename,
+		content: a.content,
+		contentType: a.contentType,
+	}));
+}

--- a/packages/notify/src/adapters/email/providers/cloudflare.ts
+++ b/packages/notify/src/adapters/email/providers/cloudflare.ts
@@ -1,4 +1,3 @@
-import { mail } from "@workkit/mail";
 import type { AdapterSendResult } from "../../../types";
 import type { EmailAttachmentWire, EmailProvider, EmailProviderSendArgs } from "../provider";
 
@@ -9,6 +8,16 @@ export interface CloudflareEmailProviderOptions {
 	replyTo?: string | string[];
 }
 
+// Lazy loader for @workkit/mail — kept optional so consumers of
+// `@workkit/notify/email` who only use `resendEmailProvider` don't pay
+// the install cost or hit a module-resolution error.
+type MailModule = typeof import("@workkit/mail");
+let mailModulePromise: Promise<MailModule> | null = null;
+function loadMail(): Promise<MailModule> {
+	if (!mailModulePromise) mailModulePromise = import("@workkit/mail");
+	return mailModulePromise;
+}
+
 /**
  * Default email provider — delegates to `@workkit/mail` which wraps
  * Cloudflare's `send_email` binding (transactional email, beta).
@@ -17,22 +26,25 @@ export interface CloudflareEmailProviderOptions {
  * exposes no delivery-webhook surface. Bounce handling is a follow-up (see
  * `createBounceRoute` in the roadmap — parses inbound DSN via Email Routing).
  *
- * Requires `@workkit/mail` as an optional peerDependency.
+ * Requires `@workkit/mail` as an optional peerDependency — imported lazily
+ * at first `send()` call.
  */
 export function cloudflareEmailProvider(options: CloudflareEmailProviderOptions): EmailProvider {
-	const client = mail(options.binding, { defaultFrom: options.from });
+	const replyTo = normalizeReplyTo(options.replyTo);
 
 	return {
 		name: "cloudflare",
 
 		async send(args: EmailProviderSendArgs): Promise<AdapterSendResult> {
 			try {
+				const { mail } = await loadMail();
+				const client = mail(options.binding, { defaultFrom: options.from });
 				const { messageId } = await client.send({
 					to: args.to,
 					subject: args.subject,
 					text: args.text,
 					html: args.html,
-					...(options.replyTo ? { replyTo: toReplyTo(options.replyTo) } : {}),
+					...(replyTo ? { replyTo } : {}),
 					...(args.attachments && args.attachments.length > 0
 						? { attachments: toMailAttachments(args.attachments) }
 						: {}),
@@ -48,11 +60,19 @@ export function cloudflareEmailProvider(options: CloudflareEmailProviderOptions)
 	};
 }
 
-function toReplyTo(value: string | string[]): string {
-	// @workkit/mail's replyTo accepts a single string | MailAddress. If the
-	// caller passed an array, pick the first — Resend supports multiple but
-	// the CF binding only honors one.
-	return Array.isArray(value) ? (value[0] ?? "") : value;
+/**
+ * @workkit/mail's `replyTo` accepts a single string. An array is treated as
+ * "first wins" (CF honors only one). An empty string or empty array is
+ * treated as unset — returning `undefined` lets the caller omit the field
+ * entirely rather than emitting a malformed `Reply-To:` header.
+ */
+function normalizeReplyTo(value: string | string[] | undefined): string | undefined {
+	if (value === undefined) return undefined;
+	if (Array.isArray(value)) {
+		const first = value.find((v) => v.length > 0);
+		return first;
+	}
+	return value.length > 0 ? value : undefined;
 }
 
 function toMailAttachments(

--- a/packages/notify/src/adapters/email/providers/resend.ts
+++ b/packages/notify/src/adapters/email/providers/resend.ts
@@ -1,0 +1,171 @@
+import type { AdapterSendResult, WebhookEvent } from "../../../types";
+import { FromDomainError } from "../errors";
+import type { EmailAttachmentWire, EmailProvider, EmailProviderSendArgs } from "../provider";
+import {
+	isComplaint,
+	isHardBounce,
+	parseResendEvents,
+	safeParseJson,
+	verifyResendSignature,
+} from "../webhook";
+
+/**
+ * Auto opt-out hook — called when a webhook event indicates a hard bounce
+ * or a complaint. **Always invoked with `notificationId: null`** (global
+ * opt-out for the channel) because Resend's webhook payload does not carry
+ * the originating notification id. The hook receives the recipient email
+ * address as `userId` — your implementation must resolve it to your
+ * internal id (typically via your user table).
+ */
+export type EmailOptOutHook = (
+	emailAddress: string,
+	channel: "email",
+	notificationId: null,
+	reason: "hard-bounce" | "complaint",
+) => Promise<void>;
+
+export interface ResendEmailProviderOptions {
+	apiKey: string;
+	from: string;
+	replyTo?: string | string[];
+	apiUrl?: string;
+	webhook?: { maxAgeMs?: number };
+	autoOptOut?: { enabled?: boolean; hook: EmailOptOutHook };
+}
+
+const DEFAULT_API_URL = "https://api.resend.com/emails";
+const FROM_RE = /^(?:.+\s)?<?([^\s<>]+@[^\s<>]+)>?$/;
+
+interface ResendSendBody {
+	from: string;
+	to: string[];
+	subject: string;
+	html: string;
+	text: string;
+	reply_to?: string | string[];
+	attachments?: { filename: string; content: string; content_type: string }[];
+	headers?: Record<string, string>;
+}
+
+interface ResendSendResponse {
+	id?: string;
+	error?: { message?: string; statusCode?: number };
+}
+
+export function resendEmailProvider(options: ResendEmailProviderOptions): EmailProvider {
+	if (!FROM_RE.test(options.from)) throw new FromDomainError(options.from);
+	const apiUrl = options.apiUrl ?? DEFAULT_API_URL;
+	const autoOptOutEnabled = options.autoOptOut?.enabled !== false;
+
+	return {
+		name: "resend",
+
+		async send(args: EmailProviderSendArgs): Promise<AdapterSendResult> {
+			const body: ResendSendBody = {
+				from: options.from,
+				to: [args.to],
+				subject: args.subject,
+				html: args.html,
+				text: args.text,
+				...(options.replyTo ? { reply_to: options.replyTo } : {}),
+				...(args.attachments && args.attachments.length > 0
+					? { attachments: encodeAttachments(args.attachments) }
+					: {}),
+				...(args.headers && Object.keys(args.headers).length > 0 ? { headers: args.headers } : {}),
+			};
+
+			let resp: Response;
+			try {
+				resp = await fetch(apiUrl, {
+					method: "POST",
+					headers: {
+						"content-type": "application/json",
+						authorization: `Bearer ${options.apiKey}`,
+					},
+					body: JSON.stringify(body),
+				});
+			} catch (err) {
+				return { status: "failed", error: err instanceof Error ? err.message : String(err) };
+			}
+
+			let json: ResendSendResponse | null = null;
+			try {
+				json = (await resp.json()) as ResendSendResponse;
+			} catch {
+				json = null;
+			}
+			if (!resp.ok) {
+				return {
+					status: "failed",
+					error: json?.error?.message ?? `resend HTTP ${resp.status} ${resp.statusText}`,
+				};
+			}
+			if (!json?.id) {
+				return { status: "failed", error: "resend response missing id" };
+			}
+			return { status: "sent", providerId: json.id };
+		},
+
+		async parseWebhook(req: Request): Promise<WebhookEvent[]> {
+			// Read body via a clone so the signature-verifier path does not
+			// consume the stream first.
+			const raw = await req.clone().text();
+			const events = parseResendEvents(raw);
+			if (autoOptOutEnabled && options.autoOptOut?.hook) {
+				const parsed = safeParseJson(raw);
+				if (parsed !== null) {
+					const arr = Array.isArray(parsed) ? parsed : [parsed];
+					for (const e of arr) await maybeAutoOptOut(e, options.autoOptOut.hook);
+				}
+			}
+			return events;
+		},
+
+		async verifySignature(req: Request, secret: string): Promise<boolean> {
+			try {
+				await verifyResendSignature(req, secret, { maxAgeMs: options.webhook?.maxAgeMs });
+				return true;
+			} catch {
+				return false;
+			}
+		},
+	};
+}
+
+async function maybeAutoOptOut(rawEvent: unknown, hook: EmailOptOutHook): Promise<void> {
+	const e = rawEvent as { data?: { to?: string[]; email_id?: string }; type?: string };
+	if (!e?.data?.to || e.data.to.length === 0) return;
+	const emailAddress = e.data.to[0]!;
+	if (isComplaint(rawEvent)) {
+		await hook(emailAddress, "email", null, "complaint");
+		return;
+	}
+	if (isHardBounce(rawEvent)) {
+		await hook(emailAddress, "email", null, "hard-bounce");
+	}
+}
+
+function encodeAttachments(
+	attachments: readonly EmailAttachmentWire[],
+): { filename: string; content: string; content_type: string }[] {
+	return attachments.map((a) => ({
+		filename: a.filename,
+		content: bytesToBase64(a.content),
+		content_type: a.contentType,
+	}));
+}
+
+/**
+ * Chunked Uint8Array → base64 to keep performance predictable on
+ * attachment-cap-sized payloads (40 MB). The naive per-byte concatenation
+ * is O(n²) in some JS engines and risks exhausting Worker CPU budgets.
+ */
+function bytesToBase64(bytes: Uint8Array): string {
+	const chunkSize = 0x8000;
+	const parts: string[] = [];
+	for (let i = 0; i < bytes.length; i += chunkSize) {
+		const chunk = bytes.subarray(i, i + chunkSize);
+		parts.push(String.fromCharCode(...chunk));
+	}
+	return btoa(parts.join(""));
+}

--- a/packages/notify/src/adapters/email/webhook.ts
+++ b/packages/notify/src/adapters/email/webhook.ts
@@ -24,16 +24,20 @@ export async function verifyResendSignature(
 	const timestampHeader = req.headers.get("svix-timestamp");
 	const idHeader = req.headers.get("svix-id");
 	if (!sigHeader || !timestampHeader || !idHeader) {
-		throw new WebhookSignatureError("missing svix-signature/svix-timestamp/svix-id headers");
+		throw new WebhookSignatureError(
+			"resend",
+			"missing svix-signature/svix-timestamp/svix-id headers",
+		);
 	}
 
 	const tsSeconds = Number(timestampHeader);
-	if (!Number.isFinite(tsSeconds)) throw new WebhookSignatureError("non-numeric svix-timestamp");
+	if (!Number.isFinite(tsSeconds))
+		throw new WebhookSignatureError("resend", "non-numeric svix-timestamp");
 	const timestampMs = tsSeconds * 1000;
 
 	const maxAgeMs = options.maxAgeMs ?? 5 * 60 * 1000;
 	if (Math.abs(Date.now() - timestampMs) > maxAgeMs) {
-		throw new WebhookSignatureError("timestamp outside replay window");
+		throw new WebhookSignatureError("resend", "timestamp outside replay window");
 	}
 
 	const rawBody = await req.text();
@@ -51,10 +55,10 @@ export async function verifyResendSignature(
 
 	const variants = parseSignatureHeader(sigHeader);
 	if (variants.length === 0) {
-		throw new WebhookSignatureError("no v1 signature variant present");
+		throw new WebhookSignatureError("resend", "no v1 signature variant present");
 	}
 	const ok = variants.some((v) => constantTimeEqual(v, expected));
-	if (!ok) throw new WebhookSignatureError("signature mismatch");
+	if (!ok) throw new WebhookSignatureError("resend", "signature mismatch");
 	return { rawBody, timestampMs };
 }
 
@@ -85,7 +89,7 @@ function decodeSecret(secret: string): Uint8Array {
 	try {
 		bin = atob(value);
 	} catch {
-		throw new WebhookSignatureError("invalid webhook secret encoding");
+		throw new WebhookSignatureError("resend", "invalid webhook secret encoding");
 	}
 	const out = new Uint8Array(bin.length);
 	for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);

--- a/packages/notify/tests/adapters/email/adapter.test.ts
+++ b/packages/notify/tests/adapters/email/adapter.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { type EmailPayload, emailAdapter } from "../../../src/adapters/email/adapter";
-import { FromDomainError } from "../../../src/adapters/email/errors";
+import { FromDomainError, ProviderMissingError } from "../../../src/adapters/email/errors";
+import { resendEmailProvider } from "../../../src/adapters/email/providers/resend";
 import type { AdapterSendArgs, ChannelTemplate } from "../../../src/types";
 
 const ORIGINAL_FETCH = globalThis.fetch;
@@ -27,61 +28,78 @@ function callArgs(template: ChannelTemplate<EmailPayload>): AdapterSendArgs<Emai
 }
 
 describe("emailAdapter()", () => {
-	it("rejects an invalid `from` at construction", () => {
-		expect(() => emailAdapter({ apiKey: "x", from: "not-an-email" })).toThrow(FromDomainError);
+	it("throws ProviderMissingError when provider is absent", () => {
+		expect(() => emailAdapter({} as never)).toThrow(ProviderMissingError);
 	});
 
-	it("posts to Resend with rendered HTML + text and returns providerId on 200", async () => {
+	it("propagates FromDomainError from the Resend provider constructor", () => {
+		expect(() => resendEmailProvider({ apiKey: "x", from: "not-an-email" })).toThrow(
+			FromDomainError,
+		);
+	});
+
+	it("delegates send to the provider and returns its result", async () => {
 		(globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
 			new Response(JSON.stringify({ id: "resend_id_1" }), {
 				status: 200,
 				headers: { "content-type": "application/json" },
 			}),
 		);
-		const adapter = emailAdapter({ apiKey: "k", from: "Reports <reports@x.example.com>" });
+		const adapter = emailAdapter({
+			provider: resendEmailProvider({ apiKey: "k", from: "Reports <reports@x.example.com>" }),
+		});
 		const result = await adapter.send(
 			callArgs({ title: () => "NIFTY", body: () => "<p>hi</p>" } as ChannelTemplate<EmailPayload>),
 		);
 		expect(result.status).toBe("sent");
 		expect(result.providerId).toBe("resend_id_1");
+	});
+
+	it("attaches List-Unsubscribe headers for notification ids in markUnsubscribable", async () => {
+		(globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+			new Response(JSON.stringify({ id: "i" }), { status: 200 }),
+		);
+		const adapter = emailAdapter({
+			provider: resendEmailProvider({ apiKey: "k", from: "x@example.com" }),
+			markUnsubscribable: ["pre-market-brief"],
+		});
+		await adapter.send(callArgs({ body: () => "<p>x</p>" }));
 		const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
 		const [, opts] = fetchMock.mock.calls[0] ?? [];
 		const body = JSON.parse((opts as RequestInit).body as string);
-		expect(body.to).toEqual(["user@example.com"]);
-		expect(body.subject).toBe("NIFTY");
-		expect(body.html).toBe("<p>hi</p>");
-		expect(body.text).toBe("hi");
+		expect(body.headers["List-Unsubscribe-Post"]).toBe("List-Unsubscribe=One-Click");
+		expect(body.headers["X-Entity-Ref-ID"]).toBe("d1");
 	});
 
-	it("returns failed when Resend returns 4xx", async () => {
-		(globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
-			new Response(JSON.stringify({ error: { message: "from-domain not verified" } }), {
-				status: 403,
-				headers: { "content-type": "application/json" },
-			}),
-		);
-		const adapter = emailAdapter({ apiKey: "k", from: "x@example.com" });
-		const result = await adapter.send(callArgs({ body: () => "<p>x</p>" }));
-		expect(result.status).toBe("failed");
-		expect(result.error).toContain("from-domain");
+	it("omits parseWebhook when provider does not implement it", () => {
+		const adapter = emailAdapter({
+			provider: {
+				name: "cloudflare",
+				async send() {
+					return { status: "sent", providerId: "id" };
+				},
+			},
+		});
+		expect(adapter.parseWebhook).toBeUndefined();
+		expect(adapter.verifySignature).toBeUndefined();
 	});
 
-	it("returns failed when fetch throws", async () => {
-		(globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(
-			new Error("ENOTFOUND"),
-		);
-		const adapter = emailAdapter({ apiKey: "k", from: "x@example.com" });
-		const result = await adapter.send(callArgs({ body: () => "<p>x</p>" }));
-		expect(result.status).toBe("failed");
-		expect(result.error).toContain("ENOTFOUND");
+	it("exposes parseWebhook / verifySignature when the provider implements them", () => {
+		const adapter = emailAdapter({
+			provider: resendEmailProvider({ apiKey: "k", from: "x@example.com" }),
+		});
+		expect(typeof adapter.parseWebhook).toBe("function");
+		expect(typeof adapter.verifySignature).toBe("function");
 	});
 
-	it("invokes the auto-opt-out hook on a complaint webhook", async () => {
+	it("delegates parseWebhook to the provider (auto-opt-out hook fires)", async () => {
 		const hook = vi.fn().mockResolvedValue(undefined);
 		const adapter = emailAdapter({
-			apiKey: "k",
-			from: "x@example.com",
-			autoOptOut: { hook },
+			provider: resendEmailProvider({
+				apiKey: "k",
+				from: "x@example.com",
+				autoOptOut: { hook },
+			}),
 		});
 		const req = new Request("https://example.com/webhook", {
 			method: "POST",
@@ -95,73 +113,5 @@ describe("emailAdapter()", () => {
 		});
 		await adapter.parseWebhook!(req);
 		expect(hook).toHaveBeenCalledWith("user@example.com", "email", null, "complaint");
-	});
-
-	it("invokes the auto-opt-out hook on a hard bounce", async () => {
-		const hook = vi.fn().mockResolvedValue(undefined);
-		const adapter = emailAdapter({
-			apiKey: "k",
-			from: "x@example.com",
-			autoOptOut: { hook },
-		});
-		const req = new Request("https://example.com/webhook", {
-			method: "POST",
-			body: JSON.stringify({
-				type: "email.bounced",
-				created_at: "2026-04-18T05:00:00Z",
-				data: { email_id: "id1", to: ["user@example.com"], bounce: { type: "hard" } },
-			}),
-		});
-		await adapter.parseWebhook!(req);
-		expect(hook).toHaveBeenCalledWith("user@example.com", "email", null, "hard-bounce");
-	});
-
-	it("does NOT invoke hook on transient bounce", async () => {
-		const hook = vi.fn().mockResolvedValue(undefined);
-		const adapter = emailAdapter({
-			apiKey: "k",
-			from: "x@example.com",
-			autoOptOut: { hook },
-		});
-		const req = new Request("https://example.com/webhook", {
-			method: "POST",
-			body: JSON.stringify({
-				type: "email.bounced",
-				data: { email_id: "id1", to: ["user@example.com"], bounce: { type: "transient" } },
-			}),
-		});
-		await adapter.parseWebhook!(req);
-		expect(hook).not.toHaveBeenCalled();
-	});
-
-	it("parseWebhook does not throw on malformed JSON when autoOptOut is enabled", async () => {
-		const hook = vi.fn();
-		const adapter = emailAdapter({
-			apiKey: "k",
-			from: "x@example.com",
-			autoOptOut: { hook },
-		});
-		const req = new Request("https://example.com/webhook", {
-			method: "POST",
-			body: "{not-json",
-		});
-		await expect(adapter.parseWebhook!(req)).resolves.toEqual([]);
-		expect(hook).not.toHaveBeenCalled();
-	});
-
-	it("attaches List-Unsubscribe header for notification ids in markUnsubscribable", async () => {
-		(globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
-			new Response(JSON.stringify({ id: "i" }), { status: 200 }),
-		);
-		const adapter = emailAdapter({
-			apiKey: "k",
-			from: "x@example.com",
-			markUnsubscribable: ["pre-market-brief"],
-		});
-		await adapter.send(callArgs({ body: () => "<p>x</p>" }));
-		const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
-		const [, opts] = fetchMock.mock.calls[0] ?? [];
-		const body = JSON.parse((opts as RequestInit).body as string);
-		expect(body.headers["List-Unsubscribe-Post"]).toBe("List-Unsubscribe=One-Click");
 	});
 });

--- a/packages/notify/tests/adapters/email/providers/cloudflare.test.ts
+++ b/packages/notify/tests/adapters/email/providers/cloudflare.test.ts
@@ -87,6 +87,30 @@ describe("cloudflareEmailProvider", () => {
 		expect(binding._sent[0].raw).toContain("reply@example.com");
 	});
 
+	it("omits Reply-To when replyTo is an empty array", async () => {
+		const binding = createMockSendEmail();
+		const provider = cloudflareEmailProvider({
+			binding: binding as unknown as SendEmail,
+			from: "x@example.com",
+			replyTo: [],
+		});
+		const result = await provider.send(baseArgs());
+		expect(result.status).toBe("sent");
+		expect(binding._sent[0].raw).not.toContain("Reply-To:");
+	});
+
+	it("omits Reply-To when replyTo is an empty string", async () => {
+		const binding = createMockSendEmail();
+		const provider = cloudflareEmailProvider({
+			binding: binding as unknown as SendEmail,
+			from: "x@example.com",
+			replyTo: "",
+		});
+		const result = await provider.send(baseArgs());
+		expect(result.status).toBe("sent");
+		expect(binding._sent[0].raw).not.toContain("Reply-To:");
+	});
+
 	it("forwards attachments to @workkit/mail", async () => {
 		const binding = createMockSendEmail();
 		const provider = cloudflareEmailProvider({

--- a/packages/notify/tests/adapters/email/providers/cloudflare.test.ts
+++ b/packages/notify/tests/adapters/email/providers/cloudflare.test.ts
@@ -1,0 +1,122 @@
+import { createMockSendEmail } from "@workkit/testing";
+import { describe, expect, it } from "vitest";
+import { cloudflareEmailProvider } from "../../../../src/adapters/email/providers/cloudflare";
+
+function baseArgs() {
+	return {
+		to: "user@example.com",
+		subject: "Hi",
+		html: "<p>hi</p>",
+		text: "hi",
+		notificationId: "n1",
+		deliveryId: "d1",
+	};
+}
+
+describe("cloudflareEmailProvider", () => {
+	it("has name 'cloudflare'", () => {
+		const binding = createMockSendEmail();
+		const provider = cloudflareEmailProvider({
+			binding: binding as unknown as SendEmail,
+			from: "x@example.com",
+		});
+		expect(provider.name).toBe("cloudflare");
+	});
+
+	it("omits parseWebhook and verifySignature (no CF webhooks)", () => {
+		const binding = createMockSendEmail();
+		const provider = cloudflareEmailProvider({
+			binding: binding as unknown as SendEmail,
+			from: "x@example.com",
+		});
+		expect(provider.parseWebhook).toBeUndefined();
+		expect(provider.verifySignature).toBeUndefined();
+	});
+
+	it("sends via the binding and returns providerId", async () => {
+		const binding = createMockSendEmail();
+		const provider = cloudflareEmailProvider({
+			binding: binding as unknown as SendEmail,
+			from: "x@example.com",
+		});
+		const result = await provider.send(baseArgs());
+		expect(result.status).toBe("sent");
+		expect(result.providerId).toBeDefined();
+		expect(binding._sent).toHaveLength(1);
+		expect(binding._sent[0].from).toBe("x@example.com");
+		expect(binding._sent[0].to).toBe("user@example.com");
+		expect(binding._sent[0].raw).toContain("Subject:");
+		expect(binding._sent[0].raw).toContain("<p>hi</p>");
+	});
+
+	it("catches mail DeliveryError and returns failed", async () => {
+		const failingBinding = {
+			async send() {
+				throw new Error("Network failure");
+			},
+		};
+		const provider = cloudflareEmailProvider({
+			binding: failingBinding as unknown as SendEmail,
+			from: "x@example.com",
+		});
+		const result = await provider.send(baseArgs());
+		expect(result.status).toBe("failed");
+		expect(result.error).toBeDefined();
+	});
+
+	it("catches mail InvalidAddressError and returns failed", async () => {
+		const binding = createMockSendEmail();
+		const provider = cloudflareEmailProvider({
+			binding: binding as unknown as SendEmail,
+			from: "x@example.com",
+		});
+		const result = await provider.send({ ...baseArgs(), to: "not-an-email" });
+		expect(result.status).toBe("failed");
+		expect(result.error).toBeDefined();
+	});
+
+	it("forwards replyTo into the composed MIME", async () => {
+		const binding = createMockSendEmail();
+		const provider = cloudflareEmailProvider({
+			binding: binding as unknown as SendEmail,
+			from: "x@example.com",
+			replyTo: "reply@example.com",
+		});
+		await provider.send(baseArgs());
+		expect(binding._sent[0].raw).toContain("Reply-To:");
+		expect(binding._sent[0].raw).toContain("reply@example.com");
+	});
+
+	it("forwards attachments to @workkit/mail", async () => {
+		const binding = createMockSendEmail();
+		const provider = cloudflareEmailProvider({
+			binding: binding as unknown as SendEmail,
+			from: "x@example.com",
+		});
+		const result = await provider.send({
+			...baseArgs(),
+			attachments: [
+				{
+					filename: "a.txt",
+					content: new TextEncoder().encode("hello"),
+					contentType: "text/plain",
+				},
+			],
+		});
+		expect(result.status).toBe("sent");
+		expect(binding._sent[0].raw).toContain("a.txt");
+	});
+
+	it("forwards custom headers into the composed MIME", async () => {
+		const binding = createMockSendEmail();
+		const provider = cloudflareEmailProvider({
+			binding: binding as unknown as SendEmail,
+			from: "x@example.com",
+		});
+		await provider.send({
+			...baseArgs(),
+			headers: { "X-Entity-Ref-ID": "d1" },
+		});
+		expect(binding._sent[0].raw).toContain("X-Entity-Ref-ID: d1");
+	});
+});

--- a/packages/notify/tests/adapters/email/providers/resend.test.ts
+++ b/packages/notify/tests/adapters/email/providers/resend.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FromDomainError } from "../../../../src/adapters/email/errors";
+import { resendEmailProvider } from "../../../../src/adapters/email/providers/resend";
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+beforeEach(() => {
+	globalThis.fetch = vi.fn() as unknown as typeof fetch;
+});
+afterEach(() => {
+	globalThis.fetch = ORIGINAL_FETCH;
+	vi.restoreAllMocks();
+});
+
+function baseArgs() {
+	return {
+		to: "user@example.com",
+		subject: "Hi",
+		html: "<p>hi</p>",
+		text: "hi",
+		notificationId: "n1",
+		deliveryId: "d1",
+	};
+}
+
+describe("resendEmailProvider", () => {
+	it("has name 'resend'", () => {
+		const provider = resendEmailProvider({ apiKey: "k", from: "x@example.com" });
+		expect(provider.name).toBe("resend");
+	});
+
+	it("rejects an invalid `from` at construction", () => {
+		expect(() => resendEmailProvider({ apiKey: "k", from: "not-an-email" })).toThrow(
+			FromDomainError,
+		);
+	});
+
+	it("posts to Resend and returns providerId on 200", async () => {
+		(globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+			new Response(JSON.stringify({ id: "resend_id" }), { status: 200 }),
+		);
+		const provider = resendEmailProvider({ apiKey: "k", from: "x@example.com" });
+		const result = await provider.send(baseArgs());
+		expect(result.status).toBe("sent");
+		expect(result.providerId).toBe("resend_id");
+	});
+
+	it("forwards replyTo from provider options", async () => {
+		(globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+			new Response(JSON.stringify({ id: "i" }), { status: 200 }),
+		);
+		const provider = resendEmailProvider({
+			apiKey: "k",
+			from: "x@example.com",
+			replyTo: "reply@example.com",
+		});
+		await provider.send(baseArgs());
+		const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+		const [, opts] = fetchMock.mock.calls[0] ?? [];
+		const body = JSON.parse((opts as RequestInit).body as string);
+		expect(body.reply_to).toBe("reply@example.com");
+	});
+
+	it("returns failed on 4xx", async () => {
+		(globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+			new Response(JSON.stringify({ error: { message: "from-domain not verified" } }), {
+				status: 403,
+			}),
+		);
+		const provider = resendEmailProvider({ apiKey: "k", from: "x@example.com" });
+		const result = await provider.send(baseArgs());
+		expect(result.status).toBe("failed");
+		expect(result.error).toContain("from-domain");
+	});
+
+	it("returns failed when fetch throws", async () => {
+		(globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(
+			new Error("ENOTFOUND"),
+		);
+		const provider = resendEmailProvider({ apiKey: "k", from: "x@example.com" });
+		const result = await provider.send(baseArgs());
+		expect(result.status).toBe("failed");
+		expect(result.error).toContain("ENOTFOUND");
+	});
+
+	it("returns failed when response lacks id", async () => {
+		(globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+			new Response(JSON.stringify({}), { status: 200 }),
+		);
+		const provider = resendEmailProvider({ apiKey: "k", from: "x@example.com" });
+		const result = await provider.send(baseArgs());
+		expect(result.status).toBe("failed");
+		expect(result.error).toContain("missing id");
+	});
+
+	it("fires auto-opt-out hook on complaint", async () => {
+		const hook = vi.fn().mockResolvedValue(undefined);
+		const provider = resendEmailProvider({
+			apiKey: "k",
+			from: "x@example.com",
+			autoOptOut: { hook },
+		});
+		const req = new Request("https://example.com/webhook", {
+			method: "POST",
+			body: JSON.stringify({
+				type: "email.complained",
+				data: { email_id: "id1", to: ["user@example.com"] },
+			}),
+		});
+		await provider.parseWebhook!(req);
+		expect(hook).toHaveBeenCalledWith("user@example.com", "email", null, "complaint");
+	});
+
+	it("fires auto-opt-out hook on hard bounce", async () => {
+		const hook = vi.fn().mockResolvedValue(undefined);
+		const provider = resendEmailProvider({
+			apiKey: "k",
+			from: "x@example.com",
+			autoOptOut: { hook },
+		});
+		const req = new Request("https://example.com/webhook", {
+			method: "POST",
+			body: JSON.stringify({
+				type: "email.bounced",
+				data: { email_id: "id1", to: ["user@example.com"], bounce: { type: "hard" } },
+			}),
+		});
+		await provider.parseWebhook!(req);
+		expect(hook).toHaveBeenCalledWith("user@example.com", "email", null, "hard-bounce");
+	});
+
+	it("does NOT fire hook on transient bounce", async () => {
+		const hook = vi.fn();
+		const provider = resendEmailProvider({
+			apiKey: "k",
+			from: "x@example.com",
+			autoOptOut: { hook },
+		});
+		const req = new Request("https://example.com/webhook", {
+			method: "POST",
+			body: JSON.stringify({
+				type: "email.bounced",
+				data: { email_id: "id1", to: ["user@example.com"], bounce: { type: "transient" } },
+			}),
+		});
+		await provider.parseWebhook!(req);
+		expect(hook).not.toHaveBeenCalled();
+	});
+
+	it("parseWebhook returns empty on malformed JSON without throwing", async () => {
+		const hook = vi.fn();
+		const provider = resendEmailProvider({
+			apiKey: "k",
+			from: "x@example.com",
+			autoOptOut: { hook },
+		});
+		const req = new Request("https://example.com/webhook", {
+			method: "POST",
+			body: "{not-json",
+		});
+		await expect(provider.parseWebhook!(req)).resolves.toEqual([]);
+		expect(hook).not.toHaveBeenCalled();
+	});
+
+	it("encodes attachments as base64", async () => {
+		(globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+			new Response(JSON.stringify({ id: "i" }), { status: 200 }),
+		);
+		const provider = resendEmailProvider({ apiKey: "k", from: "x@example.com" });
+		await provider.send({
+			...baseArgs(),
+			attachments: [
+				{
+					filename: "a.txt",
+					content: new TextEncoder().encode("hello"),
+					contentType: "text/plain",
+				},
+			],
+		});
+		const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+		const [, opts] = fetchMock.mock.calls[0] ?? [];
+		const body = JSON.parse((opts as RequestInit).body as string);
+		expect(body.attachments[0].filename).toBe("a.txt");
+		expect(body.attachments[0].content).toBe(btoa("hello"));
+		expect(body.attachments[0].content_type).toBe("text/plain");
+	});
+});

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -46,6 +46,12 @@
         "types": "./dist/src/do.d.ts",
         "default": "./dist/src/do.js"
       }
+    },
+    "./email": {
+      "import": {
+        "types": "./dist/src/email.d.ts",
+        "default": "./dist/src/email.js"
+      }
     }
   },
   "module": "./dist/src/index.js",
@@ -80,6 +86,8 @@
     "r2",
     "queue",
     "durable-objects",
+    "email",
+    "send-email",
     "workkit"
   ]
 }

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -76,6 +76,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0"
   },
+  "//constitution-allow": "no-testing reason=self-package; @workkit/testing cannot depend on itself",
   "keywords": [
     "cloudflare",
     "workers",

--- a/packages/testing/src/email.ts
+++ b/packages/testing/src/email.ts
@@ -1,6 +1,7 @@
 /**
- * In-memory mock implementations of CF Email types for testing.
- * Follows the mock-queue.ts pattern from @workkit/queue.
+ * In-memory mocks for Cloudflare Email bindings: `SendEmail` (outbound)
+ * and `ForwardableEmailMessage` (inbound). Mirrors the `createMockKV` /
+ * `createMockQueue` shape.
  */
 
 export interface MockSendEmail {
@@ -44,10 +45,6 @@ export interface MockEmailOptions {
 	headers?: Record<string, string>;
 }
 
-/**
- * Create a mock ForwardableEmailMessage for testing inbound handlers.
- * Constructs a minimal valid MIME message from the provided options.
- */
 export function createMockForwardableEmail(options: MockEmailOptions = {}): MockForwardableEmail {
 	const from = options.from ?? "sender@example.com";
 	const to = options.to ?? "recipient@example.com";

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -2,6 +2,8 @@ export { createMockKV } from "./kv";
 export { createMockD1, createFailingD1 } from "./d1";
 export { createMockR2 } from "./r2";
 export { createMockQueue } from "./queue";
+export { createMockSendEmail, createMockForwardableEmail } from "./email";
+export type { MockSendEmail, MockForwardableEmail, MockEmailOptions } from "./email";
 export { createMockDO } from "./do";
 export { createTestEnv } from "./env";
 export { createRequest } from "./request";

--- a/packages/testing/tests/email.test.ts
+++ b/packages/testing/tests/email.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { createMockForwardableEmail, createMockSendEmail } from "../src/email";
+
+describe("createMockSendEmail", () => {
+	it("starts with empty _sent", () => {
+		const binding = createMockSendEmail();
+		expect(binding._sent).toEqual([]);
+	});
+
+	it("records sent payloads from string raw", async () => {
+		const binding = createMockSendEmail();
+		await binding.send({ from: "a@x.com", to: "b@x.com", raw: "raw-mime" });
+		expect(binding._sent).toHaveLength(1);
+		expect(binding._sent[0]).toEqual({ from: "a@x.com", to: "b@x.com", raw: "raw-mime" });
+	});
+
+	it("records sent payloads from ReadableStream raw", async () => {
+		const binding = createMockSendEmail();
+		const stream = new ReadableStream({
+			start(c) {
+				c.enqueue(new TextEncoder().encode("stream-mime"));
+				c.close();
+			},
+		});
+		await binding.send({ from: "a@x.com", to: "b@x.com", raw: stream });
+		expect(binding._sent[0].raw).toBe("stream-mime");
+	});
+
+	it("accumulates multiple sends", async () => {
+		const binding = createMockSendEmail();
+		await binding.send({ from: "a@x.com", to: "b@x.com", raw: "1" });
+		await binding.send({ from: "a@x.com", to: "c@x.com", raw: "2" });
+		expect(binding._sent).toHaveLength(2);
+	});
+});
+
+describe("createMockForwardableEmail", () => {
+	it("applies sensible defaults", () => {
+		const email = createMockForwardableEmail();
+		expect(email.from).toBe("sender@example.com");
+		expect(email.to).toBe("recipient@example.com");
+		expect(email.rawSize).toBeGreaterThan(0);
+		expect(email._rejected).toBe(false);
+		expect(email._forwarded).toBe(false);
+		expect(email._replied).toBe(false);
+	});
+
+	it("accepts options overrides", () => {
+		const email = createMockForwardableEmail({
+			from: "sender@x.com",
+			to: "support@x.com",
+			subject: "Help",
+			text: "I need help",
+		});
+		expect(email.from).toBe("sender@x.com");
+		expect(email.to).toBe("support@x.com");
+		expect(email.headers.get("subject")).toBe("Help");
+	});
+
+	it("produces a readable raw MIME stream", async () => {
+		const email = createMockForwardableEmail({ subject: "Hi", text: "Body" });
+		const raw = await new Response(email.raw).text();
+		expect(raw).toContain("Subject: Hi");
+		expect(raw).toContain("Body");
+	});
+
+	it("setReject flips state", () => {
+		const email = createMockForwardableEmail();
+		email.setReject("no");
+		expect(email._rejected).toBe(true);
+		expect(email._rejectReason).toBe("no");
+	});
+
+	it("forward flips state", async () => {
+		const email = createMockForwardableEmail();
+		await email.forward("other@x.com");
+		expect(email._forwarded).toBe(true);
+		expect(email._forwardedTo).toBe("other@x.com");
+	});
+
+	it("reply flips state", async () => {
+		const email = createMockForwardableEmail();
+		await email.reply({ from: "a@x.com", to: "b@x.com", raw: "r" });
+		expect(email._replied).toBe(true);
+	});
+
+	it("includes custom headers", () => {
+		const email = createMockForwardableEmail({
+			headers: { "x-custom": "value" },
+		});
+		expect(email.headers.get("x-custom")).toBe("value");
+	});
+});


### PR DESCRIPTION
## Summary

- Makes **Cloudflare `send_email` binding** (transactional email, beta) the default email transport for `@workkit/notify` — zero config for Worker-native deployments.
- Refactors the email adapter to be **provider-pluggable**, matching the existing WhatsApp provider pattern (`metaWaProvider` / `twilioWaProvider` / `gupshupWaProvider`). New `EmailProvider` interface; two providers ship: `cloudflareEmailProvider` (default) and `resendEmailProvider` (first-class alternative).
- Promotes `createMockSendEmail` + `createMockForwardableEmail` from a private helper in `@workkit/mail` to first-class exports in `@workkit/testing`.

Closes #52. Design: [ADR 0002](../blob/feature/009-cf-email-default/adr/0002-email-provider-interface-and-cloudflare-send-email-as-default.md). Feature trail: `.maina/features/009-cf-email-default/`.

### Migration (pre-1.0 break)

```diff
- emailAdapter({ apiKey: env.RESEND_API_KEY, from: "noreply@x.com", autoOptOut: { hook } })
+ emailAdapter({ provider: resendEmailProvider({ apiKey: env.RESEND_API_KEY, from: "noreply@x.com", autoOptOut: { hook } }) })
```

Or switch to the new default (no API key, no external account):

```ts
emailAdapter({ provider: cloudflareEmailProvider({ binding: env.SEND_EMAIL, from: "noreply@x.com" }) })
```

### Packages touched

| Package | Bump | Change |
|---|---|---|
| `@workkit/notify` | minor (pre-1.0 break) | Provider interface + two providers + adapter refactor |
| `@workkit/testing` | minor | New `createMockSendEmail` / `createMockForwardableEmail` + `./email` subpath |
| `@workkit/mail` | patch | Private test helper removed, tests migrated to `@workkit/testing` |

## Known feature asymmetry

The Cloudflare `send_email` binding exposes **no delivery webhooks**. `autoOptOut` is therefore Resend-only in v1. Bounce synthesis from inbound DSN routing is tracked as follow-ups:

- #53 — `feat(mail): parseBounceDSN for RFC 3464 hard/soft bounce detection`
- #54 — `feat(notify): createBounceRoute helper wiring DSN → autoOptOut on CF transport`

Other follow-ups: #55 (preserve retry strategy through `AdapterSendResult`), #56 (docs positioning pass), #57 (SES/Postmark provider stubs).

## Test plan

- [x] `bun run test` — 172/172 notify, 64/64 mail, 11/11 new testing mocks, full suite green
- [x] `bun run typecheck` — 48/48 tasks clean
- [x] `bun run lint` (biome) — clean
- [x] `bun run constitution:check -- --diff-only` — 0 errors, 0 warnings across 32 packages
- [x] `maina verify` — passed
- [x] `maina slop` — no slop detected
- [x] `maina review` — verdict READY, no critical/important issues
- [x] Cloudflare provider contract: delegates to `@workkit/mail`, catches `DeliveryError` / `InvalidAddressError`, omits `parseWebhook` / `verifySignature`
- [x] Resend provider contract: existing behavior preserved; webhook verification + autoOptOut intact
- [x] Adapter throws `ProviderMissingError` at construction when `provider` is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added pluggable email provider architecture to `@workkit/notify`.
* Cloudflare `send_email` is now the default email transport.
* Resend remains available as an alternative provider.
* Promoted email testing utilities (`createMockSendEmail`, `createMockForwardableEmail`) to `@workkit/testing` for reuse.

## Breaking Changes
* Email adapter configuration now requires `{ provider: cloudflareEmailProvider(...) | resendEmailProvider(...) }`.
* Legacy top-level `{ apiKey, from, ... }` options removed.

## Documentation
* Updated README with provider usage examples and migration guide.
* Added Architecture Decision Record for email provider design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->