### PR TITLE
docs: ai-gateway 0.3.0 features in README and site guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Every package wraps a Cloudflare binding or API with type safety, better DX, and
 | [`@workkit/ratelimit`](packages/ratelimit) | KV-backed rate limiting (fixed/sliding/token bucket), tiered limits, and quota tracking |
 | [`@workkit/crypto`](packages/crypto) | AES-256-GCM encryption, digital signatures, key rotation, AAD, and random utilities |
 | [`@workkit/ai`](packages/ai) | Typed Workers AI client with streaming, fallback chains, and retry |
-| [`@workkit/ai-gateway`](packages/ai-gateway) | Multi-provider AI gateway with routing, cost tracking, and caching |
+| [`@workkit/ai-gateway`](packages/ai-gateway) | Multi-provider AI gateway — Workers AI, OpenAI, Anthropic, custom. Routing, streaming, fallback, retry, prompt caching, Cloudflare AI Gateway routing, cost tracking |
 | [`@workkit/api`](packages/api) | Type-safe API definitions with Standard Schema and OpenAPI generation |
 | [`@workkit/logger`](packages/logger) | Structured logging with request context and Hono middleware |
 | [`@workkit/auth`](packages/auth) | JWT, session management, and auth middleware |

--- a/apps/docs/src/content/docs/guides/ai-integration.md
+++ b/apps/docs/src/content/docs/guides/ai-integration.md
@@ -7,7 +7,7 @@ title: "AI Integration"
 workkit provides two packages for AI:
 
 - **`@workkit/ai-gateway`** (recommended) — multi-provider gateway covering Workers AI, OpenAI, Anthropic, and custom providers. Unified streaming, retry, fallback, prompt caching, routing, cost tracking, logging, and Cloudflare AI Gateway support.
-- **`@workkit/ai`** — thin Workers-AI-only client, predates the gateway. Slated to become a deprecation shim over `@workkit/ai-gateway` per [ADR-001](https://github.com/beeeku/workkit/issues/62); new code should start with `@workkit/ai-gateway`.
+- **`@workkit/ai`** — thin Workers-AI-only client, predates the gateway. Slated to become a deprecation shim over `@workkit/ai-gateway` per [ADR-001](https://github.com/beeeku/workkit/blob/master/.maina/decisions/001-ai-package-consolidation.md); new code should start with `@workkit/ai-gateway`.
 
 ## Workers AI (`@workkit/ai`)
 
@@ -334,7 +334,9 @@ Explicit `baseUrl` on a provider config overrides `cfGateway`. Workers AI and cu
 `runFallback` POSTs a provider chain to the [CF Universal Endpoint](https://developers.cloudflare.com/ai-gateway/configuration/universal-endpoint/). Cloudflare tries each entry server-side in order and returns the first success. Requires `cfGateway`.
 
 ```ts
-const result = await gateway.runFallback(
+// runFallback is an optional Gateway method — use `!` when you constructed
+// the gateway yourself via createGateway (which always implements it).
+const result = await gateway.runFallback!(
   [
     { provider: 'anthropic', model: 'claude-sonnet-4-6' },
     { provider: 'openai',    model: 'gpt-4o' },
@@ -373,7 +375,9 @@ type GatewayStreamEvent =
 Successful streams end with exactly one `done` event. Mid-stream errors reject `read()` without enqueuing a synthetic `done`. Supported across Workers AI, Anthropic SSE, and OpenAI SSE. Tool-use events are emitted when the model completes a tool call mid-stream (Anthropic `input_json_delta` accumulation; OpenAI `tool_calls` delta accumulation).
 
 ```ts
-const stream = await gateway.stream('claude-sonnet-4-6', {
+// stream is an optional Gateway method — use `!` when the gateway was built
+// via createGateway (which always implements it).
+const stream = await gateway.stream!('claude-sonnet-4-6', {
   messages: [{ role: 'user', content: 'explain quantum tunneling' }],
 })
 
@@ -423,7 +427,9 @@ export default {
       { onError: (model, err) => console.error(`AI error: ${model}`, err) },
     ), { maxAttempts: 3 })
 
-    // Streaming endpoint — typed events across providers
+    // Streaming endpoint — typed events across providers.
+    // JSON-encode each event so embedded newlines and tool_use blocks survive
+    // SSE framing; the browser-side parser decodes one JSON payload per event.
     if (body.stream) {
       const events = await gateway.stream!('claude-sonnet-4-6', {
         messages: [{ role: 'user', content: body.prompt }],
@@ -432,7 +438,7 @@ export default {
       return new Response(
         events.pipeThrough(new TransformStream({
           transform(evt, ctrl) {
-            if (evt.type === 'text') ctrl.enqueue(encoder.encode(`data: ${evt.delta}\n\n`))
+            ctrl.enqueue(encoder.encode(`data: ${JSON.stringify(evt)}\n\n`))
             if (evt.type === 'done') ctrl.enqueue(encoder.encode('data: [DONE]\n\n'))
           },
         })),

--- a/apps/docs/src/content/docs/guides/ai-integration.md
+++ b/apps/docs/src/content/docs/guides/ai-integration.md
@@ -4,7 +4,10 @@ title: "AI Integration"
 
 # AI Integration
 
-workkit provides two packages for AI: `@workkit/ai` for Workers AI (Cloudflare's built-in models) and `@workkit/ai-gateway` for multi-provider AI routing (Workers AI, OpenAI, Anthropic, custom providers) with cost tracking, caching, and logging.
+workkit provides two packages for AI:
+
+- **`@workkit/ai-gateway`** (recommended) — multi-provider gateway covering Workers AI, OpenAI, Anthropic, and custom providers. Unified streaming, retry, fallback, prompt caching, routing, cost tracking, logging, and Cloudflare AI Gateway support.
+- **`@workkit/ai`** — thin Workers-AI-only client, predates the gateway. Slated to become a deprecation shim over `@workkit/ai-gateway` per [ADR-001](https://github.com/beeeku/workkit/issues/62); new code should start with `@workkit/ai-gateway`.
 
 ## Workers AI (`@workkit/ai`)
 
@@ -283,11 +286,113 @@ const loggedGateway = withLogging(gateway, {
 })
 ```
 
+### Retry
+
+Wrap the gateway with automatic retry on retryable errors. Delay between attempts is driven by each thrown `WorkkitError`'s own `retryStrategy` from `@workkit/errors` — no delay config needed. Per-call `AbortSignal` aborts the retry loop.
+
+```ts
+import { withRetry } from '@workkit/ai-gateway'
+
+const resilient = withRetry(gateway, { maxAttempts: 3 })
+await resilient.run('claude-sonnet-4-6', { prompt: '…' })
+```
+
+`ServiceUnavailableError`, `TimeoutError`, and `RateLimitError` are retryable by default. A custom `isRetryable` hook overrides the default:
+
+```ts
+withRetry(gateway, {
+  maxAttempts: 5,
+  isRetryable: (err) => /* your logic */,
+})
+```
+
+### Cloudflare AI Gateway
+
+Route OpenAI and Anthropic traffic through your [Cloudflare AI Gateway](https://developers.cloudflare.com/ai-gateway/) for centralized caching, logs, cost dashboards, and rate-limiting. Calls go to `https://gateway.ai.cloudflare.com/v1/{accountId}/{gatewayId}/{provider}/…` and `cf-aig-*` headers are injected automatically.
+
+```ts
+createGateway({
+  providers: {
+    anthropic: { type: 'anthropic', apiKey: env.ANTHROPIC_KEY },
+    openai:    { type: 'openai',    apiKey: env.OPENAI_KEY },
+  },
+  cfGateway: {
+    accountId: env.CF_ACCOUNT_ID,
+    gatewayId: 'my-gateway',
+    authToken: env.CF_AIG_TOKEN,  // → cf-aig-authorization (optional)
+    cacheTtl: 3600,                // → cf-aig-cache-ttl (optional)
+    skipCache: true,               // → cf-aig-skip-cache (only when true)
+  },
+  defaultProvider: 'anthropic',
+})
+```
+
+Explicit `baseUrl` on a provider config overrides `cfGateway`. Workers AI and custom providers are unaffected.
+
+### Server-side fallback (CF Universal Endpoint)
+
+`runFallback` POSTs a provider chain to the [CF Universal Endpoint](https://developers.cloudflare.com/ai-gateway/configuration/universal-endpoint/). Cloudflare tries each entry server-side in order and returns the first success. Requires `cfGateway`.
+
+```ts
+const result = await gateway.runFallback(
+  [
+    { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+    { provider: 'openai',    model: 'gpt-4o' },
+  ],
+  { messages: [{ role: 'user', content: 'hi' }] },
+)
+// result.provider identifies which one served the response
+```
+
+Only `openai` and `anthropic` entries are supported. The provider of the successful response is identified by config type, so custom provider key names (e.g. `'claude'`, `'gpt'`) work correctly.
+
+### Anthropic prompt caching
+
+Mark long-lived context with `cacheControl: 'ephemeral'` — it becomes a [prompt-cached content block](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching). Cheaper and faster on repeat calls. Non-Anthropic providers silently ignore the flag.
+
+```ts
+await gateway.run('claude-sonnet-4-6', {
+  messages: [
+    { role: 'system', content: longDocument, cacheControl: 'ephemeral' },
+    { role: 'user',   content: 'summarize this' },
+  ],
+})
+```
+
+### Streaming
+
+`gateway.stream()` returns a typed `ReadableStream<GatewayStreamEvent>`:
+
+```ts
+type GatewayStreamEvent =
+  | { type: 'text'; delta: string }
+  | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
+  | { type: 'done'; usage?: TokenUsage; raw?: unknown }
+```
+
+Successful streams end with exactly one `done` event. Mid-stream errors reject `read()` without enqueuing a synthetic `done`. Supported across Workers AI, Anthropic SSE, and OpenAI SSE. Tool-use events are emitted when the model completes a tool call mid-stream (Anthropic `input_json_delta` accumulation; OpenAI `tool_calls` delta accumulation).
+
+```ts
+const stream = await gateway.stream('claude-sonnet-4-6', {
+  messages: [{ role: 'user', content: 'explain quantum tunneling' }],
+})
+
+const reader = stream.getReader()
+while (true) {
+  const { done, value } = await reader.read()
+  if (done) break
+  if (value.type === 'text') process.stdout.write(value.delta)
+  if (value.type === 'tool_use') await handleToolCall(value)
+  if (value.type === 'done') console.log('usage:', value.usage)
+}
+```
+
+Consumer `reader.cancel()` propagates to the upstream fetch, so you stop paying for tokens you're not reading.
+
 ## Full Example: AI-Powered API
 
 ```ts
-import { ai, streamAI, fallback } from '@workkit/ai'
-import { createGateway, createCostTracker } from '@workkit/ai-gateway'
+import { createGateway, withRetry, withLogging } from '@workkit/ai-gateway'
 import { fixedWindow, rateLimitResponse } from '@workkit/ratelimit'
 
 export default {
@@ -302,31 +407,53 @@ export default {
     const rl = await limiter.check(`ai:${ip}`)
     if (!rl.allowed) return rateLimitResponse(rl)
 
-    const url = new URL(request.url)
     const body = await request.json() as { prompt: string; stream?: boolean }
 
-    // Streaming endpoint
+    const gateway = withRetry(withLogging(
+      createGateway({
+        providers: {
+          anthropic: { type: 'anthropic', apiKey: env.ANTHROPIC_KEY },
+          openai:    { type: 'openai',    apiKey: env.OPENAI_KEY },
+          workers:   { type: 'workers-ai', binding: env.AI },
+        },
+        // Route HTTP providers through CF AI Gateway for caching + observability
+        cfGateway: { accountId: env.CF_ACCOUNT_ID, gatewayId: 'prod-gw' },
+        defaultProvider: 'anthropic',
+      }),
+      { onError: (model, err) => console.error(`AI error: ${model}`, err) },
+    ), { maxAttempts: 3 })
+
+    // Streaming endpoint — typed events across providers
     if (body.stream) {
-      const stream = await streamAI(env.AI, '@cf/meta/llama-3.1-8b-instruct', {
+      const events = await gateway.stream!('claude-sonnet-4-6', {
         messages: [{ role: 'user', content: body.prompt }],
       })
-      return new Response(stream, {
-        headers: { 'Content-Type': 'text/event-stream' },
-      })
+      const encoder = new TextEncoder()
+      return new Response(
+        events.pipeThrough(new TransformStream({
+          transform(evt, ctrl) {
+            if (evt.type === 'text') ctrl.enqueue(encoder.encode(`data: ${evt.delta}\n\n`))
+            if (evt.type === 'done') ctrl.enqueue(encoder.encode('data: [DONE]\n\n'))
+          },
+        })),
+        { headers: { 'Content-Type': 'text/event-stream' } },
+      )
     }
 
-    // Non-streaming with fallback
-    const result = await fallback(env.AI, [
-      { model: '@cf/meta/llama-3.1-70b-instruct', timeout: 5000 },
-      { model: '@cf/meta/llama-3.1-8b-instruct', timeout: 10000 },
-    ], {
-      messages: [{ role: 'user', content: body.prompt }],
-    })
+    // Non-streaming with server-side fallback: CF tries Anthropic, then OpenAI
+    const result = await gateway.runFallback!(
+      [
+        { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+        { provider: 'openai',    model: 'gpt-4o' },
+      ],
+      { messages: [{ role: 'user', content: body.prompt }] },
+    )
 
     return Response.json({
-      response: result.data,
+      response: result.text,
+      provider: result.provider,
       model: result.model,
-      attempts: result.attempts,
+      usage: result.usage,
     })
   },
 }


### PR DESCRIPTION
## Summary

Updates the root README one-liner and the \`guides/ai-integration.md\` site page to reflect \`@workkit/ai-gateway@0.3.0\` (merged in #65, released via #66).

### Root README

\`@workkit/ai-gateway\` description now mentions streaming, fallback, retry, prompt caching, and Cloudflare AI Gateway support.

### Site guide — guides/ai-integration.md

- Intro rewritten: \`@workkit/ai-gateway\` is the recommended entry point; \`@workkit/ai\` is flagged for deprecation per ADR-001 (#62).
- New sections:
  - **Retry** — \`withRetry\` wrapper, error-driven retry strategies.
  - **Cloudflare AI Gateway** — \`cfGateway\` option, \`cf-aig-*\` headers.
  - **Server-side fallback** — \`gateway.runFallback\` against the CF Universal Endpoint.
  - **Anthropic prompt caching** — \`cacheControl: "ephemeral"\` on \`ChatMessage\`.
  - **Streaming** — \`gateway.stream()\` + the \`GatewayStreamEvent\` union, with a consumer example.
- "Full Example" rewritten to use \`createGateway\` + \`withRetry\` + \`withLogging\` and \`gateway.stream()\` / \`runFallback()\` in place of legacy \`streamAI\`/\`fallback\` imports from \`@workkit/ai\`.

## Test plan

- [x] \`bun run build\` in \`apps/docs\` — 31 pages, clean build, no broken links.
- [ ] CI: \`Lint\`, \`Constitution\`, \`Type Check\`.
- [ ] Visual pass on the rendered \`ai-integration\` page once the site deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)