### PR TITLE
feat(agent): stream text-deltas per token

### DIFF
--- a/.changeset/agent-streaming-loop.md
+++ b/.changeset/agent-streaming-loop.md
@@ -1,0 +1,23 @@
+---
+"@workkit/agent": minor
+---
+
+**Streaming text via `agent.stream()`.** When the configured gateway exposes `gateway.stream()` (i.e. `@workkit/ai-gateway@>=0.3.0` with a streaming-capable provider), the agent loop now streams each model step and emits `text-delta` events per token as they arrive, instead of once per step with the full text. Closes #68.
+
+```ts
+const agent = defineAgent({ provider: gateway, /* … */ })
+
+for await (const event of agent.stream({ messages })) {
+  if (event.type === "text-delta") process.stdout.write(event.delta)
+  if (event.type === "tool-start") console.log("tool:", event.call.name)
+  if (event.type === "done") console.log("stopped:", event.stopReason)
+}
+```
+
+Behavior:
+- If `gateway.stream` exists, each step uses it; text deltas arrive as the model produces them.
+- If `gateway.stream` is not implemented, falls back to `gateway.run` and synthesizes a single `text-delta` per step (matches pre-0.2.x behavior).
+- Tool calls collected from the stream's `tool_use` events are dispatched by the loop exactly as before — hooks, handoffs, and stop reasons are unchanged.
+- `options.signal` and `stopWhen` cap streaming the same way they cap non-streaming.
+
+No breaking changes; public `AgentEvent` shape is unchanged.

--- a/packages/agent/src/loop.ts
+++ b/packages/agent/src/loop.ts
@@ -3,6 +3,7 @@ import { ToolValidationError } from "./errors";
 import type { AgentEvent } from "./events";
 import { HANDOFF_HOP_LIMIT } from "./handoff";
 import { toJsonSchema } from "./schema";
+import { runStep } from "./stream-step";
 import { runTool } from "./tool";
 import type {
 	Agent,
@@ -136,10 +137,12 @@ export async function runLoop(args: RunLoopArgs): Promise<{
 
 		let output: import("@workkit/ai-gateway").AiOutput;
 		try {
-			output = await currentAgent.provider.run(
-				currentAgent.model,
+			output = await runStep(
+				currentAgent,
 				{ messages: toChatMessages(messages, currentAgent.instructions) },
 				runOptions,
+				step,
+				emit,
 			);
 		} catch (error) {
 			emit({ type: "error", error: { kind: "provider", message: errorMessage(error) } });
@@ -169,7 +172,9 @@ export async function runLoop(args: RunLoopArgs): Promise<{
 		};
 		messages = [...messages, assistantMessage];
 
-		if (text.length > 0) emit({ type: "text-delta", delta: text, step });
+		// `runStep` already emitted per-token `text-delta` events when streaming
+		// (or a single synthesized one on the non-streaming path), so we don't
+		// re-emit here.
 		emit({ type: "step-complete", step, usage, assistant: assistantMessage });
 
 		const toolCalls: GatewayToolCall[] = output.toolCalls ?? [];

--- a/packages/agent/src/stream-step.ts
+++ b/packages/agent/src/stream-step.ts
@@ -1,0 +1,64 @@
+import type { AiInput, AiOutput, GatewayStreamEvent, RunOptions } from "@workkit/ai-gateway";
+import type { AgentEvent } from "./events";
+import type { InternalAgentDef } from "./loop";
+
+/**
+ * Run a single model step against the provider, returning an `AiOutput`
+ * while emitting per-token `text-delta` events via `emit`.
+ *
+ * When `provider.stream` is available, the underlying call is a streaming
+ * SSE request and text arrives token-by-token. When it isn't, we fall back
+ * to `provider.run` and emit a single synthesized `text-delta` with the
+ * full text at the end of the step (preserves the non-streaming agent UX
+ * as a graceful degradation).
+ */
+export async function runStep(
+	currentAgent: InternalAgentDef,
+	input: AiInput,
+	runOptions: RunOptions,
+	step: number,
+	emit: (e: AgentEvent) => void,
+): Promise<AiOutput> {
+	if (!currentAgent.provider.stream) {
+		// Non-streaming fallback: emit the whole text as one delta at the end.
+		const output = await currentAgent.provider.run(currentAgent.model, input, runOptions);
+		const text = output.text ?? "";
+		if (text.length > 0) emit({ type: "text-delta", delta: text, step });
+		return output;
+	}
+
+	const stream = await currentAgent.provider.stream(currentAgent.model, input, runOptions);
+	const reader = stream.getReader();
+	const toolCalls: NonNullable<AiOutput["toolCalls"]> = [];
+	let text = "";
+	let usage: AiOutput["usage"] | undefined;
+	let raw: unknown;
+
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			const event: GatewayStreamEvent = value;
+			if (event.type === "text") {
+				text += event.delta;
+				emit({ type: "text-delta", delta: event.delta, step });
+			} else if (event.type === "tool_use") {
+				toolCalls.push({ id: event.id, name: event.name, arguments: event.input });
+			} else if (event.type === "done") {
+				usage = event.usage;
+				raw = event.raw;
+			}
+		}
+	} finally {
+		reader.releaseLock();
+	}
+
+	return {
+		text: text.length > 0 ? text : undefined,
+		raw,
+		usage,
+		provider: currentAgent.provider.defaultProvider(),
+		model: currentAgent.model,
+		toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+	};
+}

--- a/packages/agent/tests/_mocks.ts
+++ b/packages/agent/tests/_mocks.ts
@@ -2,6 +2,7 @@ import type {
 	AiInput,
 	AiOutput,
 	Gateway,
+	GatewayStreamEvent,
 	GatewayToolCall,
 	RunOptions,
 	TokenUsage,
@@ -75,4 +76,61 @@ export function call(
 	id = `call_${name}`,
 ): GatewayToolCall {
 	return { id, name, arguments: args };
+}
+
+/** A scripted step for the streaming mock: per-token text deltas + optional tool_use. */
+export interface MockStreamStep {
+	chunks?: string[];
+	toolCalls?: GatewayToolCall[];
+	usage?: TokenUsage;
+}
+
+/**
+ * Mock gateway that implements `stream()`. Each `run()` call consumes one
+ * step from `steps` and surfaces it as a `ReadableStream<GatewayStreamEvent>`
+ * with per-chunk `text` events followed by `tool_use` events and a final `done`.
+ */
+export function mockStreamingGateway(steps: MockStreamStep[]): {
+	gateway: Gateway;
+	state: { streamCalls: number; runCalls: number };
+} {
+	const state = { streamCalls: 0, runCalls: 0 };
+	const gateway: Gateway = {
+		async run(model, _input, _options) {
+			state.runCalls++;
+			const step = steps.shift() ?? {};
+			return {
+				text: (step.chunks ?? []).join(""),
+				raw: {},
+				usage: step.usage,
+				provider: "mock",
+				model,
+				toolCalls: step.toolCalls,
+			};
+		},
+		async stream(_model, _input, _options) {
+			state.streamCalls++;
+			const step = steps.shift() ?? {};
+			return new ReadableStream<GatewayStreamEvent>({
+				start(controller) {
+					for (const delta of step.chunks ?? []) {
+						controller.enqueue({ type: "text", delta });
+					}
+					for (const tc of step.toolCalls ?? []) {
+						controller.enqueue({
+							type: "tool_use",
+							id: tc.id,
+							name: tc.name,
+							input: tc.arguments,
+						});
+					}
+					controller.enqueue({ type: "done", usage: step.usage });
+					controller.close();
+				},
+			});
+		},
+		providers: () => ["mock"],
+		defaultProvider: () => "mock",
+	};
+	return { gateway, state };
 }

--- a/packages/agent/tests/stream-step.test.ts
+++ b/packages/agent/tests/stream-step.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { defineAgent } from "../src/agent";
+import { tool } from "../src/tool";
+import { call, mockStreamingGateway } from "./_mocks";
+
+describe("agent.stream() — provider.stream forwarding", () => {
+	it("emits one text-delta per streamed chunk when provider.stream is available", async () => {
+		const { gateway, state } = mockStreamingGateway([{ chunks: ["Hel", "lo ", "world"] }]);
+		const agent = defineAgent({ name: "stream-chunks", model: "m", provider: gateway });
+
+		const deltas: string[] = [];
+		for await (const e of agent.stream({ messages: [{ role: "user", content: "hi" }] })) {
+			if (e.type === "text-delta") deltas.push(e.delta);
+		}
+
+		expect(deltas).toEqual(["Hel", "lo ", "world"]);
+		expect(state.streamCalls).toBe(1);
+		expect(state.runCalls).toBe(0);
+	});
+
+	it("routes tool_use events from the stream into the loop's tool dispatch", async () => {
+		const { gateway } = mockStreamingGateway([
+			{ chunks: ["thinking..."], toolCalls: [call("ping")] },
+			{ chunks: ["done"] },
+		]);
+		const ping = tool({
+			name: "ping",
+			description: "ping",
+			input: z.object({}),
+			handler: async () => "pong",
+		});
+		const agent = defineAgent({
+			name: "stream-tooluse",
+			model: "m",
+			provider: gateway,
+			tools: [ping],
+		});
+
+		const types: string[] = [];
+		for await (const e of agent.stream({ messages: [{ role: "user", content: "hi" }] })) {
+			types.push(e.type);
+		}
+
+		expect(types).toContain("tool-start");
+		expect(types).toContain("tool-end");
+		expect(types[types.length - 1]).toBe("done");
+	});
+
+	it("falls back to provider.run (and a single text-delta) when stream is absent", async () => {
+		const { gateway, state } = mockStreamingGateway([{ chunks: ["one shot"] }]);
+		// Strip stream to force the fallback path
+		delete (gateway as { stream?: unknown }).stream;
+
+		const agent = defineAgent({ name: "stream-fallback", model: "m", provider: gateway });
+		const deltas: string[] = [];
+		for await (const e of agent.stream({ messages: [{ role: "user", content: "hi" }] })) {
+			if (e.type === "text-delta") deltas.push(e.delta);
+		}
+
+		expect(state.streamCalls).toBe(0);
+		expect(state.runCalls).toBe(1);
+		expect(deltas).toEqual(["one shot"]);
+	});
+});

--- a/packages/agent/tests/stream-step.test.ts
+++ b/packages/agent/tests/stream-step.test.ts
@@ -49,8 +49,8 @@ describe("agent.stream() — provider.stream forwarding", () => {
 
 	it("falls back to provider.run (and a single text-delta) when stream is absent", async () => {
 		const { gateway, state } = mockStreamingGateway([{ chunks: ["one shot"] }]);
-		// Strip stream to force the fallback path
-		delete (gateway as { stream?: unknown }).stream;
+		// Strip stream to force the fallback path.
+		(gateway as { stream?: unknown }).stream = undefined;
 
 		const agent = defineAgent({ name: "stream-fallback", model: "m", provider: gateway });
 		const deltas: string[] = [];


### PR DESCRIPTION
Closes #68. When `gateway.stream()` is available, the agent loop streams tokens and emits one `text-delta` per chunk. Falls back to `gateway.run()` when stream isn't implemented. Tool dispatch, hooks, handoffs unchanged. 30/30 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)