### PR TITLE
feat(ai-gateway): embedding provider support

### DIFF
--- a/.changeset/ai-gateway-embeddings.md
+++ b/.changeset/ai-gateway-embeddings.md
@@ -22,6 +22,11 @@ Provider coverage:
 - **Anthropic** — throws `ValidationError` (no public embeddings endpoint).
 - **Custom** — delegates to user-supplied `embed?(model, input)` on the provider config; throws `ValidationError` if not implemented.
 
-Single-string input is normalized to a one-element array so callers can use either shape. `withCache`, `withLogging`, and `withRetry` each conditionally expose `embed` when the underlying gateway does. Additive — no breaking changes.
+Single-string input is normalized to a one-element array so callers can use either shape.
 
-This unblocks [#63](https://github.com/beeeku/workkit/issues/63) (`@workkit/ai` deprecation shim) and future `@workkit/memory` consolidation onto the gateway.
+**Wrapper integration:**
+- `withCache` — caches embeddings under a dedicated `ai-embed-cache:` key namespace so embedding and completion responses never collide. Keyed on `(model, input)`.
+- `withRetry` — retries retryable embed errors using the same error-driven strategy as `run`/`stream`.
+- `withLogging` — currently wires `onError` only for embeds; `onRequest` / `onResponse` are typed for `AiInput`/`AiOutput` and would need embed-specific callbacks to safely log embedding traffic (follow-up).
+
+Additive — no breaking changes. Unblocks future `@workkit/memory` consolidation onto the gateway.

--- a/.changeset/ai-gateway-embeddings.md
+++ b/.changeset/ai-gateway-embeddings.md
@@ -1,0 +1,27 @@
+---
+"@workkit/ai-gateway": minor
+---
+
+**Embeddings support.** New optional `gateway.embed(model, input, options?)` method returning a unified `EmbedOutput { vectors, raw, usage?, provider, model }`. Closes #69.
+
+```ts
+// Workers AI
+const { vectors } = await gateway.embed!("@cf/baai/bge-base-en-v1.5", {
+  text: ["chunk 1", "chunk 2"],
+});
+
+// OpenAI (with or without CF AI Gateway routing)
+const { vectors, usage } = await gateway.embed!("text-embedding-3-small", {
+  text: "hello",
+});
+```
+
+Provider coverage:
+- **Workers AI** — `binding.run(model, { text })`.
+- **OpenAI** — `POST /embeddings`, routes through `cfGateway` when configured, preserves vector order via `index` field.
+- **Anthropic** — throws `ValidationError` (no public embeddings endpoint).
+- **Custom** — delegates to user-supplied `embed?(model, input)` on the provider config; throws `ValidationError` if not implemented.
+
+Single-string input is normalized to a one-element array so callers can use either shape. `withCache`, `withLogging`, and `withRetry` each conditionally expose `embed` when the underlying gateway does. Additive — no breaking changes.
+
+This unblocks [#63](https://github.com/beeeku/workkit/issues/63) (`@workkit/ai` deprecation shim) and future `@workkit/memory` consolidation onto the gateway.

--- a/packages/ai-gateway/src/cache.ts
+++ b/packages/ai-gateway/src/cache.ts
@@ -1,9 +1,23 @@
 import { ConfigError } from "@workkit/errors";
-import type { AiInput, AiOutput, CacheConfig, CachedGateway, Gateway, RunOptions } from "./types";
+import type {
+	AiInput,
+	AiOutput,
+	CacheConfig,
+	CachedGateway,
+	EmbedInput,
+	EmbedOutput,
+	Gateway,
+	RunOptions,
+} from "./types";
 
 /** Default hash function: deterministic JSON stringify */
 function defaultHashFn(model: string, input: AiInput): string {
 	return `ai-cache:${model}:${stableStringify(input)}`;
+}
+
+/** Dedicated cache-key namespace for embeddings (separate from `run` outputs). */
+function embedCacheKey(model: string, input: EmbedInput): string {
+	return `ai-embed-cache:${model}:${stableStringify(input)}`;
 }
 
 /** Stable JSON.stringify — sorts object keys for determinism */
@@ -94,9 +108,26 @@ export function withCache(gateway: Gateway, config: CacheConfig): CachedGateway 
 		// Streams are not cached — each call hits the upstream gateway.
 		stream: gateway.stream?.bind(gateway),
 
-		// Embeddings pass through; a dedicated embedding cache keyed on
-		// (model, text) is a future enhancement.
-		embed: gateway.embed?.bind(gateway),
+		// Embedding cache — keyed on (model, input) with its own namespace so
+		// completion and embedding responses never collide.
+		embed: gateway.embed
+			? async (model, input, options) => {
+					const cacheKey = embedCacheKey(model, input);
+					const cached = await config.storage.get(cacheKey, { type: "text" });
+					if (cached !== null) {
+						try {
+							return JSON.parse(cached) as EmbedOutput;
+						} catch {
+							// Corrupted cache entry — fall through to provider.
+						}
+					}
+					const result = await gateway.embed!(model, input, options);
+					await config.storage.put(cacheKey, JSON.stringify(result), {
+						expirationTtl: ttl,
+					});
+					return result;
+				}
+			: undefined,
 
 		providers(): string[] {
 			return gateway.providers();

--- a/packages/ai-gateway/src/cache.ts
+++ b/packages/ai-gateway/src/cache.ts
@@ -94,6 +94,10 @@ export function withCache(gateway: Gateway, config: CacheConfig): CachedGateway 
 		// Streams are not cached — each call hits the upstream gateway.
 		stream: gateway.stream?.bind(gateway),
 
+		// Embeddings pass through; a dedicated embedding cache keyed on
+		// (model, text) is a future enhancement.
+		embed: gateway.embed?.bind(gateway),
+
 		providers(): string[] {
 			return gateway.providers();
 		},

--- a/packages/ai-gateway/src/gateway.ts
+++ b/packages/ai-gateway/src/gateway.ts
@@ -2,6 +2,7 @@ import { ConfigError, ServiceUnavailableError, ValidationError } from "@workkit/
 import { buildFallbackBodyEntry, normalizeFallbackResponse } from "./fallback";
 import { executeAnthropic } from "./providers/anthropic";
 import { executeCustom } from "./providers/custom";
+import { executeEmbed } from "./providers/embed";
 import { executeOpenAi } from "./providers/openai";
 import { cfGatewayHeaders, resolveBaseUrl, withTimeoutSignal } from "./providers/shared";
 import { executeWorkersAi } from "./providers/workers-ai";
@@ -10,6 +11,8 @@ import type {
 	AiInput,
 	AiOutput,
 	CfGatewayConfig,
+	EmbedInput,
+	EmbedOutput,
 	FallbackEntry,
 	Gateway,
 	GatewayConfig,
@@ -226,6 +229,34 @@ export function createGateway<P extends ProviderMap>(config: GatewayConfig<P>): 
 					),
 				cfGatewayHeaders,
 			);
+		},
+
+		async embed(model: string, input: EmbedInput, options?: RunOptions): Promise<EmbedOutput> {
+			if (!model) {
+				throw new ValidationError("Model name is required", [
+					{ path: ["model"], message: "Model name cannot be empty" },
+				]);
+			}
+			const providerKey = options?.provider ?? config.defaultProvider;
+			const providerConfig = config.providers[providerKey];
+			if (!providerConfig) {
+				throw new ConfigError(`Provider "${providerKey}" not found`, {
+					context: { provider: providerKey, available: providerNames },
+				});
+			}
+			const { signal, cleanup } = withTimeoutSignal(options);
+			try {
+				return await executeEmbed(
+					providerKey,
+					providerConfig,
+					model,
+					input,
+					signal ? { ...options, signal } : options,
+					config.cfGateway,
+				);
+			} finally {
+				cleanup();
+			}
 		},
 
 		providers(): string[] {

--- a/packages/ai-gateway/src/index.ts
+++ b/packages/ai-gateway/src/index.ts
@@ -34,6 +34,8 @@ export type {
 	CfGatewayConfig,
 	FallbackEntry,
 	GatewayStreamEvent,
+	EmbedInput,
+	EmbedOutput,
 	AiInput,
 	AiOutput,
 	ChatMessage,

--- a/packages/ai-gateway/src/logging.ts
+++ b/packages/ai-gateway/src/logging.ts
@@ -81,11 +81,7 @@ export function withLogging(gateway: Gateway, config: LoggingConfig): LoggedGate
 			: undefined,
 
 		embed: innerEmbed
-			? async (
-					model: string,
-					input: EmbedInput,
-					options?: RunOptions,
-				): Promise<EmbedOutput> => {
+			? async (model: string, input: EmbedInput, options?: RunOptions): Promise<EmbedOutput> => {
 					config.onRequest?.(model, input as unknown as AiInput);
 					const start = Date.now();
 					try {

--- a/packages/ai-gateway/src/logging.ts
+++ b/packages/ai-gateway/src/logging.ts
@@ -80,28 +80,15 @@ export function withLogging(gateway: Gateway, config: LoggingConfig): LoggedGate
 				}
 			: undefined,
 
+		// Embedding calls log errors only — `onRequest` and `onResponse` in
+		// `LoggingConfig` are typed for `AiInput`/`AiOutput`, so feeding them
+		// `EmbedInput`/`EmbedOutput` would require an unsafe cast. Callers who
+		// want embedding-request observability can wrap the gateway themselves
+		// or subscribe via a future `onEmbedRequest` hook.
 		embed: innerEmbed
 			? async (model: string, input: EmbedInput, options?: RunOptions): Promise<EmbedOutput> => {
-					config.onRequest?.(model, input as unknown as AiInput);
-					const start = Date.now();
 					try {
-						const result = await innerEmbed(model, input, options);
-						// Log via onResponse using a synthetic AiOutput-shaped object so
-						// existing handlers keep working. usage is preserved.
-						config.onResponse?.(
-							model,
-							{
-								text: undefined,
-								raw: result.raw,
-								usage: result.usage
-									? { inputTokens: result.usage.inputTokens, outputTokens: 0 }
-									: undefined,
-								provider: result.provider,
-								model: result.model,
-							},
-							Date.now() - start,
-						);
-						return result;
+						return await innerEmbed(model, input, options);
 					} catch (err) {
 						config.onError?.(model, err);
 						throw err;

--- a/packages/ai-gateway/src/logging.ts
+++ b/packages/ai-gateway/src/logging.ts
@@ -1,6 +1,8 @@
 import type {
 	AiInput,
 	AiOutput,
+	EmbedInput,
+	EmbedOutput,
 	FallbackEntry,
 	Gateway,
 	LoggedGateway,
@@ -26,6 +28,7 @@ import type {
 export function withLogging(gateway: Gateway, config: LoggingConfig): LoggedGateway {
 	const innerFallback = gateway.runFallback?.bind(gateway);
 	const innerStream = gateway.stream?.bind(gateway);
+	const innerEmbed = gateway.embed?.bind(gateway);
 
 	return {
 		async run(model: string, input: AiInput, options?: RunOptions): Promise<AiOutput> {
@@ -70,6 +73,39 @@ export function withLogging(gateway: Gateway, config: LoggingConfig): LoggedGate
 					config.onRequest?.(model, input);
 					try {
 						return await innerStream(model, input, options);
+					} catch (err) {
+						config.onError?.(model, err);
+						throw err;
+					}
+				}
+			: undefined,
+
+		embed: innerEmbed
+			? async (
+					model: string,
+					input: EmbedInput,
+					options?: RunOptions,
+				): Promise<EmbedOutput> => {
+					config.onRequest?.(model, input as unknown as AiInput);
+					const start = Date.now();
+					try {
+						const result = await innerEmbed(model, input, options);
+						// Log via onResponse using a synthetic AiOutput-shaped object so
+						// existing handlers keep working. usage is preserved.
+						config.onResponse?.(
+							model,
+							{
+								text: undefined,
+								raw: result.raw,
+								usage: result.usage
+									? { inputTokens: result.usage.inputTokens, outputTokens: 0 }
+									: undefined,
+								provider: result.provider,
+								model: result.model,
+							},
+							Date.now() - start,
+						);
+						return result;
 					} catch (err) {
 						config.onError?.(model, err);
 						throw err;

--- a/packages/ai-gateway/src/providers/embed.ts
+++ b/packages/ai-gateway/src/providers/embed.ts
@@ -43,7 +43,10 @@ async function embedWorkersAi(
 ): Promise<EmbedOutput> {
 	const texts = toArray(input);
 	try {
-		const raw = (await providerConfig.binding.run(model, { text: texts })) as Record<string, unknown>;
+		const raw = (await providerConfig.binding.run(model, { text: texts })) as Record<
+			string,
+			unknown
+		>;
 		const data = Array.isArray(raw?.data) ? (raw.data as number[][]) : [];
 		return {
 			vectors: data,

--- a/packages/ai-gateway/src/providers/embed.ts
+++ b/packages/ai-gateway/src/providers/embed.ts
@@ -1,4 +1,4 @@
-import { ServiceUnavailableError, ValidationError } from "@workkit/errors";
+import { ServiceUnavailableError, TimeoutError, ValidationError } from "@workkit/errors";
 import type {
 	AnthropicProviderConfig,
 	CfGatewayConfig,
@@ -79,6 +79,7 @@ async function embedOpenAi(
 		"https://api.openai.com/v1",
 	);
 	const texts = toArray(input);
+	const signal = options?.signal;
 	try {
 		const response = await fetch(`${baseUrl}/embeddings`, {
 			method: "POST",
@@ -88,7 +89,7 @@ async function embedOpenAi(
 				...cfGatewayHeaders(cfGateway),
 			},
 			body: JSON.stringify({ model, input: texts }),
-			signal: options?.signal,
+			signal,
 		});
 
 		if (!response.ok) {
@@ -100,12 +101,17 @@ async function embedOpenAi(
 
 		const raw = (await response.json()) as Record<string, unknown>;
 		const data = raw.data as Array<{ embedding: number[]; index?: number }> | undefined;
-		// Sort by index when provided so vectors stay aligned with inputs even
-		// if the provider returns them out of order.
-		const sorted = Array.isArray(data)
-			? [...data].sort((a, b) => (a.index ?? 0) - (b.index ?? 0))
+		// If every item has an `index`, sort by it so vectors stay aligned even
+		// when a provider returns them out of order. If any item lacks `index`,
+		// preserve response order (treating "missing" as 0 would reorder items
+		// ahead of legitimately-indexed ones).
+		const allIndexed = Array.isArray(data) && data.every((d) => typeof d.index === "number");
+		const ordered = Array.isArray(data)
+			? allIndexed
+				? [...data].sort((a, b) => (a.index as number) - (b.index as number))
+				: data
 			: [];
-		const vectors = sorted.map((d) => d.embedding);
+		const vectors = ordered.map((d) => d.embedding);
 		const usage = raw.usage as Record<string, unknown> | undefined;
 		const inputTokens =
 			usage && typeof usage.prompt_tokens === "number" ? usage.prompt_tokens : undefined;
@@ -118,6 +124,18 @@ async function embedOpenAi(
 		};
 	} catch (err) {
 		if (err instanceof ServiceUnavailableError) throw err;
+		// Match executeOpenAi's abort handling: only classify as TimeoutError
+		// when the caller set a timeout; rethrow bare user-aborts as-is so
+		// withRetry doesn't treat user cancellations as retryable.
+		if (signal?.aborted) {
+			if (options?.timeout !== undefined) {
+				throw new TimeoutError(`openai embed for ${model}`, options.timeout, {
+					cause: err,
+					context: { provider: providerName, model },
+				});
+			}
+			throw err;
+		}
 		throw new ServiceUnavailableError("openai embed", {
 			cause: err,
 			context: { provider: providerName, model },

--- a/packages/ai-gateway/src/providers/embed.ts
+++ b/packages/ai-gateway/src/providers/embed.ts
@@ -1,0 +1,171 @@
+import { ServiceUnavailableError, ValidationError } from "@workkit/errors";
+import type {
+	AnthropicProviderConfig,
+	CfGatewayConfig,
+	CustomProviderConfig,
+	EmbedInput,
+	EmbedOutput,
+	OpenAiProviderConfig,
+	ProviderConfig,
+	RunOptions,
+	WorkersAiProviderConfig,
+} from "../types";
+import { cfGatewayHeaders, resolveBaseUrl } from "./shared";
+
+/** Dispatch an embed request to the appropriate provider implementation. */
+export async function executeEmbed(
+	providerName: string,
+	providerConfig: ProviderConfig,
+	model: string,
+	input: EmbedInput,
+	options: RunOptions | undefined,
+	cfGateway: CfGatewayConfig | undefined,
+): Promise<EmbedOutput> {
+	switch (providerConfig.type) {
+		case "workers-ai":
+			return embedWorkersAi(providerName, providerConfig, model, input);
+		case "openai":
+			return embedOpenAi(providerName, providerConfig, model, input, options, cfGateway);
+		case "anthropic":
+			return embedAnthropic(providerName, providerConfig);
+		case "custom":
+			return embedCustom(providerName, providerConfig, model, input);
+	}
+}
+
+// ─── Workers AI ──────────────────────────────────────────────
+
+async function embedWorkersAi(
+	providerName: string,
+	providerConfig: WorkersAiProviderConfig,
+	model: string,
+	input: EmbedInput,
+): Promise<EmbedOutput> {
+	const texts = toArray(input);
+	try {
+		const raw = (await providerConfig.binding.run(model, { text: texts })) as Record<string, unknown>;
+		const data = Array.isArray(raw?.data) ? (raw.data as number[][]) : [];
+		return {
+			vectors: data,
+			raw,
+			provider: providerName,
+			model,
+		};
+	} catch (err) {
+		throw new ServiceUnavailableError("workers-ai embed", {
+			cause: err,
+			context: { provider: providerName, model },
+		});
+	}
+}
+
+// ─── OpenAI ──────────────────────────────────────────────────
+
+async function embedOpenAi(
+	providerName: string,
+	providerConfig: OpenAiProviderConfig,
+	model: string,
+	input: EmbedInput,
+	options: RunOptions | undefined,
+	cfGateway: CfGatewayConfig | undefined,
+): Promise<EmbedOutput> {
+	const baseUrl = resolveBaseUrl(
+		"openai",
+		providerConfig.baseUrl,
+		cfGateway,
+		"https://api.openai.com/v1",
+	);
+	const texts = toArray(input);
+	try {
+		const response = await fetch(`${baseUrl}/embeddings`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${providerConfig.apiKey}`,
+				...cfGatewayHeaders(cfGateway),
+			},
+			body: JSON.stringify({ model, input: texts }),
+			signal: options?.signal,
+		});
+
+		if (!response.ok) {
+			const errorBody = await response.text().catch(() => "unknown error");
+			throw new ServiceUnavailableError(`openai embed (${response.status})`, {
+				context: { provider: providerName, model, status: response.status, body: errorBody },
+			});
+		}
+
+		const raw = (await response.json()) as Record<string, unknown>;
+		const data = raw.data as Array<{ embedding: number[]; index?: number }> | undefined;
+		// Sort by index when provided so vectors stay aligned with inputs even
+		// if the provider returns them out of order.
+		const sorted = Array.isArray(data)
+			? [...data].sort((a, b) => (a.index ?? 0) - (b.index ?? 0))
+			: [];
+		const vectors = sorted.map((d) => d.embedding);
+		const usage = raw.usage as Record<string, unknown> | undefined;
+		const inputTokens =
+			usage && typeof usage.prompt_tokens === "number" ? usage.prompt_tokens : undefined;
+		return {
+			vectors,
+			raw,
+			usage: inputTokens !== undefined ? { inputTokens } : undefined,
+			provider: providerName,
+			model,
+		};
+	} catch (err) {
+		if (err instanceof ServiceUnavailableError) throw err;
+		throw new ServiceUnavailableError("openai embed", {
+			cause: err,
+			context: { provider: providerName, model },
+		});
+	}
+}
+
+// ─── Anthropic ──────────────────────────────────────────────
+
+function embedAnthropic(
+	providerName: string,
+	_providerConfig: AnthropicProviderConfig,
+): Promise<EmbedOutput> {
+	// Anthropic does not expose a public embeddings endpoint. Fail loudly.
+	throw new ValidationError("Anthropic does not support embeddings", [
+		{
+			path: ["provider", providerName],
+			message: "Use Workers AI (bge-*) or OpenAI (text-embedding-*) for embeddings.",
+		},
+	]);
+}
+
+// ─── Custom ─────────────────────────────────────────────────
+
+async function embedCustom(
+	providerName: string,
+	providerConfig: CustomProviderConfig,
+	model: string,
+	input: EmbedInput,
+): Promise<EmbedOutput> {
+	if (!providerConfig.embed) {
+		throw new ValidationError(`custom provider "${providerName}" does not implement embed()`, [
+			{
+				path: ["provider", providerName],
+				message: "Supply `embed: (model, input) => EmbedOutput` on the provider config.",
+			},
+		]);
+	}
+	try {
+		return await providerConfig.embed(model, input);
+	} catch (err) {
+		throw new ServiceUnavailableError(`custom provider "${providerName}" embed`, {
+			cause: err,
+			context: { provider: providerName, model },
+		});
+	}
+}
+
+// ─── Helpers ────────────────────────────────────────────────
+
+function toArray(input: EmbedInput): string[] {
+	if (Array.isArray(input.text)) return input.text;
+	return [input.text];
+}

--- a/packages/ai-gateway/src/retry.ts
+++ b/packages/ai-gateway/src/retry.ts
@@ -1,5 +1,5 @@
 import { getRetryDelay, getRetryStrategy, isRetryable } from "@workkit/errors";
-import type { AiInput, FallbackEntry, Gateway, RunOptions } from "./types";
+import type { AiInput, EmbedInput, FallbackEntry, Gateway, RunOptions } from "./types";
 
 /** Options for `withRetry`. */
 export interface RetryConfig {
@@ -39,6 +39,7 @@ export function withRetry(gateway: Gateway, config?: RetryConfig): Gateway {
 
 	const innerFallback = gateway.runFallback?.bind(gateway);
 	const innerStream = gateway.stream?.bind(gateway);
+	const innerEmbed = gateway.embed?.bind(gateway);
 
 	return {
 		run: (model, input, options) =>
@@ -53,6 +54,10 @@ export function withRetry(gateway: Gateway, config?: RetryConfig): Gateway {
 		stream: innerStream
 			? (model: string, input: AiInput, options?: RunOptions) =>
 					retry(() => innerStream(model, input, options), options?.signal)
+			: undefined,
+		embed: innerEmbed
+			? (model: string, input: EmbedInput, options?: RunOptions) =>
+					retry(() => innerEmbed(model, input, options), options?.signal)
 			: undefined,
 		providers: () => gateway.providers(),
 		defaultProvider: () => gateway.defaultProvider(),

--- a/packages/ai-gateway/src/types.ts
+++ b/packages/ai-gateway/src/types.ts
@@ -239,10 +239,17 @@ export interface Gateway {
 	/**
 	 * Generate embeddings for one or more strings.
 	 *
-	 * Returns a `vectors` array with one embedding per input, in order. Optional —
-	 * present on gateways returned by `createGateway` when the chosen provider
-	 * supports embeddings (Workers AI, OpenAI). Anthropic throws a
-	 * `ValidationError` since it has no public embeddings endpoint.
+	 * Returns a `vectors` array with one embedding per input, in order. Always
+	 * present on gateways from `createGateway`. Whether a given call succeeds
+	 * depends on the target provider:
+	 *  - Workers AI and OpenAI — supported.
+	 *  - Anthropic — throws `ValidationError` (no public embeddings endpoint).
+	 *  - Custom — delegates to `CustomProviderConfig.embed?`; throws
+	 *    `ValidationError` if the provider config doesn't supply one.
+	 *
+	 * Optional on the `Gateway` interface so third-party implementers aren't
+	 * forced to add it; wrappers (`withRetry`, `withCache`, `withLogging`)
+	 * conditionally expose it when the underlying gateway does.
 	 */
 	embed?(model: string, input: EmbedInput, options?: RunOptions): Promise<EmbedOutput>;
 	/** List configured providers */

--- a/packages/ai-gateway/src/types.ts
+++ b/packages/ai-gateway/src/types.ts
@@ -37,6 +37,8 @@ export interface AnthropicProviderConfig extends BaseProviderConfig {
 export interface CustomProviderConfig extends BaseProviderConfig {
 	type: "custom";
 	run: (model: string, input: AiInput) => Promise<AiOutput>;
+	/** Optional embedding handler. When absent, `gateway.embed()` rejects. */
+	embed?: (model: string, input: EmbedInput) => Promise<EmbedOutput>;
 }
 
 /** Union of all provider configs */
@@ -166,6 +168,23 @@ export interface FallbackEntry {
 	model: string;
 }
 
+/** Input to an embedding request — a single string or an array to batch. */
+export type EmbedInput = { text: string } | { text: string[] };
+
+/** Output from an embedding request. */
+export interface EmbedOutput {
+	/** One embedding vector per input string, in input order. */
+	vectors: number[][];
+	/** Raw provider response for debugging. */
+	raw: unknown;
+	/** Token usage if the provider reports it. */
+	usage?: { inputTokens: number };
+	/** Provider that handled the request. */
+	provider: string;
+	/** Model used. */
+	model: string;
+}
+
 /**
  * Unified streaming event shape across providers.
  *
@@ -217,6 +236,15 @@ export interface Gateway {
 		input: AiInput,
 		options?: RunOptions,
 	): Promise<ReadableStream<GatewayStreamEvent>>;
+	/**
+	 * Generate embeddings for one or more strings.
+	 *
+	 * Returns a `vectors` array with one embedding per input, in order. Optional —
+	 * present on gateways returned by `createGateway` when the chosen provider
+	 * supports embeddings (Workers AI, OpenAI). Anthropic throws a
+	 * `ValidationError` since it has no public embeddings endpoint.
+	 */
+	embed?(model: string, input: EmbedInput, options?: RunOptions): Promise<EmbedOutput>;
 	/** List configured providers */
 	providers(): string[];
 	/** Get the default provider name */

--- a/packages/ai-gateway/tests/embed.test.ts
+++ b/packages/ai-gateway/tests/embed.test.ts
@@ -1,0 +1,146 @@
+import { ValidationError } from "@workkit/errors";
+import { describe, expect, it, vi } from "vitest";
+import { createGateway } from "../src/gateway";
+
+function mockHttp(body: Record<string, unknown>, status = 200) {
+	return vi.fn().mockResolvedValue({
+		ok: status >= 200 && status < 300,
+		status,
+		json: () => Promise.resolve(body),
+		text: () => Promise.resolve(JSON.stringify(body)),
+	});
+}
+
+describe("gateway.embed() — Workers AI", () => {
+	it("wraps binding.run response into EmbedOutput", async () => {
+		const run = vi.fn().mockResolvedValue({
+			shape: [2, 3],
+			data: [
+				[0.1, 0.2, 0.3],
+				[0.4, 0.5, 0.6],
+			],
+		});
+		const gw = createGateway({
+			providers: { ai: { type: "workers-ai", binding: { run } } },
+			defaultProvider: "ai",
+		});
+
+		const result = await gw.embed!("@cf/baai/bge-base-en-v1.5", { text: ["hi", "there"] });
+
+		expect(run).toHaveBeenCalledWith("@cf/baai/bge-base-en-v1.5", { text: ["hi", "there"] });
+		expect(result.vectors).toEqual([
+			[0.1, 0.2, 0.3],
+			[0.4, 0.5, 0.6],
+		]);
+		expect(result.provider).toBe("ai");
+		expect(result.model).toBe("@cf/baai/bge-base-en-v1.5");
+	});
+
+	it("normalizes single-string input to an array", async () => {
+		const run = vi.fn().mockResolvedValue({ shape: [1, 3], data: [[0.1, 0.2, 0.3]] });
+		const gw = createGateway({
+			providers: { ai: { type: "workers-ai", binding: { run } } },
+			defaultProvider: "ai",
+		});
+
+		const result = await gw.embed!("@cf/baai/bge-base-en-v1.5", { text: "hi" });
+
+		expect(run.mock.calls[0][1]).toEqual({ text: ["hi"] });
+		expect(result.vectors).toHaveLength(1);
+	});
+});
+
+describe("gateway.embed() — OpenAI", () => {
+	it("POSTs to /embeddings and translates the response", async () => {
+		const fetchMock = mockHttp({
+			data: [
+				{ embedding: [0.1, 0.2], index: 0 },
+				{ embedding: [0.3, 0.4], index: 1 },
+			],
+			usage: { prompt_tokens: 8 },
+		});
+		globalThis.fetch = fetchMock;
+
+		const gw = createGateway({
+			providers: { openai: { type: "openai", apiKey: "k" } },
+			defaultProvider: "openai",
+		});
+
+		const result = await gw.embed!("text-embedding-3-small", { text: ["hi", "there"] });
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(fetchMock.mock.calls[0][0]).toBe("https://api.openai.com/v1/embeddings");
+		const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+		expect(body).toEqual({ model: "text-embedding-3-small", input: ["hi", "there"] });
+		expect(result.vectors).toEqual([
+			[0.1, 0.2],
+			[0.3, 0.4],
+		]);
+		expect(result.usage).toEqual({ inputTokens: 8 });
+	});
+
+	it("routes through CF AI Gateway when cfGateway is set", async () => {
+		const fetchMock = mockHttp({ data: [{ embedding: [0.1], index: 0 }] });
+		globalThis.fetch = fetchMock;
+
+		const gw = createGateway({
+			providers: { openai: { type: "openai", apiKey: "k" } },
+			cfGateway: { accountId: "ACCT", gatewayId: "GW" },
+			defaultProvider: "openai",
+		});
+
+		await gw.embed!("text-embedding-3-small", { text: "hi" });
+
+		expect(fetchMock.mock.calls[0][0]).toBe(
+			"https://gateway.ai.cloudflare.com/v1/ACCT/GW/openai/embeddings",
+		);
+	});
+});
+
+describe("gateway.embed() — Anthropic + custom", () => {
+	it("throws ValidationError for Anthropic (no embeddings endpoint)", async () => {
+		const gw = createGateway({
+			providers: { anthropic: { type: "anthropic", apiKey: "k" } },
+			defaultProvider: "anthropic",
+		});
+
+		await expect(gw.embed!("x", { text: "hi" })).rejects.toThrow(ValidationError);
+	});
+
+	it("delegates to custom provider embed() when present", async () => {
+		const embed = vi
+			.fn()
+			.mockResolvedValue({
+				vectors: [[0.5]],
+				raw: {},
+				provider: "custom",
+				model: "x",
+			});
+		const gw = createGateway({
+			providers: {
+				custom: {
+					type: "custom",
+					run: vi.fn(),
+					embed,
+				},
+			},
+			defaultProvider: "custom",
+		});
+
+		const result = await gw.embed!("x", { text: "hi" });
+
+		expect(embed).toHaveBeenCalledWith("x", { text: "hi" });
+		expect(result.vectors).toEqual([[0.5]]);
+	});
+
+	it("throws ValidationError for custom provider without embed()", async () => {
+		const gw = createGateway({
+			providers: {
+				custom: { type: "custom", run: vi.fn() },
+			},
+			defaultProvider: "custom",
+		});
+
+		await expect(gw.embed!("x", { text: "hi" })).rejects.toThrow(ValidationError);
+	});
+});

--- a/packages/ai-gateway/tests/embed.test.ts
+++ b/packages/ai-gateway/tests/embed.test.ts
@@ -1,6 +1,23 @@
-import { ValidationError } from "@workkit/errors";
+import { ServiceUnavailableError, ValidationError } from "@workkit/errors";
 import { describe, expect, it, vi } from "vitest";
+import { withCache } from "../src/cache";
 import { createGateway } from "../src/gateway";
+import { withRetry } from "../src/retry";
+import type { CacheStorage } from "../src/types";
+
+function createMockStorage(): CacheStorage & { _store: Map<string, string> } {
+	const store = new Map<string, string>();
+	return {
+		_store: store,
+		get: vi.fn(async (key: string) => store.get(key) ?? null),
+		put: vi.fn(async (key: string, value: string) => {
+			store.set(key, value);
+		}),
+		delete: vi.fn(async (key: string) => {
+			store.delete(key);
+		}),
+	};
+}
 
 function mockHttp(body: Record<string, unknown>, status = 200) {
 	return vi.fn().mockResolvedValue({
@@ -94,6 +111,53 @@ describe("gateway.embed() — OpenAI", () => {
 		expect(fetchMock.mock.calls[0][0]).toBe(
 			"https://gateway.ai.cloudflare.com/v1/ACCT/GW/openai/embeddings",
 		);
+	});
+});
+
+describe("gateway.embed() — withCache", () => {
+	it("caches embedding responses by (model, input) with a dedicated namespace", async () => {
+		const run = vi.fn().mockResolvedValue({ shape: [1, 3], data: [[0.1, 0.2, 0.3]] });
+		const gw = createGateway({
+			providers: { ai: { type: "workers-ai", binding: { run } } },
+			defaultProvider: "ai",
+		});
+		const storage = createMockStorage();
+		const cached = withCache(gw, { storage, ttl: 60 });
+
+		const first = await cached.embed!("@cf/baai/bge-base-en-v1.5", { text: "hi" });
+		const second = await cached.embed!("@cf/baai/bge-base-en-v1.5", { text: "hi" });
+
+		expect(run).toHaveBeenCalledTimes(1); // 2nd call hit cache
+		expect(second.vectors).toEqual(first.vectors);
+		// Embedding cache uses its own key namespace (prevents collision with run/).
+		const keys = [...storage._store.keys()];
+		expect(keys.every((k) => k.startsWith("ai-embed-cache:"))).toBe(true);
+	});
+});
+
+describe("gateway.embed() — withRetry", () => {
+	it("retries retryable embed errors and succeeds", async () => {
+		let calls = 0;
+		const gw = createGateway({
+			providers: {
+				ai: {
+					type: "workers-ai",
+					binding: {
+						run: vi.fn(async () => {
+							calls++;
+							if (calls === 1) throw new ServiceUnavailableError("boom");
+							return { shape: [1, 1], data: [[0.9]] };
+						}),
+					},
+				},
+			},
+			defaultProvider: "ai",
+		});
+
+		const result = await withRetry(gw, { maxAttempts: 2 }).embed!("m", { text: "hi" });
+
+		expect(calls).toBe(2);
+		expect(result.vectors).toEqual([[0.9]]);
 	});
 });
 

--- a/packages/ai-gateway/tests/embed.test.ts
+++ b/packages/ai-gateway/tests/embed.test.ts
@@ -108,14 +108,12 @@ describe("gateway.embed() — Anthropic + custom", () => {
 	});
 
 	it("delegates to custom provider embed() when present", async () => {
-		const embed = vi
-			.fn()
-			.mockResolvedValue({
-				vectors: [[0.5]],
-				raw: {},
-				provider: "custom",
-				model: "x",
-			});
+		const embed = vi.fn().mockResolvedValue({
+			vectors: [[0.5]],
+			raw: {},
+			provider: "custom",
+			model: "x",
+		});
 		const gw = createGateway({
 			providers: {
 				custom: {


### PR DESCRIPTION
Closes #69. Adds `Gateway.embed()` across Workers AI + OpenAI + custom providers. Anthropic throws `ValidationError`. Supports CF AI Gateway routing for OpenAI; wrappers conditionally expose `embed`. 7 tests, 189/189 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added embeddings functionality with a new `embed()` method to the AI Gateway.
  * Supported across multiple AI providers including Workers AI, OpenAI, and custom implementations.
  * Returns embeddings with vectors, metadata, and optional token usage information.
  * Accepts both single and batch text inputs.

* **Tests**
  * Added comprehensive test coverage for embeddings across all supported providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->