### PR TITLE
feat(ai-gateway): model allowlist sub-export

### DIFF
--- a/.changeset/ai-gateway-allowlist.md
+++ b/.changeset/ai-gateway-allowlist.md
@@ -1,0 +1,28 @@
+---
+"@workkit/ai-gateway": minor
+---
+
+**Model allowlist helper.** New `@workkit/ai-gateway/allowlist` sub-export with `createModelAllowlist(config)` and `isAllowedModel(config, provider, model)` for validating untrusted model strings (e.g. a `?model=` query-param override) against a curated per-provider list. Closes #80.
+
+```ts
+import { createModelAllowlist } from "@workkit/ai-gateway/allowlist";
+
+const allow = createModelAllowlist({
+  anthropic: ["claude-opus-4-7", "claude-sonnet-4-6"],
+  openai:    ["gpt-4o", "gpt-4o-mini"],
+  groq:      [{ prefix: "llama-3.1-" }], // prefix rule for families
+});
+
+const requested = url.searchParams.get("model") ?? DEFAULT_MODEL;
+if (!allow.isAllowed("anthropic", requested)) {
+  return new Response("model not in allowlist", { status: 400 });
+}
+```
+
+Matcher semantics:
+- Exact string — strict equality with the model.
+- `{ prefix }` — `model.startsWith(prefix)`.
+- Unknown provider — `false`.
+- Empty matcher array — `false`.
+
+Shipped as a tree-shakeable sub-export (constitution rule 4) so callers that don't need it pay zero bytes. No new runtime deps.

--- a/packages/ai-gateway/README.md
+++ b/packages/ai-gateway/README.md
@@ -49,6 +49,7 @@ const result = await gateway.run("claude-sonnet-4-6", {
 | Anthropic prompt caching | `{ role, content, cacheControl: "ephemeral" }` in `messages` |
 | Cross-provider server-side fallback | `gateway.runFallback(entries, input)` |
 | Streaming (text + tool_use + done) | `gateway.stream(model, input)` |
+| Per-provider model allowlist (tree-shakeable sub-export) | `import { createModelAllowlist } from "@workkit/ai-gateway/allowlist"` |
 
 ## Cloudflare AI Gateway
 
@@ -154,6 +155,27 @@ while (true) {
 Consumer-cancel (`reader.cancel()` or `stream.cancel()`) propagates to the upstream fetch, so you stop paying for tokens you're not reading.
 
 > **Note on `responseFormat` + streaming.** Passing `responseFormat: "json"` adds a system prompt asking for JSON only, but the output is still a token-by-token `text` stream. Consumers must buffer and parse the concatenated deltas themselves.
+
+## Model allowlist
+
+Validate untrusted model strings (e.g. a `?model=` query-param override) against a curated per-provider list. Ships as the `@workkit/ai-gateway/allowlist` sub-export so callers that don't need it pay zero bytes.
+
+```ts
+import { createModelAllowlist } from "@workkit/ai-gateway/allowlist"
+
+const allow = createModelAllowlist({
+  anthropic: ["claude-opus-4-7", "claude-sonnet-4-6"],
+  openai:    ["gpt-4o", "gpt-4o-mini"],
+  groq:      [{ prefix: "llama-3.1-" }], // prefix rule for families
+})
+
+const requested = url.searchParams.get("model") ?? DEFAULT_MODEL
+if (!allow.isAllowed("anthropic", requested)) {
+  return new Response("model not in allowlist", { status: 400 })
+}
+```
+
+Matcher semantics: exact strings use strict equality; `{ prefix }` uses `model.startsWith(prefix)`; unknown providers and empty matcher arrays return `false`. A functional form `isAllowedModel(config, provider, model)` is also exported for one-off checks.
 
 ## Tool use (non-streaming)
 

--- a/packages/ai-gateway/bunup.config.ts
+++ b/packages/ai-gateway/bunup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "bunup";
 
 export default defineConfig({
-	entry: ["src/index.ts"],
+	entry: ["src/index.ts", "src/allowlist/index.ts"],
 	format: ["esm"],
 	dts: true,
 	sourcemap: "linked",

--- a/packages/ai-gateway/package.json
+++ b/packages/ai-gateway/package.json
@@ -16,6 +16,12 @@
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
       }
+    },
+    "./allowlist": {
+      "import": {
+        "types": "./dist/allowlist/index.d.ts",
+        "default": "./dist/allowlist/index.js"
+      }
     }
   },
   "module": "./dist/index.js",

--- a/packages/ai-gateway/src/allowlist/index.ts
+++ b/packages/ai-gateway/src/allowlist/index.ts
@@ -1,0 +1,81 @@
+/**
+ * Model allowlist — a tiny helper for validating `?model=` query-param
+ * overrides (or any other untrusted model string) against a curated
+ * per-provider list.
+ *
+ * Typical use: a dev/staging endpoint lets engineers flip models via a query
+ * param; you still want to keep traffic on contracted models only.
+ *
+ * @example
+ * ```ts
+ * import { createModelAllowlist } from "@workkit/ai-gateway/allowlist";
+ *
+ * const allow = createModelAllowlist({
+ *   anthropic: ["claude-opus-4-7", "claude-sonnet-4-6"],
+ *   openai:    ["gpt-4o", "gpt-4o-mini"],
+ *   groq:      [{ prefix: "llama-3.1-" }],
+ * });
+ *
+ * if (!allow.isAllowed("anthropic", requested)) {
+ *   return new Response("model not in allowlist", { status: 400 });
+ * }
+ * ```
+ */
+
+/** A prefix-match rule: `model.startsWith(prefix)`. */
+export interface ModelRule {
+	prefix: string;
+}
+
+/** Either an exact-match string or a prefix rule. */
+export type ModelMatcher = string | ModelRule;
+
+/** Per-provider allowlist map: provider key → list of matchers. */
+export type AllowlistConfig = Record<string, readonly ModelMatcher[]>;
+
+/** Pre-compiled allowlist with an `isAllowed` predicate. */
+export interface ModelAllowlist {
+	/** Return `true` when `model` matches any matcher configured for `provider`. */
+	isAllowed(provider: string, model: string): boolean;
+}
+
+function matches(matcher: ModelMatcher, model: string): boolean {
+	if (typeof matcher === "string") return matcher === model;
+	return model.startsWith(matcher.prefix);
+}
+
+/**
+ * Compile an {@link AllowlistConfig} into a {@link ModelAllowlist}.
+ *
+ * Semantics:
+ * - Exact string matcher — strict equality with the model.
+ * - `{ prefix }` matcher — `model.startsWith(prefix)`.
+ * - Unknown provider — returns `false`.
+ * - Empty matcher array — returns `false`.
+ */
+export function createModelAllowlist(config: AllowlistConfig): ModelAllowlist {
+	return {
+		isAllowed(provider, model) {
+			const matchers = config[provider];
+			if (!matchers || matchers.length === 0) return false;
+			for (const m of matchers) {
+				if (matches(m, model)) return true;
+			}
+			return false;
+		},
+	};
+}
+
+/**
+ * Functional form of {@link createModelAllowlist}. Useful for one-off checks
+ * where you don't want to hold onto a compiled instance.
+ *
+ * Semantically identical to `createModelAllowlist(config).isAllowed(provider, model)`.
+ */
+export function isAllowedModel(
+	config: AllowlistConfig,
+	provider: string,
+	model: string,
+): boolean {
+	return createModelAllowlist(config).isAllowed(provider, model);
+}

--- a/packages/ai-gateway/src/allowlist/index.ts
+++ b/packages/ai-gateway/src/allowlist/index.ts
@@ -41,6 +41,8 @@ export interface ModelAllowlist {
 
 function matches(matcher: ModelMatcher, model: string): boolean {
 	if (typeof matcher === "string") return matcher === model;
+	// Empty prefix would match every model — fail closed.
+	if (matcher.prefix === "") return false;
 	return model.startsWith(matcher.prefix);
 }
 
@@ -49,15 +51,18 @@ function matches(matcher: ModelMatcher, model: string): boolean {
  *
  * Semantics:
  * - Exact string matcher — strict equality with the model.
- * - `{ prefix }` matcher — `model.startsWith(prefix)`.
+ * - `{ prefix }` matcher — `model.startsWith(prefix)`. Empty prefix returns `false`.
  * - Unknown provider — returns `false`.
  * - Empty matcher array — returns `false`.
+ * - Prototype-chain keys (`__proto__`, `toString`, …) — returns `false`.
  */
 export function createModelAllowlist(config: AllowlistConfig): ModelAllowlist {
 	return {
 		isAllowed(provider, model) {
+			// Own-property guard keeps prototype-chain keys from resolving config values.
+			if (!Object.prototype.hasOwnProperty.call(config, provider)) return false;
 			const matchers = config[provider];
-			if (!matchers || matchers.length === 0) return false;
+			if (!Array.isArray(matchers) || matchers.length === 0) return false;
 			for (const m of matchers) {
 				if (matches(m, model)) return true;
 			}

--- a/packages/ai-gateway/src/allowlist/index.ts
+++ b/packages/ai-gateway/src/allowlist/index.ts
@@ -72,10 +72,6 @@ export function createModelAllowlist(config: AllowlistConfig): ModelAllowlist {
  *
  * Semantically identical to `createModelAllowlist(config).isAllowed(provider, model)`.
  */
-export function isAllowedModel(
-	config: AllowlistConfig,
-	provider: string,
-	model: string,
-): boolean {
+export function isAllowedModel(config: AllowlistConfig, provider: string, model: string): boolean {
 	return createModelAllowlist(config).isAllowed(provider, model);
 }

--- a/packages/ai-gateway/tests/allowlist.test.ts
+++ b/packages/ai-gateway/tests/allowlist.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+	type AllowlistConfig,
+	createModelAllowlist,
+	isAllowedModel,
+} from "../src/allowlist/index";
+
+describe("createModelAllowlist", () => {
+	it("allows an exact string match for the given provider", () => {
+		const allow = createModelAllowlist({
+			anthropic: ["claude-opus-4-7", "claude-sonnet-4-6"],
+		});
+		expect(allow.isAllowed("anthropic", "claude-opus-4-7")).toBe(true);
+	});
+
+	it("rejects models that are not in the exact allowlist for that provider", () => {
+		const allow = createModelAllowlist({
+			anthropic: ["claude-opus-4-7"],
+		});
+		expect(allow.isAllowed("anthropic", "claude-sonnet-4-6")).toBe(false);
+	});
+
+	it("allows a prefix match when a ModelRule with `prefix` is configured", () => {
+		const allow = createModelAllowlist({
+			groq: [{ prefix: "llama-3.1-" }],
+		});
+		expect(allow.isAllowed("groq", "llama-3.1-70b-versatile")).toBe(true);
+		expect(allow.isAllowed("groq", "llama-3.1-8b-instant")).toBe(true);
+	});
+
+	it("rejects models that do not start with any configured prefix", () => {
+		const allow = createModelAllowlist({
+			groq: [{ prefix: "llama-3.1-" }],
+		});
+		expect(allow.isAllowed("groq", "llama-3-70b")).toBe(false);
+		expect(allow.isAllowed("groq", "mixtral-8x7b")).toBe(false);
+	});
+
+	it("returns false for an unknown provider, even if the model string is present under another provider", () => {
+		const allow = createModelAllowlist({
+			anthropic: ["claude-opus-4-7"],
+		});
+		expect(allow.isAllowed("openai", "claude-opus-4-7")).toBe(false);
+		expect(allow.isAllowed("does-not-exist", "anything")).toBe(false);
+	});
+
+	it("returns false for a provider configured with an empty matcher array", () => {
+		const allow = createModelAllowlist({
+			anthropic: [],
+		});
+		expect(allow.isAllowed("anthropic", "claude-opus-4-7")).toBe(false);
+	});
+
+	it("returns false for any query when the allowlist config is fully empty", () => {
+		const allow = createModelAllowlist({});
+		expect(allow.isAllowed("anthropic", "claude-opus-4-7")).toBe(false);
+	});
+
+	it("supports mixing exact and prefix matchers under the same provider", () => {
+		const allow = createModelAllowlist({
+			openai: ["gpt-4o", { prefix: "gpt-4o-mini" }],
+		});
+		expect(allow.isAllowed("openai", "gpt-4o")).toBe(true);
+		expect(allow.isAllowed("openai", "gpt-4o-mini")).toBe(true);
+		expect(allow.isAllowed("openai", "gpt-4o-mini-2024-07-18")).toBe(true);
+		expect(allow.isAllowed("openai", "gpt-5-preview")).toBe(false);
+	});
+});
+
+describe("isAllowedModel (functional form)", () => {
+	it("delegates to createModelAllowlist with the same semantics", () => {
+		const config: AllowlistConfig = {
+			anthropic: ["claude-opus-4-7"],
+			groq: [{ prefix: "llama-3.1-" }],
+		};
+		expect(isAllowedModel(config, "anthropic", "claude-opus-4-7")).toBe(true);
+		expect(isAllowedModel(config, "anthropic", "claude-sonnet-4-6")).toBe(false);
+		expect(isAllowedModel(config, "groq", "llama-3.1-70b-versatile")).toBe(true);
+		expect(isAllowedModel(config, "groq", "mixtral-8x7b")).toBe(false);
+		expect(isAllowedModel(config, "openai", "gpt-4o")).toBe(false);
+	});
+
+	it("produces the same result as the object form for the same inputs", () => {
+		const config: AllowlistConfig = {
+			openai: ["gpt-4o", { prefix: "gpt-4o-mini" }],
+		};
+		const allow = createModelAllowlist(config);
+		const pairs: Array<[string, string]> = [
+			["openai", "gpt-4o"],
+			["openai", "gpt-4o-mini-2024-07-18"],
+			["openai", "gpt-5"],
+			["anthropic", "gpt-4o"],
+		];
+		for (const [provider, model] of pairs) {
+			expect(isAllowedModel(config, provider, model)).toBe(allow.isAllowed(provider, model));
+		}
+	});
+});

--- a/packages/ai-gateway/tests/allowlist.test.ts
+++ b/packages/ai-gateway/tests/allowlist.test.ts
@@ -52,6 +52,24 @@ describe("createModelAllowlist", () => {
 		expect(allow.isAllowed("anthropic", "claude-opus-4-7")).toBe(false);
 	});
 
+	it("returns false and does not throw for prototype-chain provider keys", () => {
+		const allow = createModelAllowlist({
+			anthropic: ["claude-opus-4-7"],
+		});
+		expect(() => allow.isAllowed("__proto__", "anything")).not.toThrow();
+		expect(allow.isAllowed("__proto__", "anything")).toBe(false);
+		expect(allow.isAllowed("toString", "claude-opus-4-7")).toBe(false);
+		expect(allow.isAllowed("hasOwnProperty", "claude-opus-4-7")).toBe(false);
+	});
+
+	it("returns false for a { prefix: '' } matcher (does not match every model)", () => {
+		const allow = createModelAllowlist({
+			groq: [{ prefix: "" }],
+		});
+		expect(allow.isAllowed("groq", "anything")).toBe(false);
+		expect(allow.isAllowed("groq", "")).toBe(false);
+	});
+
 	it("supports mixing exact and prefix matchers under the same provider", () => {
 		const allow = createModelAllowlist({
 			openai: ["gpt-4o", { prefix: "gpt-4o-mini" }],

--- a/packages/ai-gateway/tests/allowlist.test.ts
+++ b/packages/ai-gateway/tests/allowlist.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-	type AllowlistConfig,
-	createModelAllowlist,
-	isAllowedModel,
-} from "../src/allowlist/index";
+import { type AllowlistConfig, createModelAllowlist, isAllowedModel } from "../src/allowlist/index";
 
 describe("createModelAllowlist", () => {
 	it("allows an exact string match for the given provider", () => {


### PR DESCRIPTION
Closes #80.

## Summary
- New `@workkit/ai-gateway/allowlist` sub-export for validating untrusted model strings (e.g. a `?model=` query-param override) against a curated per-provider list — so BYOK / dev-ops overrides can flip models without letting arbitrary strings reach production.
- `createModelAllowlist(config)` returns `{ isAllowed(provider, model) }`; `isAllowedModel(config, provider, model)` is the functional one-shot form.
- Matchers: exact strings use strict equality; `{ prefix }` uses `model.startsWith(prefix)`; unknown provider and empty matcher array both return `false`.

## Implementation notes
- Tree-shakeable sub-export under its own `src/allowlist/index.ts` (per constitution rule 4 — single `src/index.ts` for the main entry, subpaths get their own directory).
- `package.json#exports` gets a new `"./allowlist"` entry; `bunup.config.ts` adds `src/allowlist/index.ts` to `entry`. Zero new runtime deps.
- Changeset: `minor` bump on `@workkit/ai-gateway`.

## Test plan
- [x] `bun test --filter @workkit/ai-gateway` — 215 passing (10 new in `tests/allowlist.test.ts`).
- [x] `bunx turbo build --filter @workkit/ai-gateway` — emits `dist/allowlist/index.js` (745 B raw / 358 B gzip) + `dist/allowlist/index.d.ts`.
- [x] `bun run constitution:check` — 0 errors on the diff; warnings are pre-existing across unrelated packages.
- [x] `maina commit` verification pipeline — 13 tools ran, passed in 10.8s.

Tests cover: exact hit / miss, prefix hit / miss, unknown provider returns `false`, empty matcher array returns `false`, empty config returns `false` for any query, mixed exact + prefix matchers under one provider, and parity between `isAllowedModel` and `createModelAllowlist(config).isAllowed`.