### PR TITLE
fix(ai,agent): address Copilot review follow-ups on #70–#72

### DIFF
--- a/.changeset/copilot-followup-70-71-72.md
+++ b/.changeset/copilot-followup-70-71-72.md
@@ -1,0 +1,16 @@
+---
+"@workkit/ai": patch
+"@workkit/agent": patch
+---
+
+**Follow-up fixes from Copilot review on PRs #70–#72.**
+
+`@workkit/agent`:
+- Streaming step now always returns a defined `AiOutput.raw` (falls back to `{}` if the provider's terminal `done` event doesn't include `raw`), satisfying the `Gateway` output contract.
+- New regression test: consumer aborts mid-stream → the model stream surfaces the abort.
+- Doc comment on `mockStreamingGateway` corrected to cover both `run()` and `stream()` paths.
+
+`@workkit/ai`:
+- `calculateDelay` and `defaultIsRetryable` now also carry `@deprecated` JSDoc (they're internal helpers for the deprecated `withRetry`). The claim in the earlier changeset that "every public export now carries `@deprecated`" is now accurate.
+- `createToolRegistry` guidance corrected: `@workkit/ai-gateway` does not re-export this helper. Migrating callers can keep using it from `@workkit/ai` until the v2.0 removal or inline the equivalent `Map<string, handler>`.
+- README migration table: `await` added to the "before" column examples (they were all async), and the `fallback` → `runFallback` row now notes the `cfGateway` prerequisite and the Workers-AI-only fallback path.

--- a/packages/agent/src/stream-step.ts
+++ b/packages/agent/src/stream-step.ts
@@ -55,7 +55,10 @@ export async function runStep(
 
 	return {
 		text: text.length > 0 ? text : undefined,
-		raw,
+		// `AiOutput.raw` is required. Streams don't always surface a raw payload
+		// on the terminal `done` event (providers vary), so fall back to an
+		// empty object rather than violating the contract.
+		raw: raw ?? {},
 		usage,
 		provider: currentAgent.provider.defaultProvider(),
 		model: currentAgent.model,

--- a/packages/agent/tests/_mocks.ts
+++ b/packages/agent/tests/_mocks.ts
@@ -86,9 +86,11 @@ export interface MockStreamStep {
 }
 
 /**
- * Mock gateway that implements `stream()`. Each `run()` call consumes one
- * step from `steps` and surfaces it as a `ReadableStream<GatewayStreamEvent>`
- * with per-chunk `text` events followed by `tool_use` events and a final `done`.
+ * Mock gateway that implements both `stream()` and `run()`. Each call consumes
+ * one step from `steps`; `stream()` surfaces it as a
+ * `ReadableStream<GatewayStreamEvent>` with per-chunk `text` events followed by
+ * `tool_use` events and a final `done`, while `run()` concatenates the chunks
+ * into a single `text` field.
  */
 export function mockStreamingGateway(steps: MockStreamStep[]): {
 	gateway: Gateway;

--- a/packages/agent/tests/stream-step.test.ts
+++ b/packages/agent/tests/stream-step.test.ts
@@ -47,6 +47,45 @@ describe("agent.stream() — provider.stream forwarding", () => {
 		expect(types[types.length - 1]).toBe("done");
 	});
 
+	it("aborts the model stream when the caller aborts options.signal mid-stream", async () => {
+		const controller = new AbortController();
+		const gateway = {
+			async run() {
+				return { text: "", raw: {}, provider: "mock", model: "m" };
+			},
+			async stream(_model: string, _input: unknown, options?: { signal?: AbortSignal }) {
+				return new ReadableStream({
+					start(ctrl) {
+						ctrl.enqueue({ type: "text", delta: "hi" });
+						// Stay open until the signal aborts, then error the stream.
+						options?.signal?.addEventListener("abort", () =>
+							ctrl.error(new DOMException("aborted", "AbortError")),
+						);
+					},
+				});
+			},
+			providers: () => ["mock"],
+			defaultProvider: () => "mock",
+		};
+		const agent = defineAgent({
+			name: "stream-abort",
+			model: "m",
+			provider: gateway as never,
+		});
+
+		const events: string[] = [];
+		await expect(async () => {
+			for await (const e of agent.stream({
+				messages: [{ role: "user", content: "hi" }],
+				context: { signal: controller.signal },
+			})) {
+				events.push(e.type);
+				if (e.type === "text-delta") controller.abort();
+			}
+		}).rejects.toThrow();
+		expect(events).toContain("text-delta");
+	});
+
 	it("falls back to provider.run (and a single text-delta) when stream is absent", async () => {
 		const { gateway, state } = mockStreamingGateway([{ chunks: ["one shot"] }]);
 		// Strip stream to force the fallback path.

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -15,12 +15,13 @@ Replace `@workkit/ai` imports with `@workkit/ai-gateway` and construct a gateway
 
 | Before (`@workkit/ai`) | After (`@workkit/ai-gateway`) |
 |---|---|
-| `ai(env.AI).run(model, input)` | `gateway.run(model, input)` |
-| `streamAI(env.AI, model, input)` | `gateway.stream!(model, input)` (typed `GatewayStreamEvent`) |
-| `fallback(env.AI, [{model, timeout}], input)` | `gateway.runFallback!(entries, input)` (server-side via CF Universal Endpoint) |
-| `withRetry(env.AI, model, input, { maxRetries })` | `withRetry(gateway, { maxAttempts }).run(model, input)` |
-| `structuredAI(env.AI, model, input, { schema })` | `gateway.run(model, input, { responseFormat: { jsonSchema } })` |
-| `aiWithTools(env.AI, model, input, { tools }, handler)` | `gateway.run(model, input, { toolOptions: { tools } })` + manual dispatch |
+| `await ai(env.AI).run(model, input)` | `await gateway.run(model, input)` |
+| `await streamAI(env.AI, model, input)` | `await gateway.stream!(model, input)` (typed `GatewayStreamEvent`) |
+| `await fallback(env.AI, [{model, timeout}], input)` | `await gateway.runFallback!(entries, input)` — **requires `cfGateway` on `createGateway`** (calls the Cloudflare AI Gateway Universal Endpoint; only OpenAI / Anthropic providers in the chain). For Workers-AI-only client-side fallback, keep using `@workkit/ai`'s `fallback` or roll your own `try`/`catch` over `gateway.run`. |
+| `await withRetry(env.AI, model, input, { maxRetries })` | `await withRetry(gateway, { maxAttempts }).run(model, input)` |
+| `await structuredAI(env.AI, model, input, { schema })` | `await gateway.run(model, input, { responseFormat: { jsonSchema } })` |
+| `await aiWithTools(env.AI, model, input, { tools }, handler)` | `await gateway.run(model, input, { toolOptions: { tools } })` + manual dispatch |
+| `createToolRegistry()` | Not re-exported by `@workkit/ai-gateway`; keep using `@workkit/ai`'s helper or inline a `Map<string, handler>`. |
 
 ```ts
 // Before

--- a/packages/ai/src/retry.ts
+++ b/packages/ai/src/retry.ts
@@ -18,6 +18,10 @@ const DEFAULT_MAX_DELAY = 30000;
  * @param baseDelay - Base delay in milliseconds
  * @param maxDelay - Maximum delay in milliseconds
  * @returns Delay in milliseconds
+ *
+ * @deprecated Internal helper for the deprecated `withRetry`. Use
+ * `withRetry(gateway, { maxAttempts })` from `@workkit/ai-gateway`, which
+ * drives retry delays from each `WorkkitError`'s own `retryStrategy`.
  */
 export function calculateDelay(
 	strategy: BackoffStrategy,
@@ -47,6 +51,9 @@ export function calculateDelay(
 /**
  * Default check for whether an error is retryable.
  * Retries on timeout, rate limit, and service unavailable errors.
+ *
+ * @deprecated Internal helper for the deprecated `withRetry`. Use
+ * `isRetryable` from `@workkit/errors` (checks `WorkkitError.retryable`).
  */
 export function defaultIsRetryable(error: unknown): boolean {
 	if (error instanceof TimeoutError) return true;

--- a/packages/ai/src/tool-registry.ts
+++ b/packages/ai/src/tool-registry.ts
@@ -51,8 +51,11 @@ export interface ToolRegistry {
  * );
  * ```
  *
- * @deprecated Use `createToolRegistry` from `@workkit/ai-gateway` (same shape,
- * works with any gateway provider). See ADR-001; tracked in #63.
+ * @deprecated `@workkit/ai-gateway` doesn't re-export this helper — it's a
+ * thin ~40-line Map wrapper. After migrating to the gateway, either keep
+ * using this function from `@workkit/ai` until the v2.0 removal, or inline
+ * the equivalent (a `Map<string, ToolHandler>` with `register`/`get`/
+ * `execute`). See ADR-001; tracked in #63.
  */
 export function createToolRegistry(): ToolRegistry {
 	const handlers = new Map<string, ToolHandler>();


### PR DESCRIPTION
Post-merge follow-up addressing Copilot findings that went missed or were intentionally deferred on the three PRs that landed earlier (#70 ai-gateway embeddings, #71 agent streamLoop, #72 ai deprecation notice).

### `@workkit/agent`

- **Bug:** `runStep` now returns a defined `AiOutput.raw` — streaming providers don't always include `raw` on the terminal `done` event, and `AiOutput.raw` is required by the `Gateway` output contract.
- **Coverage:** new test for consumer-abort-mid-stream (streams surface the abort instead of hanging).
- **Doc:** `mockStreamingGateway` comment now mentions both `run()` and `stream()` paths.

### `@workkit/ai`

- **Honesty:** `calculateDelay` + `defaultIsRetryable` now also carry `@deprecated` JSDoc. The previous changeset's "every public export" claim was off.
- **Correctness:** `createToolRegistry` guidance fixed — `@workkit/ai-gateway` does NOT re-export this helper (verified against `index.ts`). Updated JSDoc + README to either keep using it from `@workkit/ai` until the v2.0 removal or inline a `Map<string, handler>`.
- **Docs:** README migration table now shows `await` on all async call sites, and the `fallback` → `runFallback` row calls out the `cfGateway` prerequisite and the Workers-AI-only fallback path.

### Test plan

- [x] `@workkit/agent` — 31/31 pass (one new test).
- [x] `@workkit/ai` — 129/129 pass (no code changes, doc-only for most).
- [x] `bun run lint` — clean.

Patch bumps for both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)