### PR TITLE
feat(ai-gateway): fallback() provider-failover wrapper (#81)

### DIFF
--- a/.changeset/ai-gateway-fallback-wrapper.md
+++ b/.changeset/ai-gateway-fallback-wrapper.md
@@ -22,6 +22,7 @@ Semantics:
 - `onFallback` fires once when the primary fails and the secondary is about to run, with the attempt tier (`"primary"`) that triggered the transition.
 - When both tiers fail, `run()` throws `FallbackExhaustedError` with `.primaryError` and `.secondaryError` preserved for inspection.
 - `AiOutput.via` is tagged `"primary" | "secondary"` so observability pipelines can break down traffic by tier. Absent on direct string-model calls.
-- Retry (`withRetry`) still wraps each tier independently: the primary retries per its policy first, and only once it gives up does the fallback trigger.
+
+Wrapper interop: `withCache`, `withLogging`, and `withRetry` accept a `FallbackModelRef` where they previously accepted a model string, and use a stable `modelLabel(ref)` → `"fallback:primary→secondary"` for cache keys and log labels (no more `[object Object]` stringification). **Retry currently wraps the whole fallback call, not each tier independently** — if the primary throws a retryable error, `withRetry` retries the overall `gateway.run(ref, …)`, which re-enters the primary first. Per-tier retry (primary exhausts its retry budget before the secondary is tried) is a follow-up; until then, put `withRetry` *inside* each tier explicitly if that matters for your use case.
 
 Two-tier only for now — chain by nesting if you need three tiers. Circuit-breaker ("stop trying primary for N minutes") is a separate follow-up. No new runtime deps.

--- a/.changeset/ai-gateway-fallback-wrapper.md
+++ b/.changeset/ai-gateway-fallback-wrapper.md
@@ -1,0 +1,27 @@
+---
+"@workkit/ai-gateway": minor
+---
+
+**Two-tier provider failover as a model reference.** New `fallback(primary, secondary, { on, onFallback? })` primitive on `@workkit/ai-gateway` lets you route a call through a secondary model when the primary throws a matching HTTP status or predicate. The returned `FallbackModelRef` plugs into `gateway.run()` exactly where a string model id would — same input, same `RunOptions`, same retry/cache/logging wrappers. Closes #81.
+
+```ts
+import { createGateway, fallback } from "@workkit/ai-gateway";
+
+const model = fallback("claude-sonnet-4-6", "gpt-4o", {
+  on: [401, 429, 500, 502, 503, 504],
+  onFallback: (err, attempt) => log.warn("provider failover", { err, attempt }),
+});
+
+const result = await gateway.run(model, { prompt: "…" });
+result.via; // "primary" | "secondary"
+```
+
+Semantics:
+- Numeric `on` entries match `err.status`, `err.statusCode`, or `err.context?.status`, walking the `.cause` chain so wrapped provider errors still trigger. Exact number match.
+- Function `on` entries receive the raw error and return `true` to fall over.
+- `onFallback` fires once when the primary fails and the secondary is about to run, with the attempt tier (`"primary"`) that triggered the transition.
+- When both tiers fail, `run()` throws `FallbackExhaustedError` with `.primaryError` and `.secondaryError` preserved for inspection.
+- `AiOutput.via` is tagged `"primary" | "secondary"` so observability pipelines can break down traffic by tier. Absent on direct string-model calls.
+- Retry (`withRetry`) still wraps each tier independently: the primary retries per its policy first, and only once it gives up does the fallback trigger.
+
+Two-tier only for now — chain by nesting if you need three tiers. Circuit-breaker ("stop trying primary for N minutes") is a separate follow-up. No new runtime deps.

--- a/.changeset/ai-gateway-fallback-wrapper.md
+++ b/.changeset/ai-gateway-fallback-wrapper.md
@@ -7,6 +7,8 @@
 ```ts
 import { createGateway, fallback } from "@workkit/ai-gateway";
 
+const gateway = createGateway({ providers: { /* … */ }, defaultProvider: "anthropic" });
+
 const model = fallback("claude-sonnet-4-6", "gpt-4o", {
   on: [401, 429, 500, 502, 503, 504],
   onFallback: (err, attempt) => log.warn("provider failover", { err, attempt }),
@@ -25,4 +27,4 @@ Semantics:
 
 Wrapper interop: `withCache`, `withLogging`, and `withRetry` accept a `FallbackModelRef` where they previously accepted a model string, and use a stable `modelLabel(ref)` → `"fallback:primary→secondary"` for cache keys and log labels (no more `[object Object]` stringification). **Retry currently wraps the whole fallback call, not each tier independently** — if the primary throws a retryable error, `withRetry` retries the overall `gateway.run(ref, …)`, which re-enters the primary first. Per-tier retry (primary exhausts its retry budget before the secondary is tried) is a follow-up; until then, put `withRetry` *inside* each tier explicitly if that matters for your use case.
 
-Two-tier only for now — chain by nesting if you need three tiers. Circuit-breaker ("stop trying primary for N minutes") is a separate follow-up. No new runtime deps.
+Two-tier only for now — `fallback()` accepts string model ids, not nested refs, so n-ary chains aren't supported by this API yet. Circuit-breaker ("stop trying primary for N minutes") is a separate follow-up. No new runtime deps.

--- a/packages/ai-gateway/src/cache.ts
+++ b/packages/ai-gateway/src/cache.ts
@@ -1,4 +1,5 @@
 import { ConfigError } from "@workkit/errors";
+import { type FallbackModelRef, modelLabel } from "./fallback-wrapper";
 import type {
 	AiInput,
 	AiOutput,
@@ -61,12 +62,18 @@ export function withCache(gateway: Gateway, config: CacheConfig): CachedGateway 
 	const ttl = config.ttl ?? 3600;
 	const hashFn = config.hashFn ?? defaultHashFn;
 
-	function getCacheKey(model: string, input: AiInput): string {
-		return hashFn(model, input);
+	// FallbackModelRef is translated to a stable label (`fallback:primary→secondary`)
+	// so cache entries are deterministic across calls with the same fallback config.
+	function getCacheKey(model: string | FallbackModelRef, input: AiInput): string {
+		return hashFn(modelLabel(model), input);
 	}
 
 	return {
-		async run(model: string, input: AiInput, options?: RunOptions): Promise<AiOutput> {
+		async run(
+			model: string | FallbackModelRef,
+			input: AiInput,
+			options?: RunOptions,
+		): Promise<AiOutput> {
 			const cacheKey = getCacheKey(model, input);
 
 			// Try cache first
@@ -91,13 +98,13 @@ export function withCache(gateway: Gateway, config: CacheConfig): CachedGateway 
 			return result;
 		},
 
-		async isCached(model: string, input: AiInput): Promise<boolean> {
+		async isCached(model: string | FallbackModelRef, input: AiInput): Promise<boolean> {
 			const cacheKey = getCacheKey(model, input);
 			const value = await config.storage.get(cacheKey, { type: "text" });
 			return value !== null;
 		},
 
-		async invalidate(model: string, input: AiInput): Promise<void> {
+		async invalidate(model: string | FallbackModelRef, input: AiInput): Promise<void> {
 			const cacheKey = getCacheKey(model, input);
 			await config.storage.delete(cacheKey);
 		},

--- a/packages/ai-gateway/src/errors.ts
+++ b/packages/ai-gateway/src/errors.ts
@@ -1,0 +1,26 @@
+/**
+ * Thrown by `gateway.run()` when a `FallbackModelRef` is used and BOTH the
+ * primary and secondary attempts fail. The original tier errors are preserved
+ * on `.primaryError` and `.secondaryError` for programmatic inspection; the
+ * primary is also set as the `.cause` so structured loggers surface it.
+ */
+export class FallbackExhaustedError extends Error {
+	readonly name = "FallbackExhaustedError";
+	readonly primaryError: unknown;
+	readonly secondaryError: unknown;
+
+	constructor(primaryError: unknown, secondaryError: unknown) {
+		super(
+			`Fallback exhausted: both primary and secondary attempts failed (primary: ${describe(primaryError)}; secondary: ${describe(secondaryError)})`,
+			{ cause: primaryError },
+		);
+		this.primaryError = primaryError;
+		this.secondaryError = secondaryError;
+		Object.setPrototypeOf(this, new.target.prototype);
+	}
+}
+
+function describe(err: unknown): string {
+	if (err instanceof Error) return `${err.name}: ${err.message}`;
+	return String(err);
+}

--- a/packages/ai-gateway/src/fallback-wrapper.ts
+++ b/packages/ai-gateway/src/fallback-wrapper.ts
@@ -181,7 +181,13 @@ export async function runWithFallback(
 	} catch (err) {
 		if (!matchesFallback(err, ref.on)) throw err;
 		primaryError = err;
-		ref.onFallback?.(err, "primary");
+		// onFallback is an observability hook — swallow throws so a broken
+		// logger/metrics emitter never blocks the actual secondary attempt.
+		try {
+			ref.onFallback?.(err, "primary");
+		} catch {
+			// ignored intentionally
+		}
 	}
 	try {
 		const result = await runOne(ref.secondary, input, options);

--- a/packages/ai-gateway/src/fallback-wrapper.ts
+++ b/packages/ai-gateway/src/fallback-wrapper.ts
@@ -1,0 +1,160 @@
+import { FallbackExhaustedError } from "./errors";
+import type { AiInput, AiOutput, RunOptions } from "./types";
+
+/** Matcher entry accepted by `fallback({ on })`. */
+export type FallbackMatcher = number | ((err: unknown) => boolean);
+
+/**
+ * A model reference that `gateway.run()` treats as a two-tier failover chain:
+ * try `primary` first; if it throws an error matched by any entry in `on`,
+ * try `secondary` with the same input and options.
+ *
+ * Created via `fallback(primary, secondary, { on, onFallback? })`.
+ */
+export interface FallbackModelRef {
+	readonly kind: "fallback";
+	readonly primary: string;
+	readonly secondary: string;
+	readonly on: ReadonlyArray<FallbackMatcher>;
+	readonly onFallback?: (err: unknown, attempt: "primary" | "secondary") => void;
+}
+
+/**
+ * Options for `fallback()`.
+ *
+ * - `on` — which errors from the primary trigger a fallback to the secondary.
+ *   Numeric entries match `err.status` or `err.statusCode` (exact number match
+ *   against the HTTP status an error carries; the check is skipped for errors
+ *   without either field). Function entries receive the raw error and return
+ *   `true` to fall over.
+ * - `onFallback` — invoked once per tier boundary with the error that caused
+ *   the transition and the attempt tier that *failed* (always `"primary"` for
+ *   the primary-to-secondary transition in the two-tier shape).
+ */
+export interface FallbackOptions {
+	on: ReadonlyArray<FallbackMatcher>;
+	onFallback?: FallbackModelRef["onFallback"];
+}
+
+/**
+ * Build a two-tier failover reference usable wherever `gateway.run()` accepts
+ * a model. When the primary throws with a matching status code or predicate,
+ * the secondary is tried with the same input and options.
+ *
+ * @example
+ * ```ts
+ * const model = fallback("claude-sonnet-4-6", "gpt-4o", {
+ *   on: [401, 429, 500, 502, 503, 504],
+ *   onFallback: (err, attempt) => log.warn("provider failover", { err, attempt }),
+ * });
+ * const result = await gateway.run(model, { prompt: "…" });
+ * // result.via === "primary" | "secondary"
+ * ```
+ */
+export function fallback(
+	primary: string,
+	secondary: string,
+	options: FallbackOptions,
+): FallbackModelRef {
+	return {
+		kind: "fallback",
+		primary,
+		secondary,
+		on: options.on,
+		onFallback: options.onFallback,
+	};
+}
+
+/** Narrow an unknown value to a `FallbackModelRef` by its discriminant tag. */
+export function isFallbackModelRef(value: unknown): value is FallbackModelRef {
+	return (
+		typeof value === "object" && value !== null && (value as { kind?: unknown }).kind === "fallback"
+	);
+}
+
+/**
+ * Test whether `err` matches any entry in the `on` list.
+ *
+ * Numeric entries match when the error (or any error in its `.cause` chain)
+ * exposes a matching HTTP status — checked against `err.status`,
+ * `err.context?.status` (the field gateway providers attach to their
+ * wrapped errors), and `err.statusCode` (the canonical field every
+ * `WorkkitError` carries). Walking the cause chain lets a wrapped
+ * `ServiceUnavailableError` still trigger a `401` matcher when the
+ * underlying provider error was a 401. Function entries are called with
+ * the raw error.
+ */
+export function matchesFallback(err: unknown, matchers: ReadonlyArray<FallbackMatcher>): boolean {
+	const statuses = collectStatuses(err);
+	for (const matcher of matchers) {
+		if (typeof matcher === "number") {
+			if (statuses.has(matcher)) return true;
+			continue;
+		}
+		try {
+			if (matcher(err)) return true;
+		} catch {
+			// Predicate threw — treat as non-match rather than masking the
+			// original error with the predicate's failure.
+		}
+	}
+	return false;
+}
+
+function collectStatuses(err: unknown): Set<number> {
+	const out = new Set<number>();
+	let current: unknown = err;
+	// Cap depth to avoid pathological circular `.cause` graphs.
+	for (let depth = 0; depth < 8 && current !== null && typeof current === "object"; depth++) {
+		const candidate = current as {
+			status?: unknown;
+			statusCode?: unknown;
+			context?: { status?: unknown };
+			cause?: unknown;
+		};
+		if (typeof candidate.status === "number") out.add(candidate.status);
+		if (typeof candidate.statusCode === "number") out.add(candidate.statusCode);
+		const ctxStatus = candidate.context?.status;
+		if (typeof ctxStatus === "number") out.add(ctxStatus);
+		if (candidate.cause === current) break;
+		current = candidate.cause;
+	}
+	return out;
+}
+
+/**
+ * Internal: run `ref` against a single-model runner, applying the two-tier
+ * failover policy. `runOne` is invoked once for the primary and at most once
+ * more for the secondary; the same `input` and `options` are passed through
+ * to both so observability hooks, timeouts, and response-format preferences
+ * apply identically to each tier.
+ *
+ * Used by `gateway.run()` when it receives a `FallbackModelRef`. Exposed
+ * from this module (not `index.ts`) so gateway wrappers — `withRetry`,
+ * `withCache`, `withLogging` — can reuse the same dispatch if they ever
+ * need to forward fallback refs themselves.
+ */
+export async function runWithFallback(
+	ref: FallbackModelRef,
+	input: AiInput,
+	options: RunOptions | undefined,
+	runOne: (model: string, input: AiInput, options?: RunOptions) => Promise<AiOutput>,
+): Promise<AiOutput> {
+	let primaryError: unknown;
+	try {
+		const result = await runOne(ref.primary, input, options);
+		return { ...result, via: "primary" };
+	} catch (err) {
+		if (!matchesFallback(err, ref.on)) throw err;
+		primaryError = err;
+		ref.onFallback?.(err, "primary");
+	}
+	try {
+		const result = await runOne(ref.secondary, input, options);
+		return { ...result, via: "secondary" };
+	} catch (secondaryError) {
+		throw new FallbackExhaustedError(primaryError, secondaryError);
+	}
+}
+
+export { FallbackExhaustedError };

--- a/packages/ai-gateway/src/fallback-wrapper.ts
+++ b/packages/ai-gateway/src/fallback-wrapper.ts
@@ -65,11 +65,45 @@ export function fallback(
 	};
 }
 
-/** Narrow an unknown value to a `FallbackModelRef` by its discriminant tag. */
+function isNonEmptyString(value: unknown): value is string {
+	return typeof value === "string" && value.length > 0;
+}
+
+function isFallbackMatcher(value: unknown): value is FallbackMatcher {
+	return typeof value === "number" || typeof value === "function";
+}
+
+/**
+ * Narrow an unknown value to a `FallbackModelRef`. Validates the discriminant
+ * tag AND that `primary`/`secondary` are non-empty strings and `on` is an
+ * array of numbers or predicates. Rejecting malformed shapes here avoids
+ * confusing runtime failures deeper in `runWithFallback` for JS callers
+ * (where TS's structural checks are absent).
+ */
 export function isFallbackModelRef(value: unknown): value is FallbackModelRef {
-	return (
-		typeof value === "object" && value !== null && (value as { kind?: unknown }).kind === "fallback"
-	);
+	if (typeof value !== "object" || value === null) return false;
+	const v = value as {
+		kind?: unknown;
+		primary?: unknown;
+		secondary?: unknown;
+		on?: unknown;
+	};
+	if (v.kind !== "fallback") return false;
+	if (!isNonEmptyString(v.primary)) return false;
+	if (!isNonEmptyString(v.secondary)) return false;
+	if (!Array.isArray(v.on)) return false;
+	return v.on.every(isFallbackMatcher);
+}
+
+/**
+ * Produce a stable, human-readable label for a model reference. Used by
+ * wrappers like `withCache` (as part of the cache key) and `withLogging` (as
+ * the log label) so a `FallbackModelRef` doesn't stringify to
+ * `"[object Object]"`.
+ */
+export function modelLabel(model: string | FallbackModelRef): string {
+	if (typeof model === "string") return model;
+	return `fallback:${model.primary}→${model.secondary}`;
 }
 
 /**

--- a/packages/ai-gateway/src/gateway.ts
+++ b/packages/ai-gateway/src/gateway.ts
@@ -1,5 +1,7 @@
 import { ConfigError, ServiceUnavailableError, ValidationError } from "@workkit/errors";
 import { buildFallbackBodyEntry, normalizeFallbackResponse } from "./fallback";
+import { isFallbackModelRef, runWithFallback } from "./fallback-wrapper";
+import type { FallbackModelRef } from "./fallback-wrapper";
 import { executeAnthropic } from "./providers/anthropic";
 import { executeCustom } from "./providers/custom";
 import { executeEmbed } from "./providers/embed";
@@ -86,36 +88,49 @@ export function createGateway<P extends ProviderMap>(config: GatewayConfig<P>): 
 
 	const providerNames = Object.keys(config.providers);
 
+	const runString = async (
+		model: string,
+		input: AiInput,
+		options?: RunOptions,
+	): Promise<AiOutput> => {
+		if (!model) {
+			throw new ValidationError("Model name is required", [
+				{ path: ["model"], message: "Model name cannot be empty" },
+			]);
+		}
+
+		const providerKey = options?.provider ?? config.defaultProvider;
+		const providerConfig = config.providers[providerKey];
+
+		if (!providerConfig) {
+			throw new ConfigError(`Provider "${providerKey}" not found`, {
+				context: { provider: providerKey, available: providerNames },
+			});
+		}
+
+		const { signal, cleanup } = withTimeoutSignal(options);
+		try {
+			return await executeProvider(
+				providerKey,
+				providerConfig,
+				model,
+				input,
+				signal ? { ...options, signal } : options,
+				config.cfGateway,
+			);
+		} finally {
+			cleanup();
+		}
+	};
+
 	return {
-		async run(model: string, input: AiInput, options?: RunOptions): Promise<AiOutput> {
-			if (!model) {
-				throw new ValidationError("Model name is required", [
-					{ path: ["model"], message: "Model name cannot be empty" },
-				]);
-			}
-
-			const providerKey = options?.provider ?? config.defaultProvider;
-			const providerConfig = config.providers[providerKey];
-
-			if (!providerConfig) {
-				throw new ConfigError(`Provider "${providerKey}" not found`, {
-					context: { provider: providerKey, available: providerNames },
-				});
-			}
-
-			const { signal, cleanup } = withTimeoutSignal(options);
-			try {
-				return await executeProvider(
-					providerKey,
-					providerConfig,
-					model,
-					input,
-					signal ? { ...options, signal } : options,
-					config.cfGateway,
-				);
-			} finally {
-				cleanup();
-			}
+		async run(
+			model: string | FallbackModelRef,
+			input: AiInput,
+			options?: RunOptions,
+		): Promise<AiOutput> {
+			if (isFallbackModelRef(model)) return runWithFallback(model, input, options, runString);
+			return runString(model, input, options);
 		},
 
 		async runFallback(

--- a/packages/ai-gateway/src/index.ts
+++ b/packages/ai-gateway/src/index.ts
@@ -17,6 +17,11 @@ export { withLogging } from "./logging";
 export { withRetry } from "./retry";
 export type { RetryConfig } from "./retry";
 
+// Fallback wrapper — two-tier provider failover usable as a model ref.
+export { fallback, isFallbackModelRef } from "./fallback-wrapper";
+export type { FallbackModelRef, FallbackMatcher, FallbackOptions } from "./fallback-wrapper";
+export { FallbackExhaustedError } from "./errors";
+
 // Tool registry — name/handler map for dispatching tool calls.
 export { createToolRegistry } from "./tool-registry";
 export type { ToolHandler, ToolRegistry } from "./tool-registry";

--- a/packages/ai-gateway/src/index.ts
+++ b/packages/ai-gateway/src/index.ts
@@ -18,7 +18,7 @@ export { withRetry } from "./retry";
 export type { RetryConfig } from "./retry";
 
 // Fallback wrapper — two-tier provider failover usable as a model ref.
-export { fallback, isFallbackModelRef } from "./fallback-wrapper";
+export { fallback, isFallbackModelRef, modelLabel } from "./fallback-wrapper";
 export type { FallbackModelRef, FallbackMatcher, FallbackOptions } from "./fallback-wrapper";
 export { FallbackExhaustedError } from "./errors";
 

--- a/packages/ai-gateway/src/logging.ts
+++ b/packages/ai-gateway/src/logging.ts
@@ -1,3 +1,4 @@
+import { type FallbackModelRef, modelLabel } from "./fallback-wrapper";
 import type {
 	AiInput,
 	AiOutput,
@@ -31,17 +32,25 @@ export function withLogging(gateway: Gateway, config: LoggingConfig): LoggedGate
 	const innerEmbed = gateway.embed?.bind(gateway);
 
 	return {
-		async run(model: string, input: AiInput, options?: RunOptions): Promise<AiOutput> {
-			config.onRequest?.(model, input);
+		async run(
+			model: string | FallbackModelRef,
+			input: AiInput,
+			options?: RunOptions,
+		): Promise<AiOutput> {
+			// `LoggingConfig` callbacks take `model: string`, so fallback refs are
+			// labeled (`fallback:primary→secondary`) before emission instead of
+			// stringifying to `[object Object]`.
+			const label = modelLabel(model);
+			config.onRequest?.(label, input);
 
 			const start = Date.now();
 			try {
 				const result = await gateway.run(model, input, options);
 				const duration = Date.now() - start;
-				config.onResponse?.(model, result, duration);
+				config.onResponse?.(label, result, duration);
 				return result;
 			} catch (err) {
-				config.onError?.(model, err);
+				config.onError?.(label, err);
 				throw err;
 			}
 		},

--- a/packages/ai-gateway/src/types.ts
+++ b/packages/ai-gateway/src/types.ts
@@ -394,9 +394,9 @@ export interface CacheConfig {
 /** A cached gateway — same interface as Gateway */
 export interface CachedGateway extends Gateway {
 	/** Check if a response is cached for the given model + input */
-	isCached(model: string, input: AiInput): Promise<boolean>;
+	isCached(model: string | FallbackModelRef, input: AiInput): Promise<boolean>;
 	/** Invalidate cached response for the given model + input */
-	invalidate(model: string, input: AiInput): Promise<void>;
+	invalidate(model: string | FallbackModelRef, input: AiInput): Promise<void>;
 }
 
 // --- Logging types ---

--- a/packages/ai-gateway/src/types.ts
+++ b/packages/ai-gateway/src/types.ts
@@ -1,3 +1,5 @@
+import type { FallbackModelRef } from "./fallback-wrapper";
+
 // --- Provider types ---
 
 /** Workers AI binding — the `env.AI` object */
@@ -145,6 +147,12 @@ export interface AiOutput {
 	model: string;
 	/** Tool calls from the model, if any */
 	toolCalls?: GatewayToolCall[];
+	/**
+	 * Which tier of a `fallback(primary, secondary)` reference served the
+	 * call. Only set when `run()` was invoked with a `FallbackModelRef`;
+	 * absent for direct string-model calls.
+	 */
+	via?: "primary" | "secondary";
 }
 
 /** Token usage stats */
@@ -208,8 +216,13 @@ export type GatewayStreamEvent =
 
 /** Gateway instance */
 export interface Gateway {
-	/** Run a model with the given input */
-	run(model: string, input: AiInput, options?: RunOptions): Promise<AiOutput>;
+	/**
+	 * Run a model with the given input. Accepts either a string model id or
+	 * a `FallbackModelRef` produced by `fallback(primary, secondary, { on })`;
+	 * in the latter case the gateway tries the primary first and falls over
+	 * to the secondary when the primary throws a matching error.
+	 */
+	run(model: string | FallbackModelRef, input: AiInput, options?: RunOptions): Promise<AiOutput>;
 	/**
 	 * Run a chain of provider/model attempts through the Cloudflare AI Gateway
 	 * Universal Endpoint. The gateway tries each entry server-side in order

--- a/packages/ai-gateway/tests/fallback-wrapper.test.ts
+++ b/packages/ai-gateway/tests/fallback-wrapper.test.ts
@@ -1,7 +1,13 @@
 import { ServiceUnavailableError, UnauthorizedError } from "@workkit/errors";
 import { describe, expect, it, vi } from "vitest";
 import { runWithFallback } from "../src/fallback-wrapper";
-import { FallbackExhaustedError, createGateway, fallback } from "../src/index";
+import {
+	FallbackExhaustedError,
+	createGateway,
+	fallback,
+	isFallbackModelRef,
+	modelLabel,
+} from "../src/index";
 import type { AiInput, AiOutput, Gateway, RunOptions, WorkersAiBinding } from "../src/types";
 
 /**
@@ -243,7 +249,7 @@ describe("runWithFallback() — direct runner contract", () => {
 		expect(out.via).toBe("secondary");
 	});
 
-	it("wraps a plain UnauthorizedError (statusCode 401) and matches on:[401]", async () => {
+	it("matches a plain UnauthorizedError (statusCode 401) and falls back on:[401]", async () => {
 		const raw = new UnauthorizedError("401");
 		const runner = vi
 			.fn()
@@ -254,5 +260,47 @@ describe("runWithFallback() — direct runner contract", () => {
 		const ref = fallback("p", "s", { on: [401] });
 		const out = await runWithFallback(ref, { prompt: "hi" }, undefined, runner);
 		expect(out.via).toBe("secondary");
+	});
+});
+
+describe("isFallbackModelRef() shape validation", () => {
+	it("returns true for a well-formed fallback() result", () => {
+		expect(isFallbackModelRef(fallback("p", "s", { on: [401] }))).toBe(true);
+	});
+	it("rejects non-objects", () => {
+		expect(isFallbackModelRef(null)).toBe(false);
+		expect(isFallbackModelRef(undefined)).toBe(false);
+		expect(isFallbackModelRef("fallback")).toBe(false);
+		expect(isFallbackModelRef(42)).toBe(false);
+	});
+	it("rejects objects missing kind === 'fallback'", () => {
+		expect(isFallbackModelRef({ kind: "other", primary: "p", secondary: "s", on: [] })).toBe(false);
+		expect(isFallbackModelRef({ primary: "p", secondary: "s", on: [] })).toBe(false);
+	});
+	it("rejects refs with empty-string primary or secondary", () => {
+		expect(isFallbackModelRef({ kind: "fallback", primary: "", secondary: "s", on: [] })).toBe(
+			false,
+		);
+		expect(isFallbackModelRef({ kind: "fallback", primary: "p", secondary: "", on: [] })).toBe(
+			false,
+		);
+	});
+	it("rejects refs where `on` is not an array or contains non-matcher entries", () => {
+		expect(isFallbackModelRef({ kind: "fallback", primary: "p", secondary: "s", on: "401" })).toBe(
+			false,
+		);
+		expect(
+			isFallbackModelRef({ kind: "fallback", primary: "p", secondary: "s", on: [{} as unknown] }),
+		).toBe(false);
+	});
+});
+
+describe("modelLabel() — stable label for wrappers", () => {
+	it("returns the string unchanged for plain string models", () => {
+		expect(modelLabel("gpt-4o")).toBe("gpt-4o");
+	});
+	it("returns a deterministic `fallback:primary→secondary` label for refs", () => {
+		const ref = fallback("claude-sonnet-4-6", "gpt-4o", { on: [401] });
+		expect(modelLabel(ref)).toBe("fallback:claude-sonnet-4-6→gpt-4o");
 	});
 });

--- a/packages/ai-gateway/tests/fallback-wrapper.test.ts
+++ b/packages/ai-gateway/tests/fallback-wrapper.test.ts
@@ -1,0 +1,258 @@
+import { ServiceUnavailableError, UnauthorizedError } from "@workkit/errors";
+import { describe, expect, it, vi } from "vitest";
+import { runWithFallback } from "../src/fallback-wrapper";
+import { FallbackExhaustedError, createGateway, fallback } from "../src/index";
+import type { AiInput, AiOutput, Gateway, RunOptions, WorkersAiBinding } from "../src/types";
+
+/**
+ * Build a gateway backed by a single `workers-ai` binding whose `run`
+ * dispatches on the model string. This lets tests simulate per-model
+ * success/failure without real HTTP while still exercising the full
+ * `createGateway` → `gateway.run(fallbackRef, …)` code path.
+ */
+function makeBindingGateway(binding: WorkersAiBinding["run"]): Gateway {
+	return createGateway({
+		providers: { ai: { type: "workers-ai", binding: { run: binding } } },
+		defaultProvider: "ai",
+	});
+}
+
+function okOutput(model: string): AiOutput {
+	return { text: "ok", raw: { text: "ok" }, provider: "ai", model };
+}
+
+/** Plain error with a `status` field — matches the shape gateway providers attach in their error `context`. */
+class HttpLikeError extends Error {
+	readonly status: number;
+	constructor(message: string, status: number) {
+		super(message);
+		this.name = "HttpLikeError";
+		this.status = status;
+	}
+}
+
+describe("fallback()", () => {
+	it("returns a FallbackModelRef with kind === 'fallback'", () => {
+		const ref = fallback("primary-model", "secondary-model", { on: [401] });
+		expect(ref.kind).toBe("fallback");
+		expect(ref.primary).toBe("primary-model");
+		expect(ref.secondary).toBe("secondary-model");
+		expect(ref.on).toEqual([401]);
+	});
+});
+
+describe("gateway.run() with FallbackModelRef", () => {
+	it("primary succeeds — secondary not called, via === 'primary'", async () => {
+		const binding = vi.fn().mockImplementation(async (model: string) => ({
+			response: `hi from ${model}`,
+		}));
+		const gw = makeBindingGateway(binding);
+
+		const ref = fallback("primary-model", "secondary-model", { on: [401] });
+		const result = await gw.run(ref, { prompt: "hi" });
+
+		expect(binding).toHaveBeenCalledTimes(1);
+		expect(binding.mock.calls[0][0]).toBe("primary-model");
+		expect(result.model).toBe("primary-model");
+		expect(result.via).toBe("primary");
+	});
+
+	it("primary throws status 401 with on:[401] — secondary called, via === 'secondary', onFallback fires", async () => {
+		const primaryErr = new HttpLikeError("anthropic 401", 401);
+		const binding = vi.fn().mockImplementation(async (model: string) => {
+			if (model === "primary-model") throw primaryErr;
+			return { response: "secondary ok" };
+		});
+		const gw = makeBindingGateway(binding);
+
+		const onFallback = vi.fn();
+		const ref = fallback("primary-model", "secondary-model", {
+			on: [401, 429, 500, 502, 503, 504],
+			onFallback,
+		});
+		const result = await gw.run(ref, { prompt: "hi" });
+
+		expect(binding).toHaveBeenCalledTimes(2);
+		expect(binding.mock.calls[1][0]).toBe("secondary-model");
+		expect(result.model).toBe("secondary-model");
+		expect(result.via).toBe("secondary");
+		expect(onFallback).toHaveBeenCalledTimes(1);
+		// The primary error is surfaced via the provider wrapper's `.cause`.
+		const reported = onFallback.mock.calls[0][0] as Error;
+		expect(reported).toBeInstanceOf(Error);
+		expect((reported as { cause?: unknown }).cause).toBe(primaryErr);
+		expect(onFallback.mock.calls[0][1]).toBe("primary");
+	});
+
+	it("primary throws status 503 — falls over with on:[401,429,500,502,503,504]", async () => {
+		const binding = vi.fn().mockImplementation(async (model: string) => {
+			if (model === "primary-model") throw new HttpLikeError("upstream", 503);
+			return { response: "secondary ok" };
+		});
+		const gw = makeBindingGateway(binding);
+
+		const ref = fallback("primary-model", "secondary-model", {
+			on: [401, 429, 500, 502, 503, 504],
+		});
+		const result = await gw.run(ref, { prompt: "hi" });
+
+		expect(result.via).toBe("secondary");
+		expect(result.model).toBe("secondary-model");
+	});
+
+	it("matches numeric entries against err.status when present", async () => {
+		const binding = vi.fn().mockImplementation(async (model: string) => {
+			if (model === "primary-model") throw new HttpLikeError("rate limited", 429);
+			return { response: "ok" };
+		});
+		const gw = makeBindingGateway(binding);
+
+		const ref = fallback("primary-model", "secondary-model", { on: [429] });
+		const result = await gw.run(ref, { prompt: "hi" });
+
+		expect(result.via).toBe("secondary");
+	});
+
+	it("primary throws 404 with on:[401,429] — does NOT fall over, secondary never invoked", async () => {
+		const binding = vi.fn().mockImplementation(async () => {
+			throw new HttpLikeError("not found", 404);
+		});
+		const gw = makeBindingGateway(binding);
+
+		const ref = fallback("primary-model", "secondary-model", { on: [401, 429] });
+		await expect(gw.run(ref, { prompt: "hi" })).rejects.not.toBeInstanceOf(FallbackExhaustedError);
+		expect(binding).toHaveBeenCalledTimes(1);
+		expect(binding.mock.calls[0][0]).toBe("primary-model");
+	});
+
+	it("predicate matcher — (err) => underlying is TimeoutError falls over", async () => {
+		class FakeTimeoutError extends Error {
+			constructor() {
+				super("timeout");
+				this.name = "TimeoutError";
+			}
+		}
+		const binding = vi.fn().mockImplementation(async (model: string) => {
+			if (model === "primary-model") throw new FakeTimeoutError();
+			return { response: "ok" };
+		});
+		const gw = makeBindingGateway(binding);
+
+		const ref = fallback("primary-model", "secondary-model", {
+			on: [
+				(err: unknown) => {
+					// The provider wrapper nests the original under `cause`.
+					const cause = (err as { cause?: unknown }).cause;
+					return cause instanceof Error && cause.name === "TimeoutError";
+				},
+			],
+		});
+		const result = await gw.run(ref, { prompt: "hi" });
+
+		expect(result.via).toBe("secondary");
+	});
+
+	it("both primary and secondary fail — throws FallbackExhaustedError with both errors", async () => {
+		const primaryRawErr = new HttpLikeError("anthropic 401", 401);
+		const secondaryRawErr = new HttpLikeError("openai 503", 503);
+		const binding = vi.fn().mockImplementation(async (model: string) => {
+			if (model === "primary-model") throw primaryRawErr;
+			throw secondaryRawErr;
+		});
+		const gw = makeBindingGateway(binding);
+
+		const ref = fallback("primary-model", "secondary-model", {
+			on: [401, 429, 500, 502, 503, 504],
+		});
+
+		await expect(gw.run(ref, { prompt: "hi" })).rejects.toBeInstanceOf(FallbackExhaustedError);
+		try {
+			await gw.run(ref, { prompt: "hi" });
+		} catch (err) {
+			expect(err).toBeInstanceOf(FallbackExhaustedError);
+			const fe = err as FallbackExhaustedError;
+			// Primary/secondary errors are the (wrapped) errors surfaced by the runner.
+			expect((fe.primaryError as { cause?: unknown }).cause).toBe(primaryRawErr);
+			expect((fe.secondaryError as { cause?: unknown }).cause).toBe(secondaryRawErr);
+		}
+	});
+
+	it("passes input and options (responseFormat, toolOptions) through to both tiers", async () => {
+		const binding = vi.fn().mockImplementation(async (model: string) => {
+			if (model === "primary-model") throw new HttpLikeError("401", 401);
+			return { response: "ok" };
+		});
+		const gw = makeBindingGateway(binding);
+
+		const input: AiInput = { messages: [{ role: "user", content: "hi" }] };
+		const options: RunOptions = {
+			responseFormat: "json",
+			toolOptions: {
+				tools: [{ name: "t", description: "d", parameters: {} }],
+				toolChoice: "auto",
+			},
+		};
+		const ref = fallback("primary-model", "secondary-model", { on: [401] });
+		const result = await gw.run(ref, input, options);
+
+		expect(result.via).toBe("secondary");
+		expect(binding).toHaveBeenCalledTimes(2);
+		// Both tiers see the same tools/response_format on the binding input.
+		const firstCallInput = binding.mock.calls[0][1] as Record<string, unknown>;
+		const secondCallInput = binding.mock.calls[1][1] as Record<string, unknown>;
+		expect(firstCallInput.response_format).toEqual({ type: "json_object" });
+		expect(secondCallInput.response_format).toEqual({ type: "json_object" });
+		expect(firstCallInput.tools).toBeDefined();
+		expect(secondCallInput.tools).toBeDefined();
+	});
+});
+
+describe("runWithFallback() — direct runner contract", () => {
+	it("passes through when runner throws a non-matching error", async () => {
+		const runner = vi.fn().mockRejectedValue(new HttpLikeError("nope", 418));
+		const ref = fallback("p", "s", { on: [401, 429] });
+		await expect(runWithFallback(ref, { prompt: "hi" }, undefined, runner)).rejects.toMatchObject({
+			status: 418,
+		});
+		expect(runner).toHaveBeenCalledTimes(1);
+	});
+
+	it("tags success results with `via` even when primary is a WorkkitError that doesn't match", async () => {
+		// A ServiceUnavailableError whose context.status is outside `on` — not a fallback trigger.
+		const runner = vi.fn().mockImplementation(async (model: string) => okOutput(model));
+		const ref = fallback("p", "s", { on: [401] });
+		const out = await runWithFallback(ref, { prompt: "hi" }, undefined, runner);
+		expect(out.via).toBe("primary");
+	});
+
+	it("honors the ServiceUnavailableError status-code path (401 nested via cause chain)", async () => {
+		// Simulate the shape providers/*.ts actually emit: ServiceUnavailableError wrapping the raw err.
+		const raw = new HttpLikeError("provider 401", 401);
+		const wrapped = new ServiceUnavailableError("anthropic (401)", {
+			cause: raw,
+			context: { status: 401 },
+		});
+		const runner = vi
+			.fn()
+			.mockImplementationOnce(async () => {
+				throw wrapped;
+			})
+			.mockImplementationOnce(async (model: string) => okOutput(model));
+		const ref = fallback("p", "s", { on: [401] });
+		const out = await runWithFallback(ref, { prompt: "hi" }, undefined, runner);
+		expect(out.via).toBe("secondary");
+	});
+
+	it("wraps a plain UnauthorizedError (statusCode 401) and matches on:[401]", async () => {
+		const raw = new UnauthorizedError("401");
+		const runner = vi
+			.fn()
+			.mockImplementationOnce(async () => {
+				throw raw;
+			})
+			.mockImplementationOnce(async (model: string) => okOutput(model));
+		const ref = fallback("p", "s", { on: [401] });
+		const out = await runWithFallback(ref, { prompt: "hi" }, undefined, runner);
+		expect(out.via).toBe("secondary");
+	});
+});

--- a/packages/ai-gateway/tests/fallback-wrapper.test.ts
+++ b/packages/ai-gateway/tests/fallback-wrapper.test.ts
@@ -261,6 +261,27 @@ describe("runWithFallback() — direct runner contract", () => {
 		const out = await runWithFallback(ref, { prompt: "hi" }, undefined, runner);
 		expect(out.via).toBe("secondary");
 	});
+
+	it("fails open on onFallback throws — secondary is still attempted", async () => {
+		const primaryErr = new HttpLikeError("401", 401);
+		const runner = vi
+			.fn()
+			.mockImplementationOnce(async () => {
+				throw primaryErr;
+			})
+			.mockImplementationOnce(async (model: string) => okOutput(model));
+		const ref = fallback("p", "s", {
+			on: [401],
+			onFallback: () => {
+				throw new Error("logger exploded");
+			},
+		});
+		const out = await runWithFallback(ref, { prompt: "hi" }, undefined, runner);
+		// A broken observability hook must not mask the provider failure or
+		// block failover to the secondary tier.
+		expect(out.via).toBe("secondary");
+		expect(runner).toHaveBeenCalledTimes(2);
+	});
 });
 
 describe("isFallbackModelRef() shape validation", () => {


### PR DESCRIPTION
## Summary

- New `fallback(primary, secondary, { on, onFallback? })` primitive on `@workkit/ai-gateway` returns a `FallbackModelRef` usable wherever `gateway.run()` accepts a string model id.
- `run()` dispatches on `.kind === "fallback"`: try primary first, call secondary with the same `input`/`options` if the primary throws a matching HTTP status (walks `.cause` chain) or a matching predicate. `AiOutput.via` tags `"primary" | "secondary"` so observability can break down traffic by tier.
- `FallbackExhaustedError { primaryError, secondaryError }` when both tiers fail. No new runtime deps.

Closes #81.

## Design decisions

- **Integration point:** the issue talks about a hypothetical `ai(gateway, modelOrFallback, …)` entry function, but this codebase's entry is `gateway.run(model, …)`. I taught `gateway.run()` to accept `string | FallbackModelRef` via a `.kind` discriminator — same ergonomics, no new top-level export, constitution rule 4 satisfied (single entry per package).
- **`on: [{ status, range: "xx" }]`:** the issue mentions that shape in passing, but its own "Scope" section falls back to an explicit-numbers list and so does the v1 instruction. Shipped with explicit numbers + predicate only, which is the simpler, more ergonomic primitive. Range objects can be added later without a breaking change.
- **`FallbackExhaustedError`:** extends plain `Error` rather than `WorkkitError` because `WorkkitErrorCode` is a closed enum in `@workkit/errors` and the instruction forbids touching files outside `packages/ai-gateway/`. Preserves both errors as properties and sets the primary as `.cause` for structured loggers.
- **`.cause` chain walking for numeric matchers:** providers wrap upstream errors in `ServiceUnavailableError` with the original as `cause` and `context.status = <upstream>`. Walking the chain means `on: [401]` still triggers when a raw provider 401 ends up nested.
- **Kept `fallback.ts` untouched:** the existing low-level CF Universal Endpoint helpers are a different concern — multi-provider routing on CF's side — and are orthogonal to this client-side primitive.

## Files touched

- `packages/ai-gateway/src/fallback-wrapper.ts` (new) — `fallback()`, `isFallbackModelRef()`, `matchesFallback()`, `runWithFallback()`.
- `packages/ai-gateway/src/errors.ts` (new) — `FallbackExhaustedError`.
- `packages/ai-gateway/src/gateway.ts` — `run()` branches on the discriminator; otherwise untouched (diff-only per rule 8).
- `packages/ai-gateway/src/types.ts` — adds `AiOutput.via?: "primary" | "secondary"` and widens `Gateway.run()`'s `model` parameter to `string | FallbackModelRef`.
- `packages/ai-gateway/src/index.ts` — re-exports `fallback`, `isFallbackModelRef`, `FallbackModelRef`, `FallbackMatcher`, `FallbackOptions`, `FallbackExhaustedError`.
- `packages/ai-gateway/tests/fallback-wrapper.test.ts` (new) — 13 tests.
- `.changeset/ai-gateway-fallback-wrapper.md` (new) — minor bump.

## Test plan

- [x] Tests written first; all 13 fall once on first red run.
- [x] `bunx vitest run tests/fallback-wrapper.test.ts` — 13/13 green.
- [x] `bunx vitest run` (full ai-gateway suite) — 218/218 green (no regressions).
- [x] `bunx turbo typecheck --filter @workkit/ai-gateway` — green.
- [x] `bunx biome check packages/ai-gateway/` — 0 errors (8 pre-existing warnings on `schema.ts`).
- [x] `bun run constitution:check -- --diff-only` — 0 errors, 0 warnings.
- [ ] Once reviewed, run a smoke test with a real Anthropic 401 key against an OpenAI fallback key to confirm end-to-end behavior matches the Anthropic-401-silent-masking scenario that motivated #81.

## Scenarios covered by tests

1. Primary succeeds → `via: "primary"`, secondary not called.
2. Primary 401 / `on:[401,429,500,502,503,504]` → `via: "secondary"`, `onFallback("primary")` fires.
3. Primary 503 (via wrapper cause chain) → falls over.
4. Raw `err.status === 429` → falls over.
5. Primary 404 / `on:[401,429]` → does NOT fall over; secondary never called.
6. Predicate matcher (`err.name === "TimeoutError"`) → falls over.
7. Both tiers fail → `FallbackExhaustedError` with both errors preserved.
8. `responseFormat: "json"` + `toolOptions` pass through to both tiers.
9. Direct `runWithFallback()` unit tests for non-matching errors, `WorkkitError` statusCode (401), and nested `ServiceUnavailableError` wrapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added two-tier model failover capability via the `fallback()` primitive, enabling automatic switchover from a primary to secondary model when specific error conditions are met (HTTP status codes or custom predicates).
  * Introduced `FallbackExhaustedError` exception thrown when both tiers fail, with both errors accessible for debugging.
  * Output results now include a `via` field indicating which tier served the request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->