### PR TITLE
feat(ai-gateway): port @workkit/ai helpers (ADR-001 phase 2)

### DIFF
--- a/.changeset/ai-gateway-port-helpers.md
+++ b/.changeset/ai-gateway-port-helpers.md
@@ -2,13 +2,13 @@
 "@workkit/ai-gateway": minor
 ---
 
-**Port `@workkit/ai` helpers into `@workkit/ai-gateway`** — phase 2 of [ADR-001](../packages/../.maina/decisions/001-ai-package-consolidation.md). All additive; no breaking changes.
+**Port `@workkit/ai` helpers into `@workkit/ai-gateway`** — phase 2 of [ADR-001](../.maina/decisions/001-ai-package-consolidation.md). All additive; no breaking changes.
 
 New public exports:
 
 - **`createToolRegistry()`** + `ToolHandler` / `ToolRegistry` types — `Map<name, handler>` helper for dispatching tool calls. Drop-in replacement for the same-named helper in `@workkit/ai`, but typed against `GatewayToolDefinition` / `GatewayToolCall`.
 - **`aiWithTools(gateway, model, input, options)`** — multi-turn tool-use session. When `options.handler` is supplied, the model's tool calls are auto-dispatched and results fed back for another turn (up to `maxTurns`). When absent, the first set of tool calls is returned for manual dispatch. Operates on `gateway.run()` with normalized tool-call handling across Workers AI / OpenAI / Anthropic.
-- **`structuredAI(gateway, model, input, { schema })`** + `StructuredOutputError` — JSON-mode output with Standard Schema validation and self-correcting retry. Calls `gateway.run(…, { responseFormat: { jsonSchema } })` so providers with strict schema support (OpenAI, Workers AI) can enforce natively, with Anthropic falling back to instruction-based JSON mode.
+- **`structuredAI(gateway, model, input, { schema })`** + `StructuredOutputError` — JSON-mode output with Standard Schema validation and self-correcting retry. Calls `gateway.run(…, { responseFormat: { jsonSchema } })`; only OpenAI enforces the schema natively (via `response_format: { type: "json_schema" }`). Workers AI and Anthropic use instruction-based JSON mode — the schema is included in a system prompt, and `structuredAI` validates the response client-side and retries with the validation errors fed back to the model.
 - **`standardSchemaToJsonSchema(schema)`** — Zod / Valibot / ArkType → JSON Schema converter (prefers the schema's own `toJSONSchema()`, falls back to Zod internals, `{type:"object"}` as a permissive default).
 - **`estimateTokens(text | messages)`** — rough heuristic for capacity/cost planning.
 

--- a/.changeset/ai-gateway-port-helpers.md
+++ b/.changeset/ai-gateway-port-helpers.md
@@ -1,0 +1,37 @@
+---
+"@workkit/ai-gateway": minor
+---
+
+**Port `@workkit/ai` helpers into `@workkit/ai-gateway`** — phase 2 of [ADR-001](../packages/../.maina/decisions/001-ai-package-consolidation.md). All additive; no breaking changes.
+
+New public exports:
+
+- **`createToolRegistry()`** + `ToolHandler` / `ToolRegistry` types — `Map<name, handler>` helper for dispatching tool calls. Drop-in replacement for the same-named helper in `@workkit/ai`, but typed against `GatewayToolDefinition` / `GatewayToolCall`.
+- **`aiWithTools(gateway, model, input, options)`** — multi-turn tool-use session. When `options.handler` is supplied, the model's tool calls are auto-dispatched and results fed back for another turn (up to `maxTurns`). When absent, the first set of tool calls is returned for manual dispatch. Operates on `gateway.run()` with normalized tool-call handling across Workers AI / OpenAI / Anthropic.
+- **`structuredAI(gateway, model, input, { schema })`** + `StructuredOutputError` — JSON-mode output with Standard Schema validation and self-correcting retry. Calls `gateway.run(…, { responseFormat: { jsonSchema } })` so providers with strict schema support (OpenAI, Workers AI) can enforce natively, with Anthropic falling back to instruction-based JSON mode.
+- **`standardSchemaToJsonSchema(schema)`** — Zod / Valibot / ArkType → JSON Schema converter (prefers the schema's own `toJSONSchema()`, falls back to Zod internals, `{type:"object"}` as a permissive default).
+- **`estimateTokens(text | messages)`** — rough heuristic for capacity/cost planning.
+
+Example:
+
+```ts
+import { createGateway, aiWithTools, createToolRegistry } from "@workkit/ai-gateway"
+
+const gateway = createGateway({
+  providers: { anthropic: { type: "anthropic", apiKey: env.ANTHROPIC_KEY } },
+  defaultProvider: "anthropic",
+})
+
+const registry = createToolRegistry()
+registry.register("get_weather", {
+  definition: { name: "get_weather", description: "…", parameters: { /* … */ } },
+  handler: async (args) => JSON.stringify(await getWeather(args.location as string)),
+})
+
+const result = await aiWithTools(gateway, "claude-sonnet-4-6",
+  { messages: [{ role: "user", content: "weather in SF?" }] },
+  { tools: registry.getTools(), handler: (call) => registry.execute(call) },
+)
+```
+
+This unblocks the full `@workkit/ai@1.0` shim rewrite tracked in #63: once this ships, `@workkit/ai` can become thin re-exports over `@workkit/ai-gateway`.

--- a/packages/ai-gateway/src/index.ts
+++ b/packages/ai-gateway/src/index.ts
@@ -17,6 +17,24 @@ export { withLogging } from "./logging";
 export { withRetry } from "./retry";
 export type { RetryConfig } from "./retry";
 
+// Tool registry — name/handler map for dispatching tool calls.
+export { createToolRegistry } from "./tool-registry";
+export type { ToolHandler, ToolRegistry } from "./tool-registry";
+
+// Tool-use session — multi-turn execution with automatic dispatch.
+export { aiWithTools } from "./tool-use";
+export type { AiWithToolsOptions, AiWithToolsResult, ToolMessage } from "./tool-use";
+
+// Structured output — JSON mode with Standard Schema validation + retry.
+export { structuredAI, StructuredOutputError } from "./structured";
+export type { StructuredOptions, StructuredResult } from "./structured";
+
+// Schema conversion.
+export { standardSchemaToJsonSchema } from "./schema";
+
+// Token estimation — rough heuristic, not a tokenizer.
+export { estimateTokens } from "./tokens";
+
 // Types
 export type {
 	// Provider types

--- a/packages/ai-gateway/src/schema.ts
+++ b/packages/ai-gateway/src/schema.ts
@@ -1,0 +1,110 @@
+/**
+ * Lightweight Standard Schema → JSON Schema converter.
+ *
+ * Prefers the schema's own `toJSONSchema()` method (Zod v4+, Valibot, ArkType).
+ * Otherwise falls back to inspecting Zod's internal `_zod.def` / `_def`
+ * structures. Returns `{ type: "object" }` as a permissive default when the
+ * schema shape isn't recognized.
+ *
+ * Ported from `@workkit/ai` so the structured-output helpers don't have to
+ * depend on the deprecated package.
+ */
+
+interface StandardSchemaLike {
+	readonly "~standard": {
+		readonly version: 1;
+		readonly vendor: string;
+		readonly validate: (value: unknown) => unknown;
+	};
+}
+
+export function standardSchemaToJsonSchema(schema: StandardSchemaLike): Record<string, unknown> {
+	// biome-ignore lint/suspicious/noExplicitAny: Schema libraries expose toJSONSchema without a standard type.
+	if (typeof (schema as any).toJSONSchema === "function") {
+		// biome-ignore lint/suspicious/noExplicitAny: same reason.
+		const full = (schema as any).toJSONSchema() as Record<string, unknown>;
+		const { $schema: _meta, ...rest } = full;
+		return rest;
+	}
+
+	// biome-ignore lint/suspicious/noExplicitAny: Inspecting Zod's private defs.
+	const def = (schema as any)?._zod?.def ?? (schema as any)?._def;
+	if (def) return convertDef(def);
+
+	return { type: "object" };
+}
+
+function convertDef(def: Record<string, unknown>): Record<string, unknown> {
+	const type = def.type as string | undefined;
+
+	switch (type) {
+		case "string":
+			return { type: "string" };
+		case "number":
+			return { type: "number" };
+		case "boolean":
+			return { type: "boolean" };
+
+		case "array": {
+			// biome-ignore lint/suspicious/noExplicitAny: Zod internal shape.
+			const items = def.element ?? (def as any).items;
+			return {
+				type: "array",
+				// biome-ignore lint/suspicious/noExplicitAny: Zod internal shape.
+				items: items ? convertDef((items as any)?._zod?.def ?? (items as any)?._def ?? {}) : {},
+			};
+		}
+
+		case "object": {
+			const shape = def.shape as Record<string, unknown> | undefined;
+			const properties: Record<string, Record<string, unknown>> = {};
+			const required: string[] = [];
+
+			if (shape) {
+				for (const [key, field] of Object.entries(shape)) {
+					// biome-ignore lint/suspicious/noExplicitAny: Zod internal shape.
+					const fieldDef = (field as any)?._zod?.def ?? (field as any)?._def ?? {};
+					properties[key] = convertDef(fieldDef);
+
+					const fieldType = fieldDef.type as string | undefined;
+					if (fieldType !== "optional" && fieldType !== "default" && fieldType !== "nullable") {
+						required.push(key);
+					}
+				}
+			}
+
+			const result: Record<string, unknown> = { type: "object", properties };
+			if (required.length > 0) result.required = required;
+			return result;
+		}
+
+		case "enum": {
+			const values = def.values ?? def.entries;
+			return {
+				type: "string",
+				enum: Array.isArray(values) ? values : Object.values(values as object),
+			};
+		}
+
+		case "literal":
+			return { const: def.value };
+
+		case "optional":
+		case "nullable": {
+			// biome-ignore lint/suspicious/noExplicitAny: Zod internal shape.
+			const inner = (def as any).innerType;
+			const innerDef = inner?._zod?.def ?? inner?._def ?? {};
+			return convertDef(innerDef);
+		}
+
+		case "default": {
+			// biome-ignore lint/suspicious/noExplicitAny: Zod internal shape.
+			const inner = (def as any).innerType;
+			const innerDef = inner?._zod?.def ?? inner?._def ?? {};
+			return { ...convertDef(innerDef), default: def.defaultValue };
+		}
+
+		default:
+			return {};
+	}
+}

--- a/packages/ai-gateway/src/structured.ts
+++ b/packages/ai-gateway/src/structured.ts
@@ -1,6 +1,6 @@
-import { ConfigError } from "@workkit/errors";
+import { ConfigError, ValidationError } from "@workkit/errors";
 import { standardSchemaToJsonSchema } from "./schema";
-import type { ChatMessage, Gateway } from "./types";
+import type { AiInput, ChatMessage, Gateway } from "./types";
 
 // ─── Standard Schema V1 types (inlined to avoid a hard dep) ────
 
@@ -72,9 +72,12 @@ const DEFAULT_MAX_RETRIES = 1;
  * validation errors included in the conversation so the model can self-correct.
  * Throws {@link StructuredOutputError} if all attempts fail.
  *
- * Adds `responseFormat: { jsonSchema }` to the gateway call so providers that
- * support strict JSON-schema enforcement (OpenAI, Workers AI JSON mode) can do
- * their part; Anthropic uses instruction-based JSON mode.
+ * Passes `responseFormat: { jsonSchema }` to the gateway call. Only OpenAI
+ * enforces the schema natively today (via `response_format: { type: "json_schema" }`).
+ * Workers AI (`{ type: "json_object" }`) and Anthropic (instruction-based) both
+ * use prompt-level hints, so the validation + retry loop here does the real
+ * work — invalid responses are fed back to the model with the validation
+ * errors inlined for self-correction.
  *
  * @example
  * ```ts
@@ -88,7 +91,7 @@ const DEFAULT_MAX_RETRIES = 1;
 export async function structuredAI<T>(
 	gateway: Gateway,
 	model: string,
-	input: { messages: ChatMessage[] },
+	input: AiInput,
 	structured: StructuredOptions<T>,
 ): Promise<StructuredResult<T>> {
 	if (!gateway) {
@@ -102,8 +105,11 @@ export async function structuredAI<T>(
 		structured.schema as unknown as Parameters<typeof standardSchemaToJsonSchema>[0],
 	);
 
-	// Clone the caller's messages so repeated attempts can append without mutating.
-	const messages: ChatMessage[] = [...input.messages];
+	// Normalize the various `AiInput` shapes into a mutable `messages` array we
+	// can append to across retry attempts. `{ prompt }` becomes a single user
+	// message; arbitrary input shapes without `messages` or `prompt` error out
+	// since we need somewhere to append the self-correction feedback.
+	const messages: ChatMessage[] = toMessages(input);
 
 	let lastRaw = "";
 	let lastIssues: unknown[] = [];
@@ -169,4 +175,17 @@ export async function structuredAI<T>(
 	}
 
 	throw new StructuredOutputError(lastRaw, lastIssues);
+}
+
+function toMessages(input: AiInput): ChatMessage[] {
+	if ("messages" in input && Array.isArray((input as { messages: unknown }).messages)) {
+		return [...(input as { messages: ChatMessage[] }).messages];
+	}
+	if ("prompt" in input && typeof (input as { prompt: unknown }).prompt === "string") {
+		return [{ role: "user", content: (input as { prompt: string }).prompt }];
+	}
+	throw new ValidationError(
+		"structuredAI requires input with `messages` or `prompt` so self-correction feedback can be appended",
+		[{ path: ["input"], message: "Expected { messages: ChatMessage[] } or { prompt: string }" }],
+	);
 }

--- a/packages/ai-gateway/src/structured.ts
+++ b/packages/ai-gateway/src/structured.ts
@@ -1,0 +1,172 @@
+import { ConfigError } from "@workkit/errors";
+import { standardSchemaToJsonSchema } from "./schema";
+import type { ChatMessage, Gateway } from "./types";
+
+// ─── Standard Schema V1 types (inlined to avoid a hard dep) ────
+
+interface StandardSchemaV1Issue {
+	readonly message: string;
+	readonly path?: ReadonlyArray<PropertyKey | { readonly key: PropertyKey }>;
+}
+
+type StandardSchemaV1Result<Output> =
+	| { readonly value: Output; readonly issues?: undefined }
+	| { readonly issues: ReadonlyArray<StandardSchemaV1Issue>; readonly value?: undefined };
+
+interface StandardSchemaV1<Input = unknown, Output = Input> {
+	readonly "~standard": {
+		readonly version: 1;
+		readonly vendor: string;
+		readonly validate: (
+			value: unknown,
+		) => StandardSchemaV1Result<Output> | Promise<StandardSchemaV1Result<Output>>;
+	};
+	readonly "~types"?: { readonly input: Input; readonly output: Output };
+}
+
+// ─── Errors ─────────────────────────────────────────────────
+
+/**
+ * Error thrown when a structured output response does not match the expected
+ * schema after all retry attempts have been exhausted.
+ */
+export class StructuredOutputError extends Error {
+	readonly raw: string;
+	readonly issues: unknown[];
+
+	constructor(raw: string, issues: unknown[], message?: string) {
+		super(message ?? "Response did not match expected schema");
+		this.name = "StructuredOutputError";
+		this.raw = raw;
+		this.issues = issues;
+	}
+}
+
+// ─── Public API ─────────────────────────────────────────────
+
+/** Options for structured (JSON-mode + schema-validated) output. */
+export interface StructuredOptions<T> {
+	/** Standard Schema v1 schema describing the expected output shape. */
+	schema: StandardSchemaV1<T>;
+	/** Number of retries on parse/validation failure (default: 1). */
+	maxRetries?: number;
+}
+
+/** Result from a structured gateway call. */
+export interface StructuredResult<T> {
+	/** The parsed, validated data. */
+	data: T;
+	/** Raw string response from the model. */
+	raw: string;
+	/** Provider that handled the request. */
+	provider: string;
+	/** Model that produced the output. */
+	model: string;
+}
+
+const DEFAULT_MAX_RETRIES = 1;
+
+/**
+ * Run a gateway model and parse the response as structured JSON validated
+ * against a Standard Schema. On failure, retries up to `maxRetries` with the
+ * validation errors included in the conversation so the model can self-correct.
+ * Throws {@link StructuredOutputError} if all attempts fail.
+ *
+ * Adds `responseFormat: { jsonSchema }` to the gateway call so providers that
+ * support strict JSON-schema enforcement (OpenAI, Workers AI JSON mode) can do
+ * their part; Anthropic uses instruction-based JSON mode.
+ *
+ * @example
+ * ```ts
+ * const result = await structuredAI(gateway, "claude-sonnet-4-6",
+ *   { messages: [{ role: "user", content: "List 3 colors" }] },
+ *   { schema: z.object({ colors: z.array(z.string()) }) },
+ * );
+ * // result.data.colors → ["red", "green", "blue"]
+ * ```
+ */
+export async function structuredAI<T>(
+	gateway: Gateway,
+	model: string,
+	input: { messages: ChatMessage[] },
+	structured: StructuredOptions<T>,
+): Promise<StructuredResult<T>> {
+	if (!gateway) {
+		throw new ConfigError("structuredAI requires a gateway", {
+			context: { gateway: String(gateway) },
+		});
+	}
+
+	const maxRetries = structured.maxRetries ?? DEFAULT_MAX_RETRIES;
+	const jsonSchema = standardSchemaToJsonSchema(
+		structured.schema as unknown as Parameters<typeof standardSchemaToJsonSchema>[0],
+	);
+
+	// Clone the caller's messages so repeated attempts can append without mutating.
+	const messages: ChatMessage[] = [...input.messages];
+
+	let lastRaw = "";
+	let lastIssues: unknown[] = [];
+
+	for (let attempt = 0; attempt <= maxRetries; attempt++) {
+		const output = await gateway.run(model, { messages }, { responseFormat: { jsonSchema } });
+		const rawText = output.text ?? "";
+		lastRaw = rawText;
+
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(rawText);
+		} catch {
+			const parseIssues = [{ message: `Invalid JSON: ${rawText.slice(0, 200)}` }];
+			lastIssues = parseIssues;
+
+			if (attempt < maxRetries) {
+				messages.push({ role: "assistant", content: rawText });
+				messages.push({
+					role: "user",
+					content:
+						"Your response was not valid JSON. Please respond with valid JSON matching the schema.",
+				});
+				continue;
+			}
+			throw new StructuredOutputError(rawText, parseIssues);
+		}
+
+		const result = await structured.schema["~standard"].validate(parsed);
+		if (result.issues) {
+			lastIssues = [...result.issues];
+
+			if (attempt < maxRetries) {
+				const issuesSummary = result.issues
+					.map((issue) => {
+						const path = issue.path
+							? issue.path
+									.map((p) =>
+										typeof p === "object" && p !== null && "key" in p ? String(p.key) : String(p),
+									)
+									.join(".")
+							: "";
+						return path ? `${path}: ${issue.message}` : issue.message;
+					})
+					.join("; ");
+
+				messages.push({ role: "assistant", content: rawText });
+				messages.push({
+					role: "user",
+					content: `Your JSON response had validation errors: ${issuesSummary}. Please fix and respond with valid JSON matching the schema.`,
+				});
+				continue;
+			}
+			throw new StructuredOutputError(rawText, lastIssues);
+		}
+
+		return {
+			data: result.value as T,
+			raw: rawText,
+			provider: output.provider,
+			model: output.model,
+		};
+	}
+
+	throw new StructuredOutputError(lastRaw, lastIssues);
+}

--- a/packages/ai-gateway/src/tokens.ts
+++ b/packages/ai-gateway/src/tokens.ts
@@ -1,0 +1,49 @@
+import type { ChatMessage } from "./types";
+
+/** Overhead tokens per message (role tags, delimiters, etc.) */
+const MESSAGE_OVERHEAD = 4;
+
+/** Base overhead for a conversation (system prompt framing, etc.) */
+const CONVERSATION_OVERHEAD = 3;
+
+/**
+ * Estimate token count for a string or chat-message array using word/character
+ * heuristics.
+ *
+ * This is a rough approximation — NOT a tokenizer. Different models use
+ * different tokenizers (BPE, SentencePiece, etc.) so exact counts vary. Good
+ * enough for capacity planning and cost estimation before a real call.
+ *
+ * The heuristic: ~1 token per short word (≤4 chars); ~1 token per 4 chars for
+ * longer words; ~`MESSAGE_OVERHEAD` per message plus a `CONVERSATION_OVERHEAD`.
+ *
+ * @example
+ * ```ts
+ * estimateTokens("Hello, how are you today?")
+ * // → ~7
+ *
+ * estimateTokens([
+ *   { role: "system", content: "You are helpful." },
+ *   { role: "user", content: "Hi" },
+ * ])
+ * // → total estimate including per-message overhead
+ * ```
+ */
+export function estimateTokens(input: string | ChatMessage[]): number {
+	if (typeof input === "string") return estimateStringTokens(input);
+	let total = CONVERSATION_OVERHEAD;
+	for (const message of input) {
+		total += estimateStringTokens(message.content) + MESSAGE_OVERHEAD;
+	}
+	return total;
+}
+
+function estimateStringTokens(text: string): number {
+	if (!text || text.length === 0) return 0;
+	const words = text.split(/\s+/).filter((w) => w.length > 0);
+	let tokens = 0;
+	for (const word of words) {
+		tokens += word.length <= 4 ? 1 : Math.ceil(word.length / 4);
+	}
+	return Math.max(1, tokens);
+}

--- a/packages/ai-gateway/src/tool-registry.ts
+++ b/packages/ai-gateway/src/tool-registry.ts
@@ -1,0 +1,65 @@
+import type { GatewayToolCall, GatewayToolDefinition } from "./types";
+
+/** A tool handler pairs a definition with an execution function. */
+export interface ToolHandler {
+	/** The tool definition to expose to the model. */
+	definition: GatewayToolDefinition;
+	/** Function that executes the tool and returns a string result. */
+	handler: (args: Record<string, unknown>) => Promise<string>;
+}
+
+/** A registry that maps tool names to handlers. */
+export interface ToolRegistry {
+	/** Register a tool handler under a given name. */
+	register(name: string, tool: ToolHandler): void;
+	/** Get all registered tool definitions. */
+	getTools(): GatewayToolDefinition[];
+	/** Execute a tool call using the registered handler. */
+	execute(call: GatewayToolCall): Promise<string>;
+}
+
+/**
+ * Create a tool registry for managing and executing tool handlers.
+ *
+ * Use with `aiWithTools` (or your own dispatch loop) to automatically route
+ * the model's tool calls to registered handlers:
+ *
+ * @example
+ * ```ts
+ * const registry = createToolRegistry();
+ * registry.register("search", {
+ *   definition: {
+ *     name: "search",
+ *     description: "Search the web",
+ *     parameters: {
+ *       type: "object",
+ *       properties: { query: { type: "string" } },
+ *       required: ["query"],
+ *     },
+ *   },
+ *   handler: async (args) => JSON.stringify(await search(args.query as string)),
+ * });
+ *
+ * const result = await aiWithTools(gateway, model, input, {
+ *   tools: registry.getTools(),
+ *   handler: (call) => registry.execute(call),
+ * });
+ * ```
+ */
+export function createToolRegistry(): ToolRegistry {
+	const handlers = new Map<string, ToolHandler>();
+
+	return {
+		register(name, tool) {
+			handlers.set(name, tool);
+		},
+		getTools() {
+			return Array.from(handlers.values()).map((h) => h.definition);
+		},
+		async execute(call) {
+			const tool = handlers.get(call.name);
+			if (!tool) throw new Error(`Unknown tool: "${call.name}"`);
+			return tool.handler(call.arguments);
+		},
+	};
+}

--- a/packages/ai-gateway/src/tool-use.ts
+++ b/packages/ai-gateway/src/tool-use.ts
@@ -1,0 +1,152 @@
+import { ConfigError } from "@workkit/errors";
+import type {
+	ChatMessage,
+	Gateway,
+	GatewayToolCall,
+	GatewayToolDefinition,
+	RunOptions,
+} from "./types";
+
+const DEFAULT_MAX_TURNS = 5;
+
+/**
+ * Message format for tool-use conversations.
+ *
+ * Extends `ChatMessage` with optional `tool_calls` / `tool_call_id` fields
+ * used during multi-turn tool execution.
+ */
+export interface ToolMessage extends Omit<ChatMessage, "role"> {
+	role: "system" | "user" | "assistant" | "tool";
+	tool_calls?: GatewayToolCall[];
+	tool_call_id?: string;
+}
+
+/** Options for an `aiWithTools` session. */
+export interface AiWithToolsOptions {
+	/** Tool definitions to expose to the model. */
+	tools: GatewayToolDefinition[];
+	/** How the model should choose tools. */
+	toolChoice?: "auto" | "none" | "required" | { name: string };
+	/** Maximum number of model turns before stopping (default: 5). */
+	maxTurns?: number;
+	/**
+	 * Tool-call handler. When provided, tool calls are dispatched automatically
+	 * and results are fed back to the model for another turn. When absent, the
+	 * first set of tool calls is returned for the caller to dispatch themselves.
+	 */
+	handler?: (call: GatewayToolCall) => Promise<string>;
+	/** Per-call gateway options (abort signal, timeout, provider override, …). */
+	runOptions?: RunOptions;
+}
+
+/** Result from a tool-use session. */
+export interface AiWithToolsResult {
+	/** Final text content from the model (or "" if we hit maxTurns). */
+	content: string;
+	/** Every tool call the model made across all turns. */
+	toolCalls: GatewayToolCall[];
+	/** Provider that produced the final response. */
+	provider: string;
+	/** Model used. */
+	model: string;
+	/** Number of model turns taken. */
+	turns: number;
+}
+
+/**
+ * Run a gateway model with tool use across one or more turns.
+ *
+ * If `options.handler` is supplied, each tool call the model emits is executed
+ * and the result is fed back as a `role: "tool"` message for the next turn,
+ * up to `maxTurns`. If `handler` is absent, the first set of tool calls is
+ * returned to the caller immediately for manual dispatch.
+ *
+ * @example
+ * ```ts
+ * const registry = createToolRegistry();
+ * registry.register("get_weather", { definition, handler: async args => … });
+ *
+ * const result = await aiWithTools(gateway, "claude-sonnet-4-6",
+ *   { messages: [{ role: "user", content: "weather in SF?" }] },
+ *   { tools: registry.getTools(), handler: (call) => registry.execute(call) },
+ * );
+ * ```
+ */
+export async function aiWithTools(
+	gateway: Gateway,
+	model: string,
+	input: { messages: ToolMessage[] },
+	options: AiWithToolsOptions,
+): Promise<AiWithToolsResult> {
+	if (!gateway) {
+		throw new ConfigError("aiWithTools requires a gateway", {
+			context: { gateway: String(gateway) },
+		});
+	}
+
+	const maxTurns = options.maxTurns ?? DEFAULT_MAX_TURNS;
+	const allToolCalls: GatewayToolCall[] = [];
+	const messages = [...input.messages];
+	let turns = 0;
+	let lastProvider = gateway.defaultProvider();
+	let lastModel = model;
+
+	for (let turn = 0; turn < maxTurns; turn++) {
+		turns++;
+
+		const output = await gateway.run(
+			model,
+			// The gateway's ChatMessage doesn't model `role: "tool"` natively — we
+			// serialize tool-result messages as role:"user" below, but the
+			// assistant messages with tool_calls stay as-is for the provider to
+			// see its own prior turn.
+			{ messages: toChatMessages(messages) },
+			{
+				...options.runOptions,
+				toolOptions: {
+					tools: options.tools,
+					...(options.toolChoice !== undefined ? { toolChoice: options.toolChoice } : {}),
+				},
+			},
+		);
+		lastProvider = output.provider;
+		lastModel = output.model;
+
+		const toolCalls = output.toolCalls ?? [];
+		const content = output.text ?? "";
+
+		if (toolCalls.length === 0) {
+			return { content, toolCalls: allToolCalls, provider: lastProvider, model: lastModel, turns };
+		}
+
+		allToolCalls.push(...toolCalls);
+
+		if (!options.handler) {
+			return { content, toolCalls: allToolCalls, provider: lastProvider, model: lastModel, turns };
+		}
+
+		// Record the assistant's tool-call turn for the next iteration's prompt.
+		messages.push({ role: "assistant", content, tool_calls: toolCalls });
+
+		for (const call of toolCalls) {
+			const result = await options.handler(call);
+			messages.push({ role: "tool", content: result, tool_call_id: call.id });
+		}
+	}
+
+	return { content: "", toolCalls: allToolCalls, provider: lastProvider, model: lastModel, turns };
+}
+
+/** Flatten `ToolMessage[]` into gateway-compatible `ChatMessage[]`. */
+function toChatMessages(messages: ToolMessage[]): ChatMessage[] {
+	return messages.map((m) => {
+		if (m.role === "tool") {
+			// Serialize tool results as a user note tagged with the call id.
+			return {
+				role: "user",
+				content: `[tool result id=${m.tool_call_id ?? ""}] ${m.content}`,
+			};
+		}
+		return { role: m.role, content: m.content };
+	});
+}

--- a/packages/ai-gateway/src/tool-use.ts
+++ b/packages/ai-gateway/src/tool-use.ts
@@ -137,7 +137,15 @@ export async function aiWithTools(
 	return { content: "", toolCalls: allToolCalls, provider: lastProvider, model: lastModel, turns };
 }
 
-/** Flatten `ToolMessage[]` into gateway-compatible `ChatMessage[]`. */
+/**
+ * Flatten `ToolMessage[]` into gateway-compatible `ChatMessage[]`.
+ *
+ * The gateway's `ChatMessage` type supports `system | user | assistant` only,
+ * so tool-result messages become `role: "user"` notes and assistant messages
+ * with `tool_calls` get their call summary inlined into `content` — otherwise
+ * the model would lose context of its own prior requests and could re-issue
+ * the same calls in the next turn.
+ */
 function toChatMessages(messages: ToolMessage[]): ChatMessage[] {
 	return messages.map((m) => {
 		if (m.role === "tool") {
@@ -146,6 +154,18 @@ function toChatMessages(messages: ToolMessage[]): ChatMessage[] {
 				role: "user",
 				content: `[tool result id=${m.tool_call_id ?? ""}] ${m.content}`,
 			};
+		}
+		// Assistant turns with tool_calls: append a compact summary so the model
+		// can see what it already requested in its own prior turn. Preserves
+		// the multi-turn loop semantics of the original @workkit/ai helper.
+		if (m.role === "assistant" && m.tool_calls && m.tool_calls.length > 0) {
+			const summary = m.tool_calls
+				.map((c) => `${c.name}(${JSON.stringify(c.arguments)}) [id=${c.id}]`)
+				.join(", ");
+			const body = m.content
+				? `${m.content}\n[tool_calls: ${summary}]`
+				: `[tool_calls: ${summary}]`;
+			return { role: "assistant", content: body };
 		}
 		return { role: m.role, content: m.content };
 	});

--- a/packages/ai-gateway/tests/helpers.test.ts
+++ b/packages/ai-gateway/tests/helpers.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	StructuredOutputError,
+	aiWithTools,
+	createToolRegistry,
+	estimateTokens,
+	standardSchemaToJsonSchema,
+	structuredAI,
+} from "../src/index";
+import type { AiOutput, Gateway } from "../src/types";
+
+/** Minimal hand-rolled Standard Schema v1 adapter for tests (mirrors @workkit/ai's). */
+function createSchema<T>(
+	validate: (
+		value: unknown,
+	) =>
+		| { value: T; issues?: undefined }
+		| { issues: Array<{ message: string; path?: string[] }>; value?: undefined },
+	jsonSchemaOverride?: Record<string, unknown>,
+): {
+	"~standard": {
+		version: 1;
+		vendor: string;
+		validate: typeof validate;
+	};
+	toJSONSchema?: () => Record<string, unknown>;
+} {
+	return {
+		"~standard": { version: 1, vendor: "test", validate },
+		...(jsonSchemaOverride ? { toJSONSchema: () => jsonSchemaOverride } : {}),
+	};
+}
+
+function makeMockGateway(outputs: Array<Partial<AiOutput>>): Gateway & { calls: number } {
+	let calls = 0;
+	const gw: Gateway & { calls: number } = {
+		get calls() {
+			return calls;
+		},
+		run: vi.fn(async (_model, _input, _options) => {
+			const out = outputs[Math.min(calls, outputs.length - 1)] ?? {};
+			calls++;
+			return {
+				text: "",
+				raw: {},
+				provider: "mock",
+				model: "m",
+				...out,
+			};
+		}),
+		providers: () => ["mock"],
+		defaultProvider: () => "mock",
+	};
+	return gw;
+}
+
+describe("createToolRegistry()", () => {
+	it("registers tools, exposes definitions, and dispatches execute()", async () => {
+		const registry = createToolRegistry();
+		const handler = vi.fn(async (args: Record<string, unknown>) => `result:${args.x}`);
+		registry.register("echo", {
+			definition: { name: "echo", description: "echo", parameters: { type: "object" } },
+			handler,
+		});
+
+		expect(registry.getTools()).toEqual([
+			{ name: "echo", description: "echo", parameters: { type: "object" } },
+		]);
+		const result = await registry.execute({ id: "c1", name: "echo", arguments: { x: 42 } });
+		expect(result).toBe("result:42");
+		expect(handler).toHaveBeenCalledWith({ x: 42 });
+	});
+
+	it("throws on unknown tool name", async () => {
+		const registry = createToolRegistry();
+		await expect(registry.execute({ id: "c1", name: "missing", arguments: {} })).rejects.toThrow(
+			"Unknown tool",
+		);
+	});
+});
+
+describe("estimateTokens()", () => {
+	it("estimates a short string", () => {
+		expect(estimateTokens("hi")).toBeGreaterThan(0);
+	});
+
+	it("scales with length", () => {
+		const short = estimateTokens("hi there");
+		const long = estimateTokens(
+			"this is a much longer prompt with lots of words to count up higher",
+		);
+		expect(long).toBeGreaterThan(short);
+	});
+
+	it("adds per-message overhead for chat arrays", () => {
+		const raw = estimateTokens("hello world");
+		const chat = estimateTokens([
+			{ role: "system", content: "hello" },
+			{ role: "user", content: "world" },
+		]);
+		expect(chat).toBeGreaterThan(raw);
+	});
+});
+
+describe("standardSchemaToJsonSchema()", () => {
+	it("uses the schema's toJSONSchema() when provided", () => {
+		const schema = createSchema<{ name: string }>((v) => ({ value: v as { name: string } }), {
+			type: "object",
+			properties: { name: { type: "string" } },
+			required: ["name"],
+		});
+		const json = standardSchemaToJsonSchema(schema);
+		expect(json.type).toBe("object");
+		expect((json.properties as Record<string, unknown>).name).toMatchObject({ type: "string" });
+	});
+
+	it("falls back to a permissive {type: 'object'} for unknown shapes", () => {
+		const schema = createSchema<{ any: string }>(() => ({ issues: [{ message: "n/a" }] }));
+		const json = standardSchemaToJsonSchema(schema);
+		expect(json.type).toBe("object");
+	});
+});
+
+describe("structuredAI()", () => {
+	it("parses and validates a JSON response", async () => {
+		const gw = makeMockGateway([{ text: '{"colors":["red","blue"]}' }]);
+		const schema = createSchema<{ colors: string[] }>((v) => {
+			if (typeof v === "object" && v !== null && Array.isArray((v as { colors: unknown }).colors)) {
+				return { value: v as { colors: string[] } };
+			}
+			return { issues: [{ message: "expected {colors: string[]}" }] };
+		});
+		const result = await structuredAI(
+			gw,
+			"m",
+			{ messages: [{ role: "user", content: "colors?" }] },
+			{ schema },
+		);
+		expect(result.data).toEqual({ colors: ["red", "blue"] });
+	});
+
+	it("retries on invalid JSON then succeeds", async () => {
+		const gw = makeMockGateway([{ text: "not json" }, { text: '{"x":1}' }]);
+		const schema = createSchema<{ x: number }>((v) => {
+			if (typeof v === "object" && v !== null && typeof (v as { x: unknown }).x === "number") {
+				return { value: v as { x: number } };
+			}
+			return { issues: [{ message: "expected {x: number}" }] };
+		});
+		const result = await structuredAI(
+			gw,
+			"m",
+			{ messages: [{ role: "user", content: "x?" }] },
+			{ schema, maxRetries: 1 },
+		);
+		expect(result.data).toEqual({ x: 1 });
+		expect(gw.calls).toBe(2);
+	});
+
+	it("throws StructuredOutputError when retries exhaust", async () => {
+		const gw = makeMockGateway([{ text: "bad" }, { text: "still bad" }]);
+		const schema = createSchema<{ x: number }>(() => ({
+			issues: [{ message: "unreachable — never valid" }],
+		}));
+		await expect(
+			structuredAI(
+				gw,
+				"m",
+				{ messages: [{ role: "user", content: "?" }] },
+				{ schema, maxRetries: 1 },
+			),
+		).rejects.toBeInstanceOf(StructuredOutputError);
+	});
+});
+
+describe("aiWithTools()", () => {
+	it("returns content immediately when no tool calls", async () => {
+		const gw = makeMockGateway([{ text: "done" }]);
+		const result = await aiWithTools(
+			gw,
+			"m",
+			{ messages: [{ role: "user", content: "hi" }] },
+			{ tools: [] },
+		);
+		expect(result.content).toBe("done");
+		expect(result.toolCalls).toEqual([]);
+		expect(result.turns).toBe(1);
+	});
+
+	it("dispatches tool calls via handler and loops to completion", async () => {
+		const gw = makeMockGateway([
+			{ toolCalls: [{ id: "c1", name: "ping", arguments: {} }] },
+			{ text: "ok" },
+		]);
+		const handler = vi.fn(async () => "pong");
+		const result = await aiWithTools(
+			gw,
+			"m",
+			{ messages: [{ role: "user", content: "ping" }] },
+			{
+				tools: [{ name: "ping", description: "", parameters: { type: "object" } }],
+				handler,
+			},
+		);
+		expect(handler).toHaveBeenCalledTimes(1);
+		expect(result.content).toBe("ok");
+		expect(result.toolCalls).toHaveLength(1);
+		expect(result.turns).toBe(2);
+	});
+
+	it("returns tool calls without dispatching when no handler is supplied", async () => {
+		const gw = makeMockGateway([{ toolCalls: [{ id: "c1", name: "ping", arguments: {} }] }]);
+		const result = await aiWithTools(
+			gw,
+			"m",
+			{ messages: [{ role: "user", content: "ping" }] },
+			{ tools: [{ name: "ping", description: "", parameters: { type: "object" } }] },
+		);
+		expect(result.toolCalls).toHaveLength(1);
+		expect(result.turns).toBe(1);
+	});
+
+	it("stops at maxTurns", async () => {
+		const gw = makeMockGateway([
+			{ toolCalls: [{ id: "c1", name: "loop", arguments: {} }] },
+			{ toolCalls: [{ id: "c2", name: "loop", arguments: {} }] },
+			{ toolCalls: [{ id: "c3", name: "loop", arguments: {} }] },
+		]);
+		const result = await aiWithTools(
+			gw,
+			"m",
+			{ messages: [{ role: "user", content: "loop" }] },
+			{
+				tools: [{ name: "loop", description: "", parameters: { type: "object" } }],
+				handler: async () => "ok",
+				maxTurns: 2,
+			},
+		);
+		expect(result.turns).toBe(2);
+		expect(result.content).toBe("");
+	});
+});


### PR DESCRIPTION
Phase 2 of [ADR-001](../../.maina/decisions/001-ai-package-consolidation.md). Ports the `@workkit/ai` helpers that aren't yet in `@workkit/ai-gateway`, so the `@workkit/ai` migration guide can actually resolve against real imports.

### New exports on `@workkit/ai-gateway`

| Helper | Purpose |
|---|---|
| `createToolRegistry()` | `Map<name, handler>` for dispatching tool calls. |
| `aiWithTools(gateway, model, input, options)` | Multi-turn tool-use session with automatic dispatch + `maxTurns`. |
| `structuredAI(gateway, model, input, { schema })` | JSON-mode + Standard Schema validation + self-correcting retry. |
| `StructuredOutputError` | Thrown when `structuredAI` exhausts retries. |
| `standardSchemaToJsonSchema(schema)` | Zod / Valibot / ArkType → JSON Schema. |
| `estimateTokens(text | messages)` | Rough token heuristic for capacity planning. |

### Impact

- **Additive** — no breaking changes to existing `@workkit/ai-gateway` exports.
- **Unblocks [#63](https://github.com/beeeku/workkit/issues/63)** — `@workkit/ai` can now shim over `@workkit/ai-gateway` by re-exporting these helpers (the actual `@workkit/ai@1.0` rewrite is a separate PR).
- **Fixes the migration guide** — callers following `@workkit/ai`'s deprecation notice for `createToolRegistry` now have a real destination to import from.

### Test plan

- [x] 205/205 tests pass (14 new: registry / tokens / schema / structuredAI retry loop / aiWithTools handler + maxTurns paths).
- [x] `tsc --noEmit` clean.
- [x] `bun run lint` clean (pre-existing warnings untouched).
- [x] `bun run format` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)