### PR TITLE
feat(chat): onFrameIn/onFrameOut transport hooks (#82)

### DIFF
--- a/.changeset/chat-frame-hooks.md
+++ b/.changeset/chat-frame-hooks.md
@@ -1,0 +1,26 @@
+---
+"@workkit/chat": minor
+---
+
+**Add `onFrameIn` / `onFrameOut` transport hooks for observability (closes #82).**
+
+`createChatTransport` now accepts two optional hooks on `ChatTransportOptions`:
+
+- `onFrameIn(event: InboundFrameEvent)` fires at each inbound lifecycle phase:
+  `received` (raw frame, pre-decode), `decoded` (parsed `ChatMessage`),
+  `handled` (user `onMessage` returned cleanly), and `rejected` (size-limit
+  violation, decode failure, or a throw from `onMessage`). `event.error` is
+  populated on `rejected`; `event.message` is populated once decoded.
+- `onFrameOut(event: OutboundFrameEvent)` fires for each `ChatMessage` the
+  transport writes to the socket with phase `sent` or `send-failed`
+  (phase `send-failed` carries the `error`). Heartbeat `ping` frames are not
+  `ChatMessage`s and are intentionally not surfaced.
+
+Hooks are fire-and-forget — a throw (or rejected promise) from either hook is
+swallowed and never crashes the worker or skips downstream transport work,
+matching the existing `onConnect` / `onDisconnect` swallow semantics.
+
+Two new exported types: `InboundFrameEvent`, `OutboundFrameEvent`.
+
+No existing public signatures change; all behaviour is opt-in via the new
+hook fields.

--- a/packages/chat/src/index.ts
+++ b/packages/chat/src/index.ts
@@ -19,5 +19,7 @@ export type {
 	ChatMessage,
 	ChatMessageType,
 	ChatTransportOptions,
+	InboundFrameEvent,
+	OutboundFrameEvent,
 	SessionState,
 } from "./types";

--- a/packages/chat/src/transport.ts
+++ b/packages/chat/src/transport.ts
@@ -119,9 +119,7 @@ export function createChatTransport(options: ChatTransportOptions): ChatTranspor
 					const byteLength = new TextEncoder().encode(raw).byteLength;
 					fireFrameIn({ sessionId, phase: "received", bytes: byteLength });
 					if (byteLength > maxMessageSize) {
-						const sizeErr = new Error(
-							`Message exceeds maximum size of ${maxMessageSize} bytes`,
-						);
+						const sizeErr = new Error(`Message exceeds maximum size of ${maxMessageSize} bytes`);
 						fireFrameIn({
 							sessionId,
 							phase: "rejected",

--- a/packages/chat/src/transport.ts
+++ b/packages/chat/src/transport.ts
@@ -110,13 +110,17 @@ export function createChatTransport(options: ChatTransportOptions): ChatTranspor
 
 			server.addEventListener("message", (event: MessageEvent) => {
 				void (async () => {
-					const raw =
-						typeof event.data === "string"
-							? event.data
-							: new TextDecoder().decode(event.data as ArrayBuffer);
+					// Measure bytes from the raw frame so the count stays accurate for
+					// payloads that aren't valid UTF-8. Only decode to string when we
+					// actually need a string (size check + message decode below).
+					const isString = typeof event.data === "string";
+					const byteLength = isString
+						? new TextEncoder().encode(event.data as string).byteLength
+						: (event.data as ArrayBuffer).byteLength;
+					const raw = isString
+						? (event.data as string)
+						: new TextDecoder().decode(event.data as ArrayBuffer);
 
-					// Size check
-					const byteLength = new TextEncoder().encode(raw).byteLength;
 					fireFrameIn({ sessionId, phase: "received", bytes: byteLength });
 					if (byteLength > maxMessageSize) {
 						const sizeErr = new Error(`Message exceeds maximum size of ${maxMessageSize} bytes`);
@@ -198,11 +202,15 @@ export function createChatTransport(options: ChatTransportOptions): ChatTranspor
 							message: incomingMessage,
 							error: handlerErr,
 						});
+						// Only echo the message back to the client when the throw was a
+						// real Error (whose .message is part of the explicit contract);
+						// anything else stays generic so we don't leak internals from a
+						// stringified non-Error throw.
 						const errorMsg: ChatMessage = {
 							id: createMessageId(),
 							type: "error",
 							role: "system",
-							content: handlerErr.message,
+							content: err instanceof Error ? err.message : "Internal error processing message",
 							timestamp: Date.now(),
 						};
 						sendMessage(errorMsg);

--- a/packages/chat/src/transport.ts
+++ b/packages/chat/src/transport.ts
@@ -1,6 +1,11 @@
 import { ChatError } from "./errors";
 import { createMessageId, decodeMessage, encodeMessage } from "./protocol";
-import type { ChatMessage, ChatTransportOptions } from "./types";
+import type {
+	ChatMessage,
+	ChatTransportOptions,
+	InboundFrameEvent,
+	OutboundFrameEvent,
+} from "./types";
 
 const DEFAULT_HEARTBEAT_INTERVAL = 30_000;
 const DEFAULT_MAX_MESSAGE_SIZE = 65_536;
@@ -23,6 +28,36 @@ export interface ChatTransport {
 export function createChatTransport(options: ChatTransportOptions): ChatTransport {
 	const heartbeatInterval = options.heartbeatInterval ?? DEFAULT_HEARTBEAT_INTERVAL;
 	const maxMessageSize = options.maxMessageSize ?? DEFAULT_MAX_MESSAGE_SIZE;
+
+	// Fire-and-forget hook wrappers — throwing from a hook must never crash
+	// the worker or skip downstream transport work. Matches the existing
+	// onConnect / onDisconnect swallow pattern.
+	const fireFrameIn = (event: InboundFrameEvent): void => {
+		if (!options.onFrameIn) return;
+		try {
+			const result = options.onFrameIn(event);
+			if (result && typeof (result as Promise<void>).catch === "function") {
+				(result as Promise<void>).catch(() => {
+					// Swallow — observability must not crash the worker
+				});
+			}
+		} catch {
+			// Swallow — observability must not crash the worker
+		}
+	};
+	const fireFrameOut = (event: OutboundFrameEvent): void => {
+		if (!options.onFrameOut) return;
+		try {
+			const result = options.onFrameOut(event);
+			if (result && typeof (result as Promise<void>).catch === "function") {
+				(result as Promise<void>).catch(() => {
+					// Swallow — observability must not crash the worker
+				});
+			}
+		} catch {
+			// Swallow — observability must not crash the worker
+		}
+	};
 
 	return {
 		handleUpgrade(_request: Request, sessionId: string): Response {
@@ -54,6 +89,25 @@ export function createChatTransport(options: ChatTransportOptions): ChatTranspor
 				});
 			}
 
+			// Encodes `msg`, sends it over the server socket, and fires onFrameOut
+			// in either `sent` or `send-failed` phase. Does not rethrow.
+			const sendMessage = (msg: ChatMessage): void => {
+				const encoded = encodeMessage(msg);
+				const bytes = new TextEncoder().encode(encoded).byteLength;
+				try {
+					server.send(encoded);
+					fireFrameOut({ sessionId, phase: "sent", bytes, message: msg });
+				} catch (err) {
+					fireFrameOut({
+						sessionId,
+						phase: "send-failed",
+						bytes,
+						message: msg,
+						error: err instanceof Error ? err : new Error(String(err)),
+					});
+				}
+			};
+
 			server.addEventListener("message", (event: MessageEvent) => {
 				void (async () => {
 					const raw =
@@ -63,15 +117,25 @@ export function createChatTransport(options: ChatTransportOptions): ChatTranspor
 
 					// Size check
 					const byteLength = new TextEncoder().encode(raw).byteLength;
+					fireFrameIn({ sessionId, phase: "received", bytes: byteLength });
 					if (byteLength > maxMessageSize) {
+						const sizeErr = new Error(
+							`Message exceeds maximum size of ${maxMessageSize} bytes`,
+						);
+						fireFrameIn({
+							sessionId,
+							phase: "rejected",
+							bytes: byteLength,
+							error: sizeErr,
+						});
 						const errorMsg: ChatMessage = {
 							id: createMessageId(),
 							type: "error",
 							role: "system",
-							content: `Message exceeds maximum size of ${maxMessageSize} bytes`,
+							content: sizeErr.message,
 							timestamp: Date.now(),
 						};
-						server.send(encodeMessage(errorMsg));
+						sendMessage(errorMsg);
 						return;
 					}
 
@@ -79,6 +143,13 @@ export function createChatTransport(options: ChatTransportOptions): ChatTranspor
 					try {
 						wire = decodeMessage(raw);
 					} catch (err) {
+						const decodeErr = err instanceof Error ? err : new Error(String(err));
+						fireFrameIn({
+							sessionId,
+							phase: "rejected",
+							bytes: byteLength,
+							error: decodeErr,
+						});
 						const errorMsg: ChatMessage = {
 							id: createMessageId(),
 							type: "error",
@@ -86,7 +157,7 @@ export function createChatTransport(options: ChatTransportOptions): ChatTranspor
 							content: err instanceof ChatError ? err.message : "Failed to decode message",
 							timestamp: Date.now(),
 						};
-						server.send(encodeMessage(errorMsg));
+						sendMessage(errorMsg);
 						return;
 					}
 
@@ -99,24 +170,44 @@ export function createChatTransport(options: ChatTransportOptions): ChatTranspor
 						metadata: wire.metadata,
 						timestamp: Date.now(),
 					};
+					fireFrameIn({
+						sessionId,
+						phase: "decoded",
+						bytes: byteLength,
+						message: incomingMessage,
+					});
 
 					try {
 						const result = await options.onMessage(sessionId, incomingMessage);
 						if (result) {
 							const messages = Array.isArray(result) ? result : [result];
 							for (const msg of messages) {
-								server.send(encodeMessage(msg));
+								sendMessage(msg);
 							}
 						}
+						fireFrameIn({
+							sessionId,
+							phase: "handled",
+							bytes: byteLength,
+							message: incomingMessage,
+						});
 					} catch (err) {
+						const handlerErr = err instanceof Error ? err : new Error(String(err));
+						fireFrameIn({
+							sessionId,
+							phase: "rejected",
+							bytes: byteLength,
+							message: incomingMessage,
+							error: handlerErr,
+						});
 						const errorMsg: ChatMessage = {
 							id: createMessageId(),
 							type: "error",
 							role: "system",
-							content: err instanceof Error ? err.message : "Internal error processing message",
+							content: handlerErr.message,
 							timestamp: Date.now(),
 						};
-						server.send(encodeMessage(errorMsg));
+						sendMessage(errorMsg);
 					}
 				})();
 			});

--- a/packages/chat/src/types.ts
+++ b/packages/chat/src/types.ts
@@ -17,6 +17,53 @@ export interface ChatMessage {
 	timestamp: number;
 }
 
+/**
+ * Event emitted on inbound frames (messages received from the client) at each
+ * lifecycle phase. Hooks are fire-and-forget — throwing from `onFrameIn` will
+ * not crash the worker or skip downstream phases.
+ *
+ * Phases:
+ * - `received`  — raw frame arrived; emitted before any decode. `bytes` is the
+ *                 UTF-8 byte length of the wire payload.
+ * - `decoded`   — payload parsed into a `ChatMessage`; `message` is populated.
+ * - `handled`   — the `onMessage` handler returned successfully; `message` is
+ *                 populated, `error` is absent.
+ * - `rejected`  — the frame was not successfully handled. Triggered by:
+ *                 size-limit violation, decode failure, or a throw from the
+ *                 `onMessage` handler. `error` is always populated. `message`
+ *                 is populated only when the throw came from the handler
+ *                 (i.e. decode had already succeeded).
+ */
+export interface InboundFrameEvent {
+	sessionId: string;
+	phase: "received" | "decoded" | "handled" | "rejected";
+	/** UTF-8 byte length of the raw wire payload. */
+	bytes: number;
+	/** Present once the frame has been decoded into a `ChatMessage`. */
+	message?: ChatMessage;
+	/** Present on `rejected` (size reject, decode failure, or handler throw). */
+	error?: Error;
+}
+
+/**
+ * Event emitted on outbound frames (messages sent to the client) from the
+ * transport. Heartbeat pings are not `ChatMessage`s and are intentionally not
+ * surfaced on this hook.
+ *
+ * Phases:
+ * - `sent`         — `server.send` returned without throwing for this message.
+ * - `send-failed`  — `server.send` threw; `error` is populated.
+ */
+export interface OutboundFrameEvent {
+	sessionId: string;
+	phase: "sent" | "send-failed";
+	/** UTF-8 byte length of the encoded wire payload. */
+	bytes: number;
+	message: ChatMessage;
+	/** Present on `send-failed`. */
+	error?: Error;
+}
+
 /** Options for creating a chat transport */
 export interface ChatTransportOptions {
 	/** Called when a message arrives on the WebSocket. Return message(s) to send back. */
@@ -32,6 +79,19 @@ export interface ChatTransportOptions {
 	heartbeatInterval?: number;
 	/** Maximum incoming message size in bytes. Default: 65536 */
 	maxMessageSize?: number;
+	/**
+	 * Transport-level observability hook fired at each phase of an inbound
+	 * frame's lifecycle (`received` / `decoded` / `handled` / `rejected`).
+	 * Errors thrown from this hook are swallowed and do not affect frame
+	 * handling. See {@link InboundFrameEvent}.
+	 */
+	onFrameIn?: (event: InboundFrameEvent) => void | Promise<void>;
+	/**
+	 * Transport-level observability hook fired for each outbound message
+	 * (not heartbeat pings). Errors thrown from this hook are swallowed and
+	 * do not affect transport behaviour. See {@link OutboundFrameEvent}.
+	 */
+	onFrameOut?: (event: OutboundFrameEvent) => void | Promise<void>;
 }
 
 /** Persisted state for a single chat session */

--- a/packages/chat/src/types.ts
+++ b/packages/chat/src/types.ts
@@ -34,16 +34,27 @@ export interface ChatMessage {
  *                 is populated only when the throw came from the handler
  *                 (i.e. decode had already succeeded).
  */
-export interface InboundFrameEvent {
+interface InboundFrameEventBase {
 	sessionId: string;
-	phase: "received" | "decoded" | "handled" | "rejected";
-	/** UTF-8 byte length of the raw wire payload. */
+	/**
+	 * Byte length of the raw wire payload: `ArrayBuffer.byteLength` for binary
+	 * frames, UTF-8 byte length for string frames. Stable even if the payload
+	 * isn't valid UTF-8.
+	 */
 	bytes: number;
-	/** Present once the frame has been decoded into a `ChatMessage`. */
-	message?: ChatMessage;
-	/** Present on `rejected` (size reject, decode failure, or handler throw). */
-	error?: Error;
 }
+
+/** Discriminated inbound-frame event — `phase` narrows the shape. */
+export type InboundFrameEvent =
+	| (InboundFrameEventBase & { phase: "received" })
+	| (InboundFrameEventBase & { phase: "decoded"; message: ChatMessage })
+	| (InboundFrameEventBase & { phase: "handled"; message: ChatMessage })
+	| (InboundFrameEventBase & {
+			phase: "rejected";
+			/** Decoded message when the reject happened post-decode (handler throw); otherwise absent. */
+			message?: ChatMessage;
+			error: Error;
+	  });
 
 /**
  * Event emitted on outbound frames (messages sent to the client) from the
@@ -54,15 +65,17 @@ export interface InboundFrameEvent {
  * - `sent`         — `server.send` returned without throwing for this message.
  * - `send-failed`  — `server.send` threw; `error` is populated.
  */
-export interface OutboundFrameEvent {
+interface OutboundFrameEventBase {
 	sessionId: string;
-	phase: "sent" | "send-failed";
 	/** UTF-8 byte length of the encoded wire payload. */
 	bytes: number;
 	message: ChatMessage;
-	/** Present on `send-failed`. */
-	error?: Error;
 }
+
+/** Discriminated outbound-frame event — `phase` narrows the shape. */
+export type OutboundFrameEvent =
+	| (OutboundFrameEventBase & { phase: "sent" })
+	| (OutboundFrameEventBase & { phase: "send-failed"; error: Error });
 
 /** Options for creating a chat transport */
 export interface ChatTransportOptions {

--- a/packages/chat/tests/frame-hooks.test.ts
+++ b/packages/chat/tests/frame-hooks.test.ts
@@ -1,0 +1,433 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createChatTransport } from "../src/transport";
+import type {
+	ChatMessage,
+	ChatTransportOptions,
+	InboundFrameEvent,
+	OutboundFrameEvent,
+} from "../src/types";
+
+// --- Reuse the Mock WebSocket / Response pattern from transport.test.ts ---
+
+const OriginalResponse = globalThis.Response;
+
+class MockResponse {
+	status: number;
+	webSocket: unknown;
+	body: unknown;
+
+	constructor(body: unknown, init?: { status?: number; webSocket?: unknown }) {
+		this.body = body;
+		this.status = init?.status ?? 200;
+		this.webSocket = init?.webSocket;
+	}
+}
+
+class MockWebSocket {
+	readonly sent: string[] = [];
+	readonly listeners: Map<string, ((...args: any[]) => void)[]> = new Map();
+	readyState = 1; // OPEN
+
+	/** If set, send() throws this error on each call. */
+	sendShouldThrow: Error | undefined;
+
+	accept() {}
+
+	send(data: string) {
+		if (this.sendShouldThrow) {
+			throw this.sendShouldThrow;
+		}
+		this.sent.push(data);
+	}
+
+	addEventListener(event: string, handler: (...args: any[]) => void) {
+		const existing = this.listeners.get(event) ?? [];
+		existing.push(handler);
+		this.listeners.set(event, existing);
+	}
+
+	close(_code?: number, _reason?: string) {
+		this.readyState = 3;
+	}
+
+	_emit(event: string, data?: unknown) {
+		const handlers = this.listeners.get(event) ?? [];
+		for (const handler of handlers) {
+			handler(data);
+		}
+	}
+}
+
+function installMocks(): { getLastPair: () => [MockWebSocket, MockWebSocket] } {
+	let lastClient: MockWebSocket;
+	let lastServer: MockWebSocket;
+
+	(globalThis as any).WebSocketPair = class {
+		0: MockWebSocket;
+		1: MockWebSocket;
+		constructor() {
+			lastClient = new MockWebSocket();
+			lastServer = new MockWebSocket();
+			this[0] = lastClient;
+			this[1] = lastServer;
+		}
+	};
+
+	(globalThis as any).Response = MockResponse;
+
+	return {
+		getLastPair: () => [lastClient, lastServer],
+	};
+}
+
+function cleanupMocks() {
+	(globalThis as any).WebSocketPair = undefined;
+	(globalThis as any).Response = OriginalResponse;
+}
+
+function dummyRequest(): Request {
+	return new Request("http://localhost/ws");
+}
+
+function makeOptions(overrides?: Partial<ChatTransportOptions>): ChatTransportOptions {
+	return {
+		onMessage: vi.fn().mockResolvedValue(undefined),
+		...overrides,
+	};
+}
+
+describe("chat transport frame hooks", () => {
+	let wsHelper: ReturnType<typeof installMocks>;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		wsHelper = installMocks();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		cleanupMocks();
+	});
+
+	it("fires onFrameIn with phase 'received' + correct bytes + sessionId", async () => {
+		const onFrameIn = vi.fn();
+		const transport = createChatTransport(makeOptions({ onFrameIn }));
+		transport.handleUpgrade(dummyRequest(), "s-recv");
+
+		const [, server] = wsHelper.getLastPair();
+		const raw = JSON.stringify({ type: "message", content: "hello", role: "user" });
+		server._emit("message", { data: raw });
+
+		await vi.waitFor(() => {
+			expect(onFrameIn).toHaveBeenCalled();
+		});
+
+		const expectedBytes = new TextEncoder().encode(raw).byteLength;
+		const received = onFrameIn.mock.calls
+			.map((c) => c[0] as InboundFrameEvent)
+			.find((evt) => evt.phase === "received");
+		expect(received).toBeDefined();
+		expect(received?.sessionId).toBe("s-recv");
+		expect(received?.bytes).toBe(expectedBytes);
+		expect(received?.message).toBeUndefined();
+		expect(received?.error).toBeUndefined();
+	});
+
+	it("fires onFrameIn with phase 'decoded' after a successful decode, with the ChatMessage", async () => {
+		const onFrameIn = vi.fn();
+		const transport = createChatTransport(makeOptions({ onFrameIn }));
+		transport.handleUpgrade(dummyRequest(), "s-dec");
+
+		const [, server] = wsHelper.getLastPair();
+		const raw = JSON.stringify({
+			type: "message",
+			content: "hi",
+			role: "user",
+			id: "msg-42",
+		});
+		server._emit("message", { data: raw });
+
+		await vi.waitFor(() => {
+			const phases = onFrameIn.mock.calls.map((c) => (c[0] as InboundFrameEvent).phase);
+			expect(phases).toContain("decoded");
+		});
+
+		const decoded = onFrameIn.mock.calls
+			.map((c) => c[0] as InboundFrameEvent)
+			.find((evt) => evt.phase === "decoded");
+		expect(decoded).toBeDefined();
+		expect(decoded?.sessionId).toBe("s-dec");
+		expect(decoded?.message).toBeDefined();
+		expect(decoded?.message?.id).toBe("msg-42");
+		expect(decoded?.message?.type).toBe("message");
+		expect(decoded?.message?.content).toBe("hi");
+		expect(decoded?.message?.role).toBe("user");
+	});
+
+	it("fires onFrameIn with phase 'handled' after onMessage returns successfully", async () => {
+		const onFrameIn = vi.fn();
+		const onMessage = vi.fn().mockResolvedValue(undefined);
+		const transport = createChatTransport(makeOptions({ onMessage, onFrameIn }));
+		transport.handleUpgrade(dummyRequest(), "s-hand");
+
+		const [, server] = wsHelper.getLastPair();
+		server._emit("message", {
+			data: JSON.stringify({ type: "message", content: "hey", role: "user" }),
+		});
+
+		await vi.waitFor(() => {
+			const phases = onFrameIn.mock.calls.map((c) => (c[0] as InboundFrameEvent).phase);
+			expect(phases).toContain("handled");
+		});
+
+		const handled = onFrameIn.mock.calls
+			.map((c) => c[0] as InboundFrameEvent)
+			.find((evt) => evt.phase === "handled");
+		expect(handled).toBeDefined();
+		expect(handled?.sessionId).toBe("s-hand");
+		expect(handled?.message).toBeDefined();
+		expect(handled?.error).toBeUndefined();
+	});
+
+	it("fires onFrameIn with phase 'rejected' + error when size limit is exceeded", async () => {
+		const onFrameIn = vi.fn();
+		const transport = createChatTransport(
+			makeOptions({ onFrameIn, maxMessageSize: 20 }),
+		);
+		transport.handleUpgrade(dummyRequest(), "s-big");
+
+		const [, server] = wsHelper.getLastPair();
+		const raw = JSON.stringify({ type: "message", content: "A".repeat(200), role: "user" });
+		server._emit("message", { data: raw });
+
+		await vi.waitFor(() => {
+			const phases = onFrameIn.mock.calls.map((c) => (c[0] as InboundFrameEvent).phase);
+			expect(phases).toContain("rejected");
+		});
+
+		const rejected = onFrameIn.mock.calls
+			.map((c) => c[0] as InboundFrameEvent)
+			.find((evt) => evt.phase === "rejected");
+		expect(rejected).toBeDefined();
+		expect(rejected?.sessionId).toBe("s-big");
+		expect(rejected?.error).toBeInstanceOf(Error);
+		expect(rejected?.error?.message).toMatch(/exceeds maximum size/i);
+		expect(rejected?.message).toBeUndefined();
+
+		// No decoded / handled phase should fire on size reject
+		const phases = onFrameIn.mock.calls.map((c) => (c[0] as InboundFrameEvent).phase);
+		expect(phases).not.toContain("decoded");
+		expect(phases).not.toContain("handled");
+	});
+
+	it("fires onFrameIn with phase 'rejected' + error when JSON decode fails", async () => {
+		const onFrameIn = vi.fn();
+		const transport = createChatTransport(makeOptions({ onFrameIn }));
+		transport.handleUpgrade(dummyRequest(), "s-bad");
+
+		const [, server] = wsHelper.getLastPair();
+		server._emit("message", { data: "<<not json>>" });
+
+		await vi.waitFor(() => {
+			const phases = onFrameIn.mock.calls.map((c) => (c[0] as InboundFrameEvent).phase);
+			expect(phases).toContain("rejected");
+		});
+
+		const rejected = onFrameIn.mock.calls
+			.map((c) => c[0] as InboundFrameEvent)
+			.find((evt) => evt.phase === "rejected");
+		expect(rejected).toBeDefined();
+		expect(rejected?.error).toBeInstanceOf(Error);
+		expect(rejected?.message).toBeUndefined();
+
+		const phases = onFrameIn.mock.calls.map((c) => (c[0] as InboundFrameEvent).phase);
+		expect(phases).not.toContain("decoded");
+		expect(phases).not.toContain("handled");
+	});
+
+	it("fires onFrameIn with phase 'rejected' + handler error when onMessage throws", async () => {
+		const onFrameIn = vi.fn();
+		const handlerErr = new Error("boom-from-handler");
+		const onMessage = vi.fn().mockRejectedValue(handlerErr);
+		const transport = createChatTransport(makeOptions({ onMessage, onFrameIn }));
+		transport.handleUpgrade(dummyRequest(), "s-throw");
+
+		const [, server] = wsHelper.getLastPair();
+		server._emit("message", {
+			data: JSON.stringify({ type: "message", content: "go", role: "user" }),
+		});
+
+		await vi.waitFor(() => {
+			const phases = onFrameIn.mock.calls.map((c) => (c[0] as InboundFrameEvent).phase);
+			expect(phases).toContain("rejected");
+		});
+
+		const rejected = onFrameIn.mock.calls
+			.map((c) => c[0] as InboundFrameEvent)
+			.find((evt) => evt.phase === "rejected");
+		expect(rejected).toBeDefined();
+		expect(rejected?.sessionId).toBe("s-throw");
+		expect(rejected?.error).toBe(handlerErr);
+		// message should be populated — we already decoded it before the handler ran
+		expect(rejected?.message).toBeDefined();
+		expect(rejected?.message?.content).toBe("go");
+
+		// handled should NOT fire when handler throws
+		const phases = onFrameIn.mock.calls.map((c) => (c[0] as InboundFrameEvent).phase);
+		expect(phases).not.toContain("handled");
+	});
+
+	it("fires onFrameOut with phase 'sent' for each message returned by the handler", async () => {
+		const responses: ChatMessage[] = [
+			{
+				id: "r1",
+				type: "message",
+				role: "assistant",
+				content: "one",
+				timestamp: Date.now(),
+			},
+			{
+				id: "r2",
+				type: "message",
+				role: "assistant",
+				content: "two",
+				timestamp: Date.now(),
+			},
+		];
+		const onMessage = vi.fn().mockResolvedValue(responses);
+		const onFrameOut = vi.fn();
+		const transport = createChatTransport(makeOptions({ onMessage, onFrameOut }));
+		transport.handleUpgrade(dummyRequest(), "s-out");
+
+		const [, server] = wsHelper.getLastPair();
+		server._emit("message", {
+			data: JSON.stringify({ type: "message", content: "ping", role: "user" }),
+		});
+
+		await vi.waitFor(() => {
+			const sent = onFrameOut.mock.calls
+				.map((c) => c[0] as OutboundFrameEvent)
+				.filter((e) => e.phase === "sent");
+			expect(sent).toHaveLength(2);
+		});
+
+		const sent = onFrameOut.mock.calls
+			.map((c) => c[0] as OutboundFrameEvent)
+			.filter((e) => e.phase === "sent");
+		expect(sent[0].sessionId).toBe("s-out");
+		expect(sent[0].message.id).toBe("r1");
+		expect(sent[0].bytes).toBe(
+			new TextEncoder().encode(JSON.stringify(responses[0])).byteLength,
+		);
+		expect(sent[1].message.id).toBe("r2");
+		expect(sent[0].error).toBeUndefined();
+	});
+
+	it("does not fire onFrameOut for heartbeat pings", () => {
+		const onFrameOut = vi.fn();
+		const transport = createChatTransport(
+			makeOptions({ onFrameOut, heartbeatInterval: 1000 }),
+		);
+		transport.handleUpgrade(dummyRequest(), "s-hb");
+
+		vi.advanceTimersByTime(3000);
+		expect(onFrameOut).not.toHaveBeenCalled();
+	});
+
+	it("fires onFrameOut with phase 'send-failed' when server.send throws", async () => {
+		const responseMsg: ChatMessage = {
+			id: "r-fail",
+			type: "message",
+			role: "assistant",
+			content: "x",
+			timestamp: Date.now(),
+		};
+		const onMessage = vi.fn().mockResolvedValue(responseMsg);
+		const onFrameOut = vi.fn();
+		const transport = createChatTransport(makeOptions({ onMessage, onFrameOut }));
+		transport.handleUpgrade(dummyRequest(), "s-fail");
+
+		const [, server] = wsHelper.getLastPair();
+		const sendErr = new Error("socket gone");
+		server.sendShouldThrow = sendErr;
+
+		server._emit("message", {
+			data: JSON.stringify({ type: "message", content: "trigger", role: "user" }),
+		});
+
+		await vi.waitFor(() => {
+			const phases = onFrameOut.mock.calls.map((c) => (c[0] as OutboundFrameEvent).phase);
+			expect(phases).toContain("send-failed");
+		});
+
+		const failed = onFrameOut.mock.calls
+			.map((c) => c[0] as OutboundFrameEvent)
+			.find((e) => e.phase === "send-failed");
+		expect(failed).toBeDefined();
+		expect(failed?.sessionId).toBe("s-fail");
+		expect(failed?.message.id).toBe("r-fail");
+		expect(failed?.error).toBe(sendErr);
+	});
+
+	it("does not crash when onFrameIn throws — subsequent frames still fire", async () => {
+		const calls: InboundFrameEvent[] = [];
+		let throwCount = 0;
+		const onFrameIn = vi.fn((evt: InboundFrameEvent) => {
+			calls.push(evt);
+			if (evt.phase === "received") {
+				throwCount++;
+				throw new Error("hook-boom");
+			}
+		});
+		const onMessage = vi.fn().mockResolvedValue(undefined);
+		const transport = createChatTransport(makeOptions({ onMessage, onFrameIn }));
+		transport.handleUpgrade(dummyRequest(), "s-hookthrow");
+
+		const [, server] = wsHelper.getLastPair();
+		server._emit("message", {
+			data: JSON.stringify({ type: "message", content: "one", role: "user" }),
+		});
+
+		await vi.waitFor(() => {
+			const phases = calls.map((c) => c.phase);
+			expect(phases).toContain("handled");
+		});
+
+		// Received threw, but decoded + handled still fired
+		expect(throwCount).toBe(1);
+		const phases = calls.map((c) => c.phase);
+		expect(phases).toContain("received");
+		expect(phases).toContain("decoded");
+		expect(phases).toContain("handled");
+	});
+
+	it("does not crash when onFrameOut throws — handler return path completes", async () => {
+		const responseMsg: ChatMessage = {
+			id: "r-ok",
+			type: "message",
+			role: "assistant",
+			content: "hi",
+			timestamp: Date.now(),
+		};
+		const onMessage = vi.fn().mockResolvedValue(responseMsg);
+		const onFrameOut = vi.fn(() => {
+			throw new Error("out-hook-boom");
+		});
+		const transport = createChatTransport(makeOptions({ onMessage, onFrameOut }));
+		transport.handleUpgrade(dummyRequest(), "s-outthrow");
+
+		const [, server] = wsHelper.getLastPair();
+		server._emit("message", {
+			data: JSON.stringify({ type: "message", content: "ping", role: "user" }),
+		});
+
+		// The outbound message must still be actually sent over the wire
+		// even though the hook threw.
+		await vi.waitFor(() => {
+			expect(server.sent.length).toBeGreaterThan(0);
+		});
+		const wire = JSON.parse(server.sent[0]);
+		expect(wire.id).toBe("r-ok");
+		expect(onFrameOut).toHaveBeenCalled();
+	});
+});

--- a/packages/chat/tests/frame-hooks.test.ts
+++ b/packages/chat/tests/frame-hooks.test.ts
@@ -191,9 +191,7 @@ describe("chat transport frame hooks", () => {
 
 	it("fires onFrameIn with phase 'rejected' + error when size limit is exceeded", async () => {
 		const onFrameIn = vi.fn();
-		const transport = createChatTransport(
-			makeOptions({ onFrameIn, maxMessageSize: 20 }),
-		);
+		const transport = createChatTransport(makeOptions({ onFrameIn, maxMessageSize: 20 }));
 		transport.handleUpgrade(dummyRequest(), "s-big");
 
 		const [, server] = wsHelper.getLastPair();
@@ -316,18 +314,14 @@ describe("chat transport frame hooks", () => {
 			.filter((e) => e.phase === "sent");
 		expect(sent[0].sessionId).toBe("s-out");
 		expect(sent[0].message.id).toBe("r1");
-		expect(sent[0].bytes).toBe(
-			new TextEncoder().encode(JSON.stringify(responses[0])).byteLength,
-		);
+		expect(sent[0].bytes).toBe(new TextEncoder().encode(JSON.stringify(responses[0])).byteLength);
 		expect(sent[1].message.id).toBe("r2");
 		expect(sent[0].error).toBeUndefined();
 	});
 
 	it("does not fire onFrameOut for heartbeat pings", () => {
 		const onFrameOut = vi.fn();
-		const transport = createChatTransport(
-			makeOptions({ onFrameOut, heartbeatInterval: 1000 }),
-		);
+		const transport = createChatTransport(makeOptions({ onFrameOut, heartbeatInterval: 1000 }));
 		transport.handleUpgrade(dummyRequest(), "s-hb");
 
 		vi.advanceTimersByTime(3000);


### PR DESCRIPTION
Closes #82.

## Summary

- Add two optional transport-level observability hooks to `ChatTransportOptions`: `onFrameIn` (phases: `received` / `decoded` / `handled` / `rejected`) and `onFrameOut` (phases: `sent` / `send-failed`). Consumers plug in their logger of choice — no logger baked in (constitution rule 7).
- Hooks are fire-and-forget: thrown errors / rejected promises are swallowed and never crash the worker or skip downstream transport work, matching the existing `onConnect` / `onDisconnect` semantics.
- Heartbeat `ping` frames are intentionally not surfaced on `onFrameOut` — they are not `ChatMessage`s. Documented on `OutboundFrameEvent`.

## Semantics

- `onMessage` handler throws → fire `rejected` with the handler error (and the decoded `message`); `handled` does not fire. Documented on `InboundFrameEvent`.
- Size-limit rejection and JSON decode failure both fire `rejected` with an `error` and no `message`.
- Every `ChatMessage` the transport writes (handler-returned messages and internal error responses) fires `onFrameOut`. The outbound send is wrapped so that a `server.send` throw emits `send-failed` with the error instead of bubbling up.

## Files changed

- `packages/chat/src/types.ts` — new `InboundFrameEvent` / `OutboundFrameEvent` + optional fields on `ChatTransportOptions`.
- `packages/chat/src/transport.ts` — additive hook call sites (diff-only) plus a small `sendMessage` helper around `server.send`.
- `packages/chat/src/index.ts` — export the two new event types.
- `packages/chat/tests/frame-hooks.test.ts` — new, 11 tests.
- `.changeset/chat-frame-hooks.md` — minor.

## Test plan

- [x] `bun run test` in `packages/chat` — 59/59 pass (14 existing transport + 11 new frame-hooks + 34 other).
- [x] `bun run constitution:check -- --diff-only` — 0 errors.
- [x] `bunx turbo typecheck --filter @workkit/chat` — clean.
- [x] Verified no `console.*` calls introduced in `packages/chat/src/`.
- [x] TDD: tests written first and observed failing (10 failed) before implementation.

Covered cases:
- `received` fires with correct UTF-8 bytes + sessionId.
- `decoded` fires post-decode with the built `ChatMessage`.
- `rejected` fires on oversize payload (no `decoded` / `handled` follows).
- `rejected` fires on malformed JSON (no `decoded` / `handled` follows).
- `rejected` fires when `onMessage` throws, with the handler error and the decoded message; `handled` does not follow.
- `handled` fires on clean handler return.
- `sent` fires for each outbound message from the handler result (single and array).
- No `onFrameOut` calls for heartbeat pings.
- `send-failed` fires when `server.send` throws.
- Throws from `onFrameIn` / `onFrameOut` do not propagate — subsequent phases still fire and outbound messages still reach the socket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)