### PR TITLE
feat(agent): strictTools mode — reject off-palette tool calls (#79)

### DIFF
--- a/.changeset/agent-strict-tools.md
+++ b/.changeset/agent-strict-tools.md
@@ -1,0 +1,11 @@
+---
+"@workkit/agent": minor
+---
+
+**Add `strictTools` mode for off-palette rejection.** New `defineAgent({ strictTools: true })` opt-in rejects tool calls naming a tool outside the agent's palette: the loop terminates with `stopReason: "error"`, emits a `{ type: "tool-rejected", call, reason: "off-palette", step }` event, throws a typed `OffPaletteToolError` (carrying `toolName` and `allowedPalette`), and does **not** execute any sibling calls from the same assistant turn.
+
+Default remains `false` — preserves the current soft behavior where unknown tool names return a `"unknown tool: <name>"` tool-result message and the loop continues. Purely additive; zero migration cost.
+
+Motivation: strong models self-correct after a soft unknown-tool message, but weaker open-weight models (e.g. Llama 3.x routed through CF AI Gateway) tend to double down on hallucinated tool names and burn the entire step budget. Strict mode lets consumers opt into fail-fast when they know their model is weak or need predictable budgets.
+
+Closes #79.

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -44,6 +44,7 @@ export function defineAgent(options: DefineAgentOptions): Agent {
 		tools,
 		stopWhen,
 		hooks: options.hooks ?? {},
+		strictTools: options.strictTools ?? false,
 	};
 
 	sharedRegistry.register(internal);

--- a/packages/agent/src/errors.ts
+++ b/packages/agent/src/errors.ts
@@ -1,5 +1,5 @@
 import { ConfigError, ValidationError, WorkkitError } from "@workkit/errors";
-import type { RetryStrategy } from "@workkit/errors";
+import type { RetryStrategy, WorkkitErrorCode } from "@workkit/errors";
 
 export class ToolValidationError extends ValidationError {
 	constructor(toolName: string, issues: Array<{ path: PropertyKey[]; message: string }>) {
@@ -43,5 +43,27 @@ export class BudgetExceededError extends WorkkitError {
 
 	constructor(kind: "max_steps" | "max_tokens", limit: number) {
 		super(`agent budget exceeded: ${kind} >= ${limit}`, { context: { kind, limit } });
+	}
+}
+
+export class OffPaletteToolError extends WorkkitError {
+	// The code union in @workkit/errors is centrally registered; agent-specific
+	// subcodes that haven't been added to the shared union cast locally. This
+	// preserves the package boundary (we don't reach into @workkit/errors for
+	// this additive change) while still surfacing a stable, greppable code.
+	readonly code = "WORKKIT_AGENT_OFF_PALETTE_TOOL" as unknown as WorkkitErrorCode;
+	readonly statusCode = 400;
+	readonly retryable = false;
+	readonly defaultRetryStrategy: RetryStrategy = { kind: "none" };
+	readonly toolName: string;
+	readonly allowedPalette: readonly string[];
+
+	constructor(toolName: string, allowedPalette: readonly string[]) {
+		super(
+			`off-palette tool call "${toolName}" rejected (allowed: ${allowedPalette.length > 0 ? allowedPalette.join(", ") : "<none>"})`,
+			{ context: { toolName, allowedPalette: [...allowedPalette] } },
+		);
+		this.toolName = toolName;
+		this.allowedPalette = [...allowedPalette];
 	}
 }

--- a/packages/agent/src/events.ts
+++ b/packages/agent/src/events.ts
@@ -8,6 +8,7 @@ export type AgentEvent =
 	| { type: "tool-end"; call: GatewayToolCall; result: string; isError: boolean; step: number }
 	| { type: "handoff"; from: string; to: string; step: number }
 	| { type: "step-complete"; step: number; usage: TokenUsage; assistant: Message }
+	| { type: "tool-rejected"; call: GatewayToolCall; reason: "off-palette"; step: number }
 	| {
 			type: "error";
 			error: { kind: "tool" | "provider" | "hook" | "config"; toolName?: string; message: string };

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -13,6 +13,7 @@ export type { HandoffOptions } from "./handoff";
 export {
 	BudgetExceededError,
 	HandoffCycleError,
+	OffPaletteToolError,
 	ToolNameCollisionError,
 	ToolValidationError,
 } from "./errors";

--- a/packages/agent/src/loop.ts
+++ b/packages/agent/src/loop.ts
@@ -184,18 +184,25 @@ export async function runLoop(args: RunLoopArgs): Promise<{
 			return { messages, usage, stopReason: "stop", finalText };
 		}
 
+		// Strict mode: pre-scan the whole turn so no sibling tool executes if any
+		// call is off-palette. Reject at the first off-palette call; never emit
+		// `tool-start` for a rejected turn, so event pairs stay balanced.
+		if (currentAgent.strictTools) {
+			const paletteNames = new Set(currentAgent.tools.map((t) => t.name));
+			const offPalette = toolCalls.find((c) => !paletteNames.has(c.name));
+			if (offPalette) {
+				emit({ type: "tool-rejected", call: offPalette, reason: "off-palette", step });
+				emit({ type: "done", stopReason: "error", usage });
+				throw new OffPaletteToolError(offPalette.name, Array.from(paletteNames));
+			}
+		}
+
 		// Run tools (sequential — keeps order deterministic; parallel can come later).
 		let switched = false;
 		for (const call of toolCalls) {
 			emit({ type: "tool-start", call, step });
 			const tool = currentAgent.tools.find((t) => t.name === call.name);
 			if (!tool) {
-				if (currentAgent.strictTools) {
-					const allowedPalette = currentAgent.tools.map((t) => t.name);
-					emit({ type: "tool-rejected", call, reason: "off-palette", step });
-					emit({ type: "done", stopReason: "error", usage });
-					throw new OffPaletteToolError(call.name, allowedPalette);
-				}
 				const errMsg = `unknown tool: ${call.name}`;
 				const toolMsg: Message = {
 					role: "tool",

--- a/packages/agent/src/loop.ts
+++ b/packages/agent/src/loop.ts
@@ -1,5 +1,5 @@
 import type { ChatMessage, GatewayToolCall, RunOptions, TokenUsage } from "@workkit/ai-gateway";
-import { ToolValidationError } from "./errors";
+import { OffPaletteToolError, ToolValidationError } from "./errors";
 import type { AgentEvent } from "./events";
 import { HANDOFF_HOP_LIMIT } from "./handoff";
 import { toJsonSchema } from "./schema";
@@ -24,6 +24,7 @@ export interface InternalAgentDef {
 	tools: Tool[];
 	stopWhen: Required<StopWhen>;
 	hooks: AgentHooks;
+	strictTools: boolean;
 }
 
 const ZERO_USAGE: TokenUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
@@ -189,6 +190,12 @@ export async function runLoop(args: RunLoopArgs): Promise<{
 			emit({ type: "tool-start", call, step });
 			const tool = currentAgent.tools.find((t) => t.name === call.name);
 			if (!tool) {
+				if (currentAgent.strictTools) {
+					const allowedPalette = currentAgent.tools.map((t) => t.name);
+					emit({ type: "tool-rejected", call, reason: "off-palette", step });
+					emit({ type: "done", stopReason: "error", usage });
+					throw new OffPaletteToolError(call.name, allowedPalette);
+				}
 				const errMsg = `unknown tool: ${call.name}`;
 				const toolMsg: Message = {
 					role: "tool",

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -68,6 +68,15 @@ export interface DefineAgentOptions {
 	tools?: Tool[];
 	stopWhen?: StopWhen;
 	hooks?: AgentHooks;
+	/**
+	 * When true, a tool call naming a tool outside the agent's palette is
+	 * rejected: the loop terminates with `stopReason: "error"`, emits a
+	 * `tool-rejected` event, and throws `OffPaletteToolError`. Sibling calls
+	 * from the same assistant turn are not executed. Default: `false`
+	 * (soft behavior — unknown tool returns an error tool-result and the
+	 * loop continues).
+	 */
+	strictTools?: boolean;
 }
 
 export interface RunArgs {

--- a/packages/agent/tests/strict-tools.test.ts
+++ b/packages/agent/tests/strict-tools.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { defineAgent } from "../src/agent";
+import { OffPaletteToolError } from "../src/errors";
+import type { AgentEvent } from "../src/events";
+import { tool } from "../src/tool";
+import { call, mockGateway } from "./_mocks";
+
+describe("strictTools mode", () => {
+	it("default strictTools=false preserves soft unknown-tool behavior", async () => {
+		const { gateway } = mockGateway([
+			{ toolCalls: [call("not-a-tool")] },
+			{ text: "moved on" },
+		]);
+		const agent = defineAgent({
+			name: "strict-default",
+			model: "m",
+			provider: gateway,
+		});
+		const result = await agent.run({ messages: [{ role: "user", content: "go" }] });
+		expect(result.text).toBe("moved on");
+		expect(result.stopReason).toBe("stop");
+		const toolMsg = result.messages.find((m) => m.role === "tool");
+		expect(toolMsg && (toolMsg as { content: string }).content).toMatch(/unknown tool/i);
+	});
+
+	it("strictTools=true throws OffPaletteToolError on unknown tool call", async () => {
+		const { gateway } = mockGateway([{ toolCalls: [call("compute_greeks")] }]);
+		const known = tool({
+			name: "search",
+			description: "searches",
+			input: z.object({ q: z.string() }),
+			handler: async () => "ok",
+		});
+		const agent = defineAgent({
+			name: "strict-on-1",
+			model: "m",
+			provider: gateway,
+			tools: [known],
+			strictTools: true,
+		});
+		await expect(agent.run({ messages: [{ role: "user", content: "go" }] })).rejects.toBeInstanceOf(
+			OffPaletteToolError,
+		);
+	});
+
+	it("strictTools=true terminates loop with stopReason:'error' (via done event)", async () => {
+		const { gateway } = mockGateway([{ toolCalls: [call("compute_greeks")] }]);
+		const agent = defineAgent({
+			name: "strict-on-2",
+			model: "m",
+			provider: gateway,
+			strictTools: true,
+		});
+		const events: AgentEvent[] = [];
+		try {
+			for await (const e of agent.stream({ messages: [{ role: "user", content: "go" }] })) {
+				events.push(e);
+			}
+		} catch {
+			// expected
+		}
+		const doneEvent = events.find((e) => e.type === "done");
+		expect(doneEvent).toBeDefined();
+		expect(doneEvent && (doneEvent as { stopReason: string }).stopReason).toBe("error");
+	});
+
+	it("strictTools=true with [unknown, known] calls does NOT execute the known tool", async () => {
+		let knownCallCount = 0;
+		const known = tool({
+			name: "search",
+			description: "searches",
+			input: z.object({}),
+			handler: async () => {
+				knownCallCount += 1;
+				return "ran";
+			},
+		});
+		const { gateway } = mockGateway([
+			{ toolCalls: [call("compute_greeks"), call("search")] },
+		]);
+		const agent = defineAgent({
+			name: "strict-on-3",
+			model: "m",
+			provider: gateway,
+			tools: [known],
+			strictTools: true,
+		});
+		await expect(agent.run({ messages: [{ role: "user", content: "go" }] })).rejects.toBeInstanceOf(
+			OffPaletteToolError,
+		);
+		expect(knownCallCount).toBe(0);
+	});
+
+	it("emits a tool-rejected event with call + reason='off-palette'", async () => {
+		const offPaletteCall = call("compute_greeks", { foo: 1 });
+		const { gateway } = mockGateway([{ toolCalls: [offPaletteCall] }]);
+		const known = tool({
+			name: "search",
+			description: "searches",
+			input: z.object({}),
+			handler: async () => "ok",
+		});
+		const agent = defineAgent({
+			name: "strict-on-4",
+			model: "m",
+			provider: gateway,
+			tools: [known],
+			strictTools: true,
+		});
+		const events: AgentEvent[] = [];
+		try {
+			for await (const e of agent.stream({ messages: [{ role: "user", content: "go" }] })) {
+				events.push(e);
+			}
+		} catch {
+			// expected
+		}
+		const rejected = events.find((e) => e.type === "tool-rejected");
+		expect(rejected).toBeDefined();
+		if (rejected && rejected.type === "tool-rejected") {
+			expect(rejected.reason).toBe("off-palette");
+			expect(rejected.call.name).toBe("compute_greeks");
+			expect(typeof rejected.step).toBe("number");
+		}
+	});
+
+	it("OffPaletteToolError carries toolName and allowedPalette", async () => {
+		const { gateway } = mockGateway([{ toolCalls: [call("compute_greeks")] }]);
+		const a = tool({
+			name: "search",
+			description: "searches",
+			input: z.object({}),
+			handler: async () => "ok",
+		});
+		const b = tool({
+			name: "lookup_ticker",
+			description: "looks up",
+			input: z.object({}),
+			handler: async () => "ok",
+		});
+		const agent = defineAgent({
+			name: "strict-on-5",
+			model: "m",
+			provider: gateway,
+			tools: [a, b],
+			strictTools: true,
+		});
+		try {
+			await agent.run({ messages: [{ role: "user", content: "go" }] });
+			throw new Error("expected throw");
+		} catch (err) {
+			expect(err).toBeInstanceOf(OffPaletteToolError);
+			const e = err as OffPaletteToolError;
+			expect(e.toolName).toBe("compute_greeks");
+			expect(e.allowedPalette).toEqual(["search", "lookup_ticker"]);
+		}
+	});
+});

--- a/packages/agent/tests/strict-tools.test.ts
+++ b/packages/agent/tests/strict-tools.test.ts
@@ -87,6 +87,42 @@ describe("strictTools mode", () => {
 		expect(knownCallCount).toBe(0);
 	});
 
+	it("strictTools=true with [known, unknown] calls does NOT execute the earlier known tool either", async () => {
+		// Regression guard: the rejection must pre-scan the whole turn, otherwise
+		// a known tool placed *before* an off-palette one would run and leave a
+		// partial side effect from a turn we're about to reject.
+		let knownCallCount = 0;
+		const known = tool({
+			name: "search",
+			description: "searches",
+			input: z.object({}),
+			handler: async () => {
+				knownCallCount += 1;
+				return "ran";
+			},
+		});
+		const { gateway } = mockGateway([{ toolCalls: [call("search"), call("compute_greeks")] }]);
+		const agent = defineAgent({
+			name: "strict-on-3b",
+			model: "m",
+			provider: gateway,
+			tools: [known],
+			strictTools: true,
+		});
+		const events: AgentEvent[] = [];
+		try {
+			for await (const e of agent.stream({ messages: [{ role: "user", content: "go" }] })) {
+				events.push(e);
+			}
+		} catch {
+			// expected
+		}
+		expect(knownCallCount).toBe(0);
+		// No tool-start should have been emitted for any call in the rejected turn,
+		// so tool-start/tool-end pairs stay balanced for downstream consumers.
+		expect(events.some((e) => e.type === "tool-start")).toBe(false);
+	});
+
 	it("emits a tool-rejected event with call + reason='off-palette'", async () => {
 		const offPaletteCall = call("compute_greeks", { foo: 1 });
 		const { gateway } = mockGateway([{ toolCalls: [offPaletteCall] }]);

--- a/packages/agent/tests/strict-tools.test.ts
+++ b/packages/agent/tests/strict-tools.test.ts
@@ -8,10 +8,7 @@ import { call, mockGateway } from "./_mocks";
 
 describe("strictTools mode", () => {
 	it("default strictTools=false preserves soft unknown-tool behavior", async () => {
-		const { gateway } = mockGateway([
-			{ toolCalls: [call("not-a-tool")] },
-			{ text: "moved on" },
-		]);
+		const { gateway } = mockGateway([{ toolCalls: [call("not-a-tool")] }, { text: "moved on" }]);
 		const agent = defineAgent({
 			name: "strict-default",
 			model: "m",
@@ -76,9 +73,7 @@ describe("strictTools mode", () => {
 				return "ran";
 			},
 		});
-		const { gateway } = mockGateway([
-			{ toolCalls: [call("compute_greeks"), call("search")] },
-		]);
+		const { gateway } = mockGateway([{ toolCalls: [call("compute_greeks"), call("search")] }]);
 		const agent = defineAgent({
 			name: "strict-on-3",
 			model: "m",


### PR DESCRIPTION
Closes #79.

### Problem

`loop.ts` currently handles unknown tool calls softly — it appends `"unknown tool: <name>"` as a tool message and lets the loop continue. Strong models self-correct from that; weaker open-weight models (e.g. Llama 3.x routed through CF AI Gateway) tend to double down on the hallucinated name and burn the entire step budget reaching for tools that don't exist.

### Solution

Add opt-in `strictTools?: boolean` to `defineAgent`. Default stays `false` — purely additive, zero migration cost.

When `strictTools: true`:
- An off-palette tool call does **not** append a tool result and continue.
- Sibling calls in the same assistant turn are **not** executed (avoids partial side effects from a turn we're rejecting).
- Loop emits `{ type: "tool-rejected", call, reason: "off-palette", step }` (new event variant).
- Loop terminates with `stopReason: "error"` (via a `done` event) and throws a typed `OffPaletteToolError` carrying `toolName` and `allowedPalette: string[]`.

### Changes

| File | Change |
|---|---|
| `packages/agent/src/types.ts` | Add `strictTools?: boolean` to `DefineAgentOptions`. |
| `packages/agent/src/agent.ts` | Propagate `strictTools` into `InternalAgentDef` (default `false`). |
| `packages/agent/src/loop.ts` | In the unknown-tool branch, when `strictTools` is on: emit `tool-rejected` + `done(error)`, throw `OffPaletteToolError`, skip sibling calls. |
| `packages/agent/src/events.ts` | New `tool-rejected` variant in `AgentEvent` union. |
| `packages/agent/src/errors.ts` | New `OffPaletteToolError` class (WorkkitError subclass, carries `toolName` + `allowedPalette`). |
| `packages/agent/src/index.ts` | Sub-export `OffPaletteToolError`. |
| `.changeset/agent-strict-tools.md` | `@workkit/agent` minor bump. |

### Test plan

- [x] `bunx vitest run` — 37/37 pass, including 6 new tests in `tests/strict-tools.test.ts`:
  - default `strictTools: false` preserves soft unknown-tool behavior.
  - `strictTools: true` + unknown tool throws `OffPaletteToolError`.
  - loop terminates with `stopReason: "error"` (asserted on `done` event).
  - `[unknown, known]` turn does not execute the known tool.
  - event stream contains `{ type: "tool-rejected", reason: "off-palette", call, step }`.
  - `OffPaletteToolError` carries `toolName` + full `allowedPalette`.
- [x] `bunx turbo typecheck --filter @workkit/agent` — clean.
- [x] `bun run constitution:check -- --diff-only` — 0 errors.
- [x] `maina commit` verification pipeline — 13 tools ran, passed in 11.7s.

### Out of scope

- Fuzzy-match suggestions ("did you mean `compute_vega`?") — follow-up.
- Per-step palette overrides (handoff-aware) — already handled via agent switch.
- Does not touch `afterModel` hook / sibling issue #58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)