### PR TITLE
feat(ai-gateway): structuredWithRetry — reprompt on schema parse failure

### DIFF
--- a/.changeset/ai-gateway-structured-with-retry.md
+++ b/.changeset/ai-gateway-structured-with-retry.md
@@ -1,0 +1,15 @@
+---
+"@workkit/ai-gateway": minor
+---
+
+feat(ai-gateway/structured): `structuredWithRetry` — reprompt on schema parse failure (#83)
+
+Adds a caller-controlled reprompt loop for LLM callers that parse structured output against a Standard Schema. On validation failure the previous attempt's error message is threaded into the next `generate` call so callers decide how to fold the reminder into the prompt (system vs user, wording). Exhausts after `maxAttempts` with a `StructuredRetryExhaustedError` that carries `attempts`, `lastError`, and `lastRaw`. Non-validation errors (network, abort) propagate immediately — per-attempt network retry stays on the gateway (`withRetry`).
+
+Scope-corrected from `@workkit/workflow` to `@workkit/ai-gateway/structured` per the issue body: the workflow package's step retry is generic and doesn't know about schemas or LLM reprompts; this loop belongs next to the existing `structuredAI` helper.
+
+New public surface (same `src/index.ts` entry):
+
+- `structuredWithRetry<T>(opts)` → `{ value, attempts, raw }`
+- `StructuredWithRetryOptions<T>`, `StructuredWithRetryResult<T>`
+- `StructuredRetryExhaustedError`

--- a/packages/ai-gateway/src/index.ts
+++ b/packages/ai-gateway/src/index.ts
@@ -26,8 +26,18 @@ export { aiWithTools } from "./tool-use";
 export type { AiWithToolsOptions, AiWithToolsResult, ToolMessage } from "./tool-use";
 
 // Structured output — JSON mode with Standard Schema validation + retry.
-export { structuredAI, StructuredOutputError } from "./structured";
-export type { StructuredOptions, StructuredResult } from "./structured";
+export {
+	structuredAI,
+	StructuredOutputError,
+	structuredWithRetry,
+	StructuredRetryExhaustedError,
+} from "./structured";
+export type {
+	StructuredOptions,
+	StructuredResult,
+	StructuredWithRetryOptions,
+	StructuredWithRetryResult,
+} from "./structured";
 
 // Schema conversion.
 export { standardSchemaToJsonSchema } from "./schema";

--- a/packages/ai-gateway/src/structured.ts
+++ b/packages/ai-gateway/src/structured.ts
@@ -143,18 +143,7 @@ export async function structuredAI<T>(
 			lastIssues = [...result.issues];
 
 			if (attempt < maxRetries) {
-				const issuesSummary = result.issues
-					.map((issue) => {
-						const path = issue.path
-							? issue.path
-									.map((p) =>
-										typeof p === "object" && p !== null && "key" in p ? String(p.key) : String(p),
-									)
-									.join(".")
-							: "";
-						return path ? `${path}: ${issue.message}` : issue.message;
-					})
-					.join("; ");
+				const issuesSummary = formatIssues(result.issues);
 
 				messages.push({ role: "assistant", content: rawText });
 				messages.push({
@@ -204,15 +193,26 @@ function toMessages(input: AiInput): ChatMessage[] {
  */
 export class StructuredRetryExhaustedError extends Error {
 	readonly attempts: number;
-	readonly lastError: unknown;
+	/** The parse/validation error from the final attempt. */
+	readonly lastError: Error | undefined;
+	/** The `raw` field from the final attempt's generator output, if any. */
 	readonly lastRaw: unknown;
+	/** The `text` field from the final attempt's generator output — useful for logging bad generations. */
+	readonly lastText: string | undefined;
 
-	constructor(attempts: number, lastError: unknown, lastRaw: unknown, message?: string) {
+	constructor(
+		attempts: number,
+		lastError: Error | undefined,
+		lastRaw: unknown,
+		lastText: string | undefined,
+		message?: string,
+	) {
 		super(message ?? `structuredWithRetry exhausted after ${attempts} attempt(s)`);
 		this.name = "StructuredRetryExhaustedError";
 		this.attempts = attempts;
 		this.lastError = lastError;
 		this.lastRaw = lastRaw;
+		this.lastText = lastText;
 	}
 }
 
@@ -232,10 +232,14 @@ export interface StructuredWithRetryOptions<T> {
 	onAttempt?: (attempt: number, error: unknown) => void;
 }
 
-/** Result from a successful {@link structuredWithRetry} call. */
+/**
+ * Result from a successful {@link structuredWithRetry} call. Naming mirrors
+ * {@link StructuredResult} (`data` for the parsed payload) so the two helpers
+ * stay interoperable in consumer code.
+ */
 export interface StructuredWithRetryResult<T> {
 	/** The parsed, validated data. */
-	value: T;
+	data: T;
 	/** How many attempts it took to get a valid response (1-based). */
 	attempts: number;
 	/** The `raw` field from the attempt that validated. */
@@ -283,14 +287,19 @@ function formatIssues(issues: ReadonlyArray<StandardSchemaV1Issue>): string {
 export async function structuredWithRetry<T>(
 	opts: StructuredWithRetryOptions<T>,
 ): Promise<StructuredWithRetryResult<T>> {
-	if (!Number.isFinite(opts.maxAttempts) || opts.maxAttempts < 1) {
+	if (
+		!Number.isFinite(opts.maxAttempts) ||
+		!Number.isInteger(opts.maxAttempts) ||
+		opts.maxAttempts < 1
+	) {
 		throw new ValidationError("structuredWithRetry requires maxAttempts >= 1", [
 			{ path: ["maxAttempts"], message: "Expected an integer >= 1" },
 		]);
 	}
 
-	let lastError: unknown = undefined;
+	let lastError: Error | undefined;
 	let lastRaw: unknown = undefined;
+	let lastText: string | undefined;
 	let remindWith: string | undefined;
 
 	for (let attempt = 1; attempt <= opts.maxAttempts; attempt++) {
@@ -303,6 +312,7 @@ export async function structuredWithRetry<T>(
 		const output = await opts.generate(remindWith);
 		lastRaw = output.raw;
 		const rawText = output.text ?? "";
+		lastText = rawText;
 
 		let parsed: unknown;
 		try {
@@ -326,11 +336,11 @@ export async function structuredWithRetry<T>(
 		}
 
 		return {
-			value: result.value as T,
+			data: result.value as T,
 			attempts: attempt,
 			raw: output.raw,
 		};
 	}
 
-	throw new StructuredRetryExhaustedError(opts.maxAttempts, lastError, lastRaw);
+	throw new StructuredRetryExhaustedError(opts.maxAttempts, lastError, lastRaw, lastText);
 }

--- a/packages/ai-gateway/src/structured.ts
+++ b/packages/ai-gateway/src/structured.ts
@@ -189,3 +189,148 @@ function toMessages(input: AiInput): ChatMessage[] {
 		[{ path: ["input"], message: "Expected { messages: ChatMessage[] } or { prompt: string }" }],
 	);
 }
+
+// ─── structuredWithRetry ────────────────────────────────────
+//
+// Caller-controlled reprompt loop: callers own the `generate` function, so
+// model/gateway/prompt choices stay outside this helper. This is the
+// parse-and-reprompt loop only — per-attempt network retry belongs on the
+// gateway (`withRetry`).
+
+/**
+ * Error thrown by {@link structuredWithRetry} when every attempt fails schema
+ * validation. Carries the final attempt count plus the last parse error and
+ * raw output so callers can log or fall back.
+ */
+export class StructuredRetryExhaustedError extends Error {
+	readonly attempts: number;
+	readonly lastError: unknown;
+	readonly lastRaw: unknown;
+
+	constructor(attempts: number, lastError: unknown, lastRaw: unknown, message?: string) {
+		super(message ?? `structuredWithRetry exhausted after ${attempts} attempt(s)`);
+		this.name = "StructuredRetryExhaustedError";
+		this.attempts = attempts;
+		this.lastError = lastError;
+		this.lastRaw = lastRaw;
+	}
+}
+
+/** Options for {@link structuredWithRetry}. */
+export interface StructuredWithRetryOptions<T> {
+	/** Standard Schema v1 validator for the expected output shape. */
+	schema: StandardSchemaV1<T>;
+	/**
+	 * Produce a candidate structured response. Called with `undefined` on the
+	 * first attempt and with the previous parse error's `.message` on each
+	 * subsequent attempt so the caller can fold it into the prompt.
+	 */
+	generate: (remindWith?: string) => Promise<{ text?: string; raw?: unknown }>;
+	/** Maximum attempts. Must be >= 1; 1 means "validate once, no retry". */
+	maxAttempts: number;
+	/** Fires on each RETRY (attempts 2..N) with the prior parse error. */
+	onAttempt?: (attempt: number, error: unknown) => void;
+}
+
+/** Result from a successful {@link structuredWithRetry} call. */
+export interface StructuredWithRetryResult<T> {
+	/** The parsed, validated data. */
+	value: T;
+	/** How many attempts it took to get a valid response (1-based). */
+	attempts: number;
+	/** The `raw` field from the attempt that validated. */
+	raw: unknown;
+}
+
+function formatIssues(issues: ReadonlyArray<StandardSchemaV1Issue>): string {
+	return issues
+		.map((issue) => {
+			const path = issue.path
+				? issue.path
+						.map((p) =>
+							typeof p === "object" && p !== null && "key" in p ? String(p.key) : String(p),
+						)
+						.join(".")
+				: "";
+			return path ? `${path}: ${issue.message}` : issue.message;
+		})
+		.join("; ");
+}
+
+/**
+ * Run `generate` and validate its output against `schema`, retrying on parse
+ * failure up to `maxAttempts` times. The previous attempt's error message is
+ * threaded into `generate` so callers control how the reminder is folded into
+ * the next prompt.
+ *
+ * - Schema-validation errors drive the retry loop.
+ * - Any other error from `generate` (network, abort, etc.) propagates
+ *   immediately — per-attempt retry is the gateway's job, not this helper's.
+ * - On exhaustion throws {@link StructuredRetryExhaustedError}.
+ *
+ * @example
+ * ```ts
+ * const result = await structuredWithRetry({
+ *   schema: MySchema,
+ *   generate: (remindWith) => ai(gateway, model, input, {
+ *     responseFormat: "json",
+ *     system: remindWith ? `${base}\n\nReminder: ${remindWith}` : base,
+ *   }),
+ *   maxAttempts: 3,
+ * });
+ * ```
+ */
+export async function structuredWithRetry<T>(
+	opts: StructuredWithRetryOptions<T>,
+): Promise<StructuredWithRetryResult<T>> {
+	if (!Number.isFinite(opts.maxAttempts) || opts.maxAttempts < 1) {
+		throw new ValidationError("structuredWithRetry requires maxAttempts >= 1", [
+			{ path: ["maxAttempts"], message: "Expected an integer >= 1" },
+		]);
+	}
+
+	let lastError: unknown = undefined;
+	let lastRaw: unknown = undefined;
+	let remindWith: string | undefined;
+
+	for (let attempt = 1; attempt <= opts.maxAttempts; attempt++) {
+		// Fire onAttempt on RETRIES only (attempts 2..N), with the prior error.
+		if (attempt > 1) {
+			opts.onAttempt?.(attempt, lastError);
+		}
+
+		// Non-parse errors (network, etc.) propagate immediately — no retry.
+		const output = await opts.generate(remindWith);
+		lastRaw = output.raw;
+		const rawText = output.text ?? "";
+
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(rawText);
+		} catch (parseErr) {
+			const message =
+				parseErr instanceof Error
+					? `Invalid JSON: ${parseErr.message}`
+					: `Invalid JSON: ${String(parseErr)}`;
+			lastError = new Error(message);
+			remindWith = message;
+			continue;
+		}
+
+		const result = await opts.schema["~standard"].validate(parsed);
+		if (result.issues) {
+			const summary = formatIssues(result.issues);
+			lastError = new Error(summary);
+			remindWith = summary;
+			continue;
+		}
+
+		return {
+			value: result.value as T,
+			attempts: attempt,
+			raw: output.raw,
+		};
+	}
+
+	throw new StructuredRetryExhaustedError(opts.maxAttempts, lastError, lastRaw);
+}

--- a/packages/ai-gateway/tests/structured-with-retry.test.ts
+++ b/packages/ai-gateway/tests/structured-with-retry.test.ts
@@ -49,7 +49,7 @@ describe("structuredWithRetry", () => {
 			onAttempt,
 		});
 
-		expect(result.value).toEqual({ name: "Alice", age: 30 });
+		expect(result.data).toEqual({ name: "Alice", age: 30 });
 		expect(result.attempts).toBe(1);
 		expect(result.raw).toEqual({ provider: "test" });
 		expect(generate).toHaveBeenCalledTimes(1);
@@ -74,7 +74,7 @@ describe("structuredWithRetry", () => {
 			onAttempt,
 		});
 
-		expect(result.value).toEqual({ name: "Bob", age: 42 });
+		expect(result.data).toEqual({ name: "Bob", age: 42 });
 		expect(result.attempts).toBe(2);
 		expect(generate).toHaveBeenCalledTimes(2);
 		expect(onAttempt).toHaveBeenCalledTimes(1);
@@ -82,24 +82,55 @@ describe("structuredWithRetry", () => {
 		expect(onAttempt.mock.calls[0][1]).toBeInstanceOf(Error);
 	});
 
-	it("exhausts after maxAttempts: 3 and throws StructuredRetryExhaustedError", async () => {
+	it("exhausts after maxAttempts: 3 and throws StructuredRetryExhaustedError carrying lastError + lastText + lastRaw", async () => {
+		const badText = JSON.stringify({ wrongShape: true });
 		const generate = vi.fn().mockResolvedValue({
-			text: JSON.stringify({ wrongShape: true }),
+			text: badText,
 			raw: { attempt: "bad" },
 		});
 
-		await expect(
-			structuredWithRetry<Person>({
+		let caught: unknown;
+		try {
+			await structuredWithRetry<Person>({
 				schema: personSchema,
 				generate,
 				maxAttempts: 3,
-			}),
-		).rejects.toMatchObject({
+			});
+		} catch (err) {
+			caught = err;
+		}
+
+		expect(caught).toMatchObject({
 			name: "StructuredRetryExhaustedError",
 			attempts: 3,
 		});
+		// Narrowed types: lastError is Error | undefined, lastText carries the last
+		// generation so consumers can log the bad output without the raw envelope.
+		const exhausted = caught as {
+			lastError: Error | undefined;
+			lastText: string | undefined;
+			lastRaw: unknown;
+		};
+		expect(exhausted.lastError).toBeInstanceOf(Error);
+		expect(exhausted.lastText).toBe(badText);
+		expect(exhausted.lastRaw).toEqual({ attempt: "bad" });
 
 		expect(generate).toHaveBeenCalledTimes(3);
+	});
+
+	it("rejects invalid maxAttempts values", async () => {
+		const generate = vi.fn().mockResolvedValue({ text: "{}", raw: null });
+		for (const bad of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+			await expect(
+				structuredWithRetry<Person>({
+					schema: personSchema,
+					generate,
+					maxAttempts: bad,
+				}),
+			).rejects.toThrow(/maxAttempts/);
+		}
+		// None of the invalid values should trigger a generate call.
+		expect(generate).not.toHaveBeenCalled();
 	});
 
 	it("passes the actual parse error to onAttempt", async () => {

--- a/packages/ai-gateway/tests/structured-with-retry.test.ts
+++ b/packages/ai-gateway/tests/structured-with-retry.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it, vi } from "vitest";
+import { StructuredRetryExhaustedError, structuredWithRetry } from "../src/structured";
+
+// ─── Hand-written Standard Schema stub ─────────────────────────
+//
+// Accepts `{ name: string; age: number }`. Returns issues otherwise. We hand-
+// roll one instead of pulling in Zod so the test stays dep-free and the
+// structural contract we rely on is obvious.
+
+interface Person {
+	name: string;
+	age: number;
+}
+
+const personSchema = {
+	"~standard": {
+		version: 1 as const,
+		vendor: "test",
+		validate(value: unknown) {
+			if (
+				value &&
+				typeof value === "object" &&
+				typeof (value as { name?: unknown }).name === "string" &&
+				typeof (value as { age?: unknown }).age === "number"
+			) {
+				return { value: value as Person };
+			}
+			return {
+				issues: [{ message: "expected { name: string; age: number }" }],
+			};
+		},
+	},
+};
+
+// ─── Tests ─────────────────────────────────────────────────────
+
+describe("structuredWithRetry", () => {
+	it("returns on clean first attempt and does not fire onAttempt", async () => {
+		const onAttempt = vi.fn();
+		const generate = vi.fn().mockResolvedValue({
+			text: JSON.stringify({ name: "Alice", age: 30 }),
+			raw: { provider: "test" },
+		});
+
+		const result = await structuredWithRetry<Person>({
+			schema: personSchema,
+			generate,
+			maxAttempts: 3,
+			onAttempt,
+		});
+
+		expect(result.value).toEqual({ name: "Alice", age: 30 });
+		expect(result.attempts).toBe(1);
+		expect(result.raw).toEqual({ provider: "test" });
+		expect(generate).toHaveBeenCalledTimes(1);
+		expect(generate).toHaveBeenNthCalledWith(1, undefined);
+		expect(onAttempt).not.toHaveBeenCalled();
+	});
+
+	it("reprompts once on bad JSON and returns attempts: 2 with onAttempt fired once", async () => {
+		const onAttempt = vi.fn();
+		const generate = vi
+			.fn()
+			.mockResolvedValueOnce({ text: "not valid json at all", raw: null })
+			.mockResolvedValueOnce({
+				text: JSON.stringify({ name: "Bob", age: 42 }),
+				raw: { ok: true },
+			});
+
+		const result = await structuredWithRetry<Person>({
+			schema: personSchema,
+			generate,
+			maxAttempts: 3,
+			onAttempt,
+		});
+
+		expect(result.value).toEqual({ name: "Bob", age: 42 });
+		expect(result.attempts).toBe(2);
+		expect(generate).toHaveBeenCalledTimes(2);
+		expect(onAttempt).toHaveBeenCalledTimes(1);
+		expect(onAttempt.mock.calls[0][0]).toBe(2);
+		expect(onAttempt.mock.calls[0][1]).toBeInstanceOf(Error);
+	});
+
+	it("exhausts after maxAttempts: 3 and throws StructuredRetryExhaustedError", async () => {
+		const generate = vi.fn().mockResolvedValue({
+			text: JSON.stringify({ wrongShape: true }),
+			raw: { attempt: "bad" },
+		});
+
+		await expect(
+			structuredWithRetry<Person>({
+				schema: personSchema,
+				generate,
+				maxAttempts: 3,
+			}),
+		).rejects.toMatchObject({
+			name: "StructuredRetryExhaustedError",
+			attempts: 3,
+		});
+
+		expect(generate).toHaveBeenCalledTimes(3);
+	});
+
+	it("passes the actual parse error to onAttempt", async () => {
+		const onAttempt = vi.fn();
+		const generate = vi
+			.fn()
+			.mockResolvedValueOnce({
+				text: JSON.stringify({ wrongShape: true }),
+				raw: null,
+			})
+			.mockResolvedValueOnce({
+				text: JSON.stringify({ name: "Carol", age: 7 }),
+				raw: null,
+			});
+
+		await structuredWithRetry<Person>({
+			schema: personSchema,
+			generate,
+			maxAttempts: 3,
+			onAttempt,
+		});
+
+		expect(onAttempt).toHaveBeenCalledTimes(1);
+		const [attemptNum, err] = onAttempt.mock.calls[0];
+		expect(attemptNum).toBe(2);
+		expect(err).toBeInstanceOf(Error);
+		expect((err as Error).message).toContain("expected { name: string; age: number }");
+	});
+
+	it("propagates non-parse errors from generate without retrying", async () => {
+		const onAttempt = vi.fn();
+		const networkErr = new Error("network down");
+		const generate = vi.fn().mockRejectedValue(networkErr);
+
+		await expect(
+			structuredWithRetry<Person>({
+				schema: personSchema,
+				generate,
+				maxAttempts: 5,
+				onAttempt,
+			}),
+		).rejects.toBe(networkErr);
+
+		expect(generate).toHaveBeenCalledTimes(1);
+		expect(onAttempt).not.toHaveBeenCalled();
+	});
+
+	it("throws StructuredRetryExhaustedError with maxAttempts: 1 and bad output (no retry)", async () => {
+		const onAttempt = vi.fn();
+		const generate = vi.fn().mockResolvedValue({
+			text: "not json",
+			raw: { last: true },
+		});
+
+		let caught: unknown;
+		try {
+			await structuredWithRetry<Person>({
+				schema: personSchema,
+				generate,
+				maxAttempts: 1,
+				onAttempt,
+			});
+		} catch (err) {
+			caught = err;
+		}
+
+		expect(caught).toBeInstanceOf(StructuredRetryExhaustedError);
+		expect((caught as StructuredRetryExhaustedError).attempts).toBe(1);
+		expect((caught as StructuredRetryExhaustedError).lastRaw).toEqual({
+			last: true,
+		});
+		expect((caught as StructuredRetryExhaustedError).lastError).toBeInstanceOf(Error);
+		expect(generate).toHaveBeenCalledTimes(1);
+		expect(onAttempt).not.toHaveBeenCalled();
+	});
+
+	it("threads the prior parse error's .message into the remindWith arg on attempt 2", async () => {
+		const generate = vi
+			.fn()
+			.mockResolvedValueOnce({
+				text: JSON.stringify({ wrongShape: true }),
+				raw: null,
+			})
+			.mockResolvedValueOnce({
+				text: JSON.stringify({ name: "Dave", age: 99 }),
+				raw: null,
+			});
+
+		await structuredWithRetry<Person>({
+			schema: personSchema,
+			generate,
+			maxAttempts: 3,
+		});
+
+		expect(generate).toHaveBeenCalledTimes(2);
+		// First call: remindWith = undefined
+		expect(generate).toHaveBeenNthCalledWith(1, undefined);
+		// Second call: remindWith = the prior parse error's .message
+		const secondArg = generate.mock.calls[1][0];
+		expect(typeof secondArg).toBe("string");
+		expect(secondArg).toContain("expected { name: string; age: number }");
+	});
+});


### PR DESCRIPTION
## Summary

Closes #83.

Adds `structuredWithRetry` — a caller-controlled reprompt loop for LLM callers that parse structured output against a Standard Schema. The previous attempt's parse error is threaded into the next `generate` call so callers decide how to fold the reminder into the prompt (system vs user, wording). Non-validation errors propagate immediately — per-attempt network retry stays on the gateway (`withRetry`). On exhaustion throws `StructuredRetryExhaustedError` with `attempts`, `lastError`, `lastRaw`.

- Scope-corrected per issue body: lives in `@workkit/ai-gateway/structured` (next to the existing `structuredAI`), not `@workkit/workflow` — the workflow step retry is generic and doesn't know about schemas.
- Standard Schema only in the public signature (constitution rule 2); reuses the `StandardSchemaV1` type already inlined in `structured.ts`.
- No new runtime deps; `structured.ts` already inlines the Standard Schema v1 types.

## New public surface (same `src/index.ts` entry)

- `structuredWithRetry<T>(opts)` → `{ value, attempts, raw }`
- `StructuredWithRetryOptions<T>`, `StructuredWithRetryResult<T>`
- `StructuredRetryExhaustedError`

## Files touched

- `packages/ai-gateway/src/structured.ts` — appended helper + error class
- `packages/ai-gateway/src/index.ts` — re-exports
- `packages/ai-gateway/tests/structured-with-retry.test.ts` — 7 vitest cases
- `.changeset/ai-gateway-structured-with-retry.md` — minor

## Test plan

- [x] `bunx vitest run structured-with-retry` — 7/7 green (clean first attempt; reprompt-once; exhaust after 3; `onAttempt` receives prior error; non-parse errors propagate without retry; `maxAttempts: 1` bad output throws without retry; `remindWith` threads prior error's `.message`)
- [x] Full `@workkit/ai-gateway` suite — 212/212 green
- [x] `bunx biome format --write packages/ai-gateway/` + `bunx biome check packages/ai-gateway/src/structured.ts packages/ai-gateway/src/index.ts packages/ai-gateway/tests/structured-with-retry.test.ts` — zero issues on changed files (pre-existing warnings on `src/schema.ts` are untouched)
- [x] `bunx turbo typecheck --filter @workkit/ai-gateway` — green
- [x] `bun run constitution:check -- --diff-only` — 0 errors, 0 warnings

DRAFT — not ready for review; sibling PR #81 (`fallback-wrapper`) is still in flight and this branch intentionally avoids touching `src/allowlist/` and `src/fallback-wrapper.ts`.