### PR TITLE
docs(ai): @workkit/ai deprecation notice (ADR-001 phase 1)

### DIFF
--- a/.changeset/ai-deprecation-notice.md
+++ b/.changeset/ai-deprecation-notice.md
@@ -1,0 +1,18 @@
+---
+"@workkit/ai": patch
+---
+
+**Deprecation notice — `@workkit/ai` is folding into `@workkit/ai-gateway`.** Every public export now carries a `@deprecated` JSDoc tag pointing at its `@workkit/ai-gateway` equivalent, and the README leads with a migration table. Implementations are unchanged in this release — nothing breaks — but new code should start with `@workkit/ai-gateway`. See [ADR-001](../packages/../.maina/decisions/001-ai-package-consolidation.md).
+
+**Deprecated exports:**
+- `ai()` → `createGateway({ providers: { ai: { type: "workers-ai", binding } }, defaultProvider: "ai" })`
+- `streamAI()` → `gateway.stream!(model, input)` (returns typed `GatewayStreamEvent`)
+- `fallback()` → `gateway.runFallback!(entries, input)` (server-side via CF Universal Endpoint)
+- `withRetry()` → `withRetry(gateway, { maxAttempts })`
+- `structuredAI()` → `gateway.run(model, input, { responseFormat: { jsonSchema } })`
+- `aiWithTools()` → `gateway.run(model, input, { toolOptions })` + manual dispatch
+- `createToolRegistry()` → same function from `@workkit/ai-gateway`
+
+**Not deprecated:** `StructuredOutputError` and `estimateTokens` remain.
+
+**Timeline:** removal scheduled for `@workkit/ai@2.0`. The full reimplementation as a shim over `@workkit/ai-gateway` is tracked in [#63](https://github.com/beeeku/workkit/issues/63) and will ship as `@workkit/ai@1.0` before the 2.0 removal.

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -1,9 +1,43 @@
 # @workkit/ai
 
+> **⚠️ Deprecated — use [`@workkit/ai-gateway`](../ai-gateway) instead.**
+>
+> Per [ADR-001](../../.maina/decisions/001-ai-package-consolidation.md), this package is being folded into `@workkit/ai-gateway`. Existing APIs still work today but are marked `@deprecated`; the shim is tracked in [#63](https://github.com/beeeku/workkit/issues/63) and the package will be removed at `@workkit/ai@2.0`.
+
 > Typed Workers AI client with streaming, fallback chains, and retry
 
 [![npm](https://img.shields.io/npm/v/@workkit/ai)](https://www.npmjs.com/package/@workkit/ai)
 [![bundle size](https://img.shields.io/bundlephobia/minzip/@workkit/ai)](https://bundlephobia.com/package/@workkit/ai)
+
+## Migration
+
+Replace `@workkit/ai` imports with `@workkit/ai-gateway` and construct a gateway over your `env.AI` binding:
+
+| Before (`@workkit/ai`) | After (`@workkit/ai-gateway`) |
+|---|---|
+| `ai(env.AI).run(model, input)` | `gateway.run(model, input)` |
+| `streamAI(env.AI, model, input)` | `gateway.stream!(model, input)` (typed `GatewayStreamEvent`) |
+| `fallback(env.AI, [{model, timeout}], input)` | `gateway.runFallback!(entries, input)` (server-side via CF Universal Endpoint) |
+| `withRetry(env.AI, model, input, { maxRetries })` | `withRetry(gateway, { maxAttempts }).run(model, input)` |
+| `structuredAI(env.AI, model, input, { schema })` | `gateway.run(model, input, { responseFormat: { jsonSchema } })` |
+| `aiWithTools(env.AI, model, input, { tools }, handler)` | `gateway.run(model, input, { toolOptions: { tools } })` + manual dispatch |
+
+```ts
+// Before
+import { ai } from "@workkit/ai"
+const client = ai(env.AI)
+const result = await client.run("@cf/meta/llama-3.1-8b-instruct", { messages })
+
+// After
+import { createGateway } from "@workkit/ai-gateway"
+const gateway = createGateway({
+  providers: { ai: { type: "workers-ai", binding: env.AI } },
+  defaultProvider: "ai",
+})
+const result = await gateway.run("@cf/meta/llama-3.1-8b-instruct", { messages })
+```
+
+`StructuredOutputError` and `estimateTokens` remain in `@workkit/ai` and aren't deprecated.
 
 ## Install
 

--- a/packages/ai/src/client.ts
+++ b/packages/ai/src/client.ts
@@ -31,6 +31,11 @@ export interface WorkkitAiClient {
 /**
  * Create a typed AI client from a Cloudflare Workers AI binding.
  *
+ * @deprecated Use `createGateway({ providers: { ai: { type: "workers-ai", binding } }, defaultProvider: "ai" })`
+ * from `@workkit/ai-gateway`. See ADR-001 (`.maina/decisions/001-ai-package-consolidation.md`).
+ * `@workkit/ai` will be removed at v2.0; track migration via
+ * [#63](https://github.com/beeeku/workkit/issues/63).
+ *
  * @param binding - The AI binding from the worker environment (env.AI)
  * @returns A typed AI client
  * @throws {BindingNotFoundError} If the binding is nullish

--- a/packages/ai/src/fallback.ts
+++ b/packages/ai/src/fallback.ts
@@ -28,6 +28,11 @@ export interface FallbackOptions extends RunOptions {
  *   messages: [{ role: 'user', content: 'Hello' }],
  * })
  * ```
+ *
+ * @deprecated Use `gateway.runFallback(entries, input, options)` from
+ * `@workkit/ai-gateway` for server-side fallback via the Cloudflare Universal
+ * Endpoint. For client-side Workers-AI-only fallback, chain calls manually
+ * with try/catch. See ADR-001; tracked in #63.
  */
 export async function fallback<T = unknown>(
 	binding: AiBinding,

--- a/packages/ai/src/retry.ts
+++ b/packages/ai/src/retry.ts
@@ -84,6 +84,11 @@ export function defaultIsRetryable(error: unknown): boolean {
  *   backoff: 'exponential',
  * })
  * ```
+ *
+ * @deprecated Use `withRetry(gateway, { maxAttempts })` from `@workkit/ai-gateway`.
+ * That wrapper retries the unified gateway (covering Workers AI + OpenAI +
+ * Anthropic + custom) and uses each `WorkkitError`'s own `retryStrategy`.
+ * See ADR-001; tracked in #63.
  */
 export async function withRetry<T = unknown>(
 	binding: AiBinding,

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -27,6 +27,9 @@ export interface StreamOptions extends RunOptions {
  *   headers: { 'Content-Type': 'text/event-stream' },
  * })
  * ```
+ *
+ * @deprecated Use `gateway.stream(model, input, options)` from `@workkit/ai-gateway`
+ * (returns typed `GatewayStreamEvent`s). See ADR-001; tracked in #63.
  */
 export async function streamAI(
 	binding: AiBinding,

--- a/packages/ai/src/structured.ts
+++ b/packages/ai/src/structured.ts
@@ -80,6 +80,10 @@ const DEFAULT_MAX_RETRIES = 1;
  * );
  * // result.data.colors → ["red", "green", "blue"]
  * ```
+ *
+ * @deprecated Use `gateway.run(model, input, { responseFormat: { jsonSchema } })`
+ * from `@workkit/ai-gateway` — normalizes JSON mode across Workers AI, OpenAI,
+ * and Anthropic. See ADR-001; tracked in #63.
  */
 export async function structuredAI<T>(
 	binding: AiBinding,

--- a/packages/ai/src/tool-registry.ts
+++ b/packages/ai/src/tool-registry.ts
@@ -50,6 +50,9 @@ export interface ToolRegistry {
  *   (call) => registry.execute(call),
  * );
  * ```
+ *
+ * @deprecated Use `createToolRegistry` from `@workkit/ai-gateway` (same shape,
+ * works with any gateway provider). See ADR-001; tracked in #63.
  */
 export function createToolRegistry(): ToolRegistry {
 	const handlers = new Map<string, ToolHandler>();

--- a/packages/ai/src/tool-use.ts
+++ b/packages/ai/src/tool-use.ts
@@ -118,6 +118,10 @@ function toWorkersAiTools(tools: ToolUseOptions["tools"]): Array<{
  * )
  * // result.toolCalls contains the model's requested calls
  * ```
+ *
+ * @deprecated Use `gateway.run(model, input, { toolOptions: { tools, toolChoice } })`
+ * from `@workkit/ai-gateway` — unified tool-call normalization across Workers AI,
+ * OpenAI, and Anthropic. See ADR-001; tracked in #63.
  */
 export async function aiWithTools(
 	binding: AiBinding,


### PR DESCRIPTION
Phase 1 of [#63](https://github.com/beeeku/workkit/issues/63) / [ADR-001](../../.maina/decisions/001-ai-package-consolidation.md).

Adds `@deprecated` JSDoc on every public `@workkit/ai` export pointing at its `@workkit/ai-gateway` equivalent. README leads with a deprecation banner and migration table. Implementations unchanged — no runtime regression.

`StructuredOutputError` and `estimateTokens` remain (not deprecated).

### Not in scope of this PR

Phase 2 (the full shim-over-ai-gateway rewrite that makes `@workkit/ai` just re-export from `@workkit/ai-gateway`) is deferred. The existing implementations are 1,577 LOC across 13 files with their own semantics and tests; rewriting them as wrappers in one PR is high-risk. Issue #63 stays open to track that work, which will ship as `@workkit/ai@1.0` before the `@2.0` removal.

### Test plan

- [x] 129/129 existing tests still pass (no runtime changes).
- [x] `tsc --noEmit` clean.
- [ ] Readers of the docs site see the deprecation banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)