### PR TITLE
feat(agent): afterModel hook for output-side guardrails (#58)

### DIFF
--- a/.changeset/agent-after-model.md
+++ b/.changeset/agent-after-model.md
@@ -1,0 +1,13 @@
+---
+"@workkit/agent": minor
+---
+
+**Add `afterModel` hook for output-side guardrails with retry-and-reminder.** New optional `AgentHooks.afterModel(assistant, ctx)` fires after every assistant turn (text-only, tool-call, or mixed), receives the full assistant message, and may return `{ retry: true, reminder?: string }` to reject the turn and re-run the model. Tools from a rejected turn are **not** executed — the hook call site is between `step-complete` and the strict-tools pre-scan / tool dispatch, so any `tool_calls` on a rejected turn are discarded along with the assistant message.
+
+Retries consume from `stopWhen.maxSteps` (keeps budgets honest) and are additionally capped per-step by a new `maxAfterModelRetries` option (default `2`). When the per-step cap is hit the loop soft-fails: it proceeds with the last-returned assistant message rather than throwing. Throws from `afterModel` route through `onError({ kind: "hook", error })`; if `onError` returns `{ abort: false }` the throw is suppressed and the turn is treated as no-retry, otherwise the loop terminates with `stopReason: "error"`.
+
+New event variant `{ type: "after-model-retry", step, attempt, reminder? }` is emitted per retry so consumers can trace guardrail activity. The reminder (when present) is appended as a `{ role: "user", content: reminder }` message before the next model call; the rejected assistant message is popped from history so the model doesn't re-read its own bad output.
+
+New export: `AfterModelDecision` type. Purely additive — existing agents ignoring the hook see zero behavior change.
+
+Closes #58.

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -45,6 +45,7 @@ export function defineAgent(options: DefineAgentOptions): Agent {
 		stopWhen,
 		hooks: options.hooks ?? {},
 		strictTools: options.strictTools ?? false,
+		maxAfterModelRetries: options.maxAfterModelRetries ?? 2,
 	};
 
 	sharedRegistry.register(internal);

--- a/packages/agent/src/events.ts
+++ b/packages/agent/src/events.ts
@@ -9,6 +9,7 @@ export type AgentEvent =
 	| { type: "handoff"; from: string; to: string; step: number }
 	| { type: "step-complete"; step: number; usage: TokenUsage; assistant: Message }
 	| { type: "tool-rejected"; call: GatewayToolCall; reason: "off-palette"; step: number }
+	| { type: "after-model-retry"; step: number; attempt: number; reminder?: string }
 	| {
 			type: "error";
 			error: { kind: "tool" | "provider" | "hook" | "config"; toolName?: string; message: string };

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -23,6 +23,7 @@ export { toJsonSchema } from "./schema";
 
 // Public types
 export type {
+	AfterModelDecision,
 	Agent,
 	AgentEvent,
 	AgentHooks,

--- a/packages/agent/src/loop.ts
+++ b/packages/agent/src/loop.ts
@@ -207,7 +207,17 @@ export async function runLoop(args: RunLoopArgs): Promise<{
 			afterModelDecision = undefined;
 		}
 
-		if (afterModelDecision?.retry && afterModelRetryCount < currentAgent.maxAfterModelRetries) {
+		// Only honor the retry if another model call actually fits in the step
+		// budget. Otherwise popping the assistant message and bumping `step`
+		// would exit the loop at the top with `stopReason: "max_steps"` while
+		// `finalText` still points at the just-removed message — soft-fail is
+		// supposed to proceed with the last-returned message instead.
+		const retryFitsBudget = step + 1 < currentAgent.stopWhen.maxSteps;
+		if (
+			afterModelDecision?.retry &&
+			afterModelRetryCount < currentAgent.maxAfterModelRetries &&
+			retryFitsBudget
+		) {
 			// Reject the turn: pop the assistant message, optionally append a
 			// reminder as a user message, and re-run the model for this step.
 			// The retry consumes one slot from `stopWhen.maxSteps`.
@@ -225,8 +235,9 @@ export async function runLoop(args: RunLoopArgs): Promise<{
 			step += 1;
 			continue;
 		}
-		// Either the turn was accepted, the hook returned no decision, or the
-		// per-step retry cap was hit (soft-fail: proceed with the last message).
+		// Either the turn was accepted, the hook returned no decision, the
+		// per-step retry cap was hit, or the step budget can't fit another
+		// model call (soft-fail: proceed with the last message).
 		afterModelRetryCount = 0;
 
 		const toolCalls: GatewayToolCall[] = output.toolCalls ?? [];

--- a/packages/agent/src/loop.ts
+++ b/packages/agent/src/loop.ts
@@ -6,6 +6,7 @@ import { toJsonSchema } from "./schema";
 import { runStep } from "./stream-step";
 import { runTool } from "./tool";
 import type {
+	AfterModelDecision,
 	Agent,
 	AgentHooks,
 	Message,
@@ -25,6 +26,7 @@ export interface InternalAgentDef {
 	stopWhen: Required<StopWhen>;
 	hooks: AgentHooks;
 	strictTools: boolean;
+	maxAfterModelRetries: number;
 }
 
 const ZERO_USAGE: TokenUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
@@ -93,6 +95,9 @@ export async function runLoop(args: RunLoopArgs): Promise<{
 
 	let step = 0;
 	let finalText = "";
+	// Per-step tracking for `afterModel` retry-with-reminder. Resets whenever
+	// the step advances into tool dispatch (i.e. a model turn was accepted).
+	let afterModelRetryCount = 0;
 
 	while (true) {
 		if (ctx.signal?.aborted) {
@@ -177,6 +182,52 @@ export async function runLoop(args: RunLoopArgs): Promise<{
 		// (or a single synthesized one on the non-streaming path), so we don't
 		// re-emit here.
 		emit({ type: "step-complete", step, usage, assistant: assistantMessage });
+
+		// afterModel hook — fires after every assistant turn (text-only, tool-call,
+		// or mixed). Must run BEFORE the strictTools pre-scan and tool dispatch so
+		// that a rejected turn never executes side effects.
+		let afterModelDecision: AfterModelDecision | undefined;
+		try {
+			const raw = await currentAgent.hooks.afterModel?.(
+				assistantMessage as Extract<Message, { role: "assistant" }>,
+				{ ...ctx, agentPath, usage },
+			);
+			afterModelDecision = raw ?? undefined;
+		} catch (error) {
+			emit({ type: "error", error: { kind: "hook", message: errorMessage(error) } });
+			const decision = await currentAgent.hooks.onError?.(
+				{ kind: "hook", error },
+				{ ...ctx, agentPath, usage },
+			);
+			if (!decision || decision.abort !== false) {
+				emit({ type: "done", stopReason: "error", usage });
+				throw error;
+			}
+			// onError opted to suppress: treat as no-retry.
+			afterModelDecision = undefined;
+		}
+
+		if (afterModelDecision?.retry && afterModelRetryCount < currentAgent.maxAfterModelRetries) {
+			// Reject the turn: pop the assistant message, optionally append a
+			// reminder as a user message, and re-run the model for this step.
+			// The retry consumes one slot from `stopWhen.maxSteps`.
+			afterModelRetryCount += 1;
+			emit({
+				type: "after-model-retry",
+				step,
+				attempt: afterModelRetryCount,
+				reminder: afterModelDecision.reminder,
+			});
+			messages = messages.slice(0, -1);
+			if (afterModelDecision.reminder) {
+				messages = [...messages, { role: "user", content: afterModelDecision.reminder }];
+			}
+			step += 1;
+			continue;
+		}
+		// Either the turn was accepted, the hook returned no decision, or the
+		// per-step retry cap was hit (soft-fail: proceed with the last message).
+		afterModelRetryCount = 0;
 
 		const toolCalls: GatewayToolCall[] = output.toolCalls ?? [];
 		if (toolCalls.length === 0) {

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -30,8 +30,25 @@ export interface OnErrorDecision {
 	abort?: boolean;
 }
 
+export interface AfterModelDecision {
+	/** Reject the assistant message and re-run the model for this step. */
+	retry?: boolean;
+	/** Optional system-style reminder appended (as a `user` message) before the retry. */
+	reminder?: string;
+}
+
 export interface AgentHooks {
 	beforeModel?(ctx: RunContext): void | Promise<void>;
+	/**
+	 * Fires after every assistant turn — text-only, tool-call, or mixed.
+	 * Returning `{ retry: true }` rejects the assistant message and re-runs
+	 * the model for the step. Tools from a rejected turn do NOT execute.
+	 * See `DefineAgentOptions.maxAfterModelRetries` for the per-step cap.
+	 */
+	afterModel?(
+		assistant: Extract<Message, { role: "assistant" }>,
+		ctx: RunContext,
+	): undefined | AfterModelDecision | Promise<undefined | AfterModelDecision>;
 	afterTool?(call: GatewayToolCall, result: string, ctx: RunContext): void | Promise<void>;
 	onError?(
 		err: { kind: "tool" | "provider" | "hook"; toolName?: string; error: unknown },
@@ -77,6 +94,14 @@ export interface DefineAgentOptions {
 	 * loop continues).
 	 */
 	strictTools?: boolean;
+	/**
+	 * Per-step cap on how many times `afterModel` may request a retry before
+	 * the loop gives up and proceeds with the last-returned assistant message
+	 * (soft-fail). Prevents infinite loops when the model keeps ignoring the
+	 * reminder. Each retry also consumes one slot from `stopWhen.maxSteps`.
+	 * Default: `2`.
+	 */
+	maxAfterModelRetries?: number;
 }
 
 export interface RunArgs {

--- a/packages/agent/tests/after-model.test.ts
+++ b/packages/agent/tests/after-model.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { defineAgent } from "../src/agent";
+import { OffPaletteToolError } from "../src/errors";
+import type { AgentEvent } from "../src/events";
+import { tool } from "../src/tool";
+import type { AfterModelDecision, Message } from "../src/types";
+import { call, mockGateway } from "./_mocks";
+
+describe("afterModel hook", () => {
+	it("fires on a text-only turn — hook sees the produced assistant message", async () => {
+		const { gateway } = mockGateway([{ text: "hello" }]);
+		const seen: Array<Extract<Message, { role: "assistant" }>> = [];
+		const agent = defineAgent({
+			name: "am-text-1",
+			model: "m",
+			provider: gateway,
+			hooks: {
+				afterModel: (assistant) => {
+					seen.push(assistant);
+				},
+			},
+		});
+		const result = await agent.run({ messages: [{ role: "user", content: "hi" }] });
+		expect(result.text).toBe("hello");
+		expect(seen).toHaveLength(1);
+		expect(seen[0]?.role).toBe("assistant");
+		expect(seen[0]?.content).toBe("hello");
+		expect(seen[0]?.tool_calls).toBeUndefined();
+	});
+
+	it("fires on a tool-call turn — hook sees the assistant message with tool_calls", async () => {
+		const { gateway } = mockGateway([
+			{ toolCalls: [call("search", { q: "x" })] },
+			{ text: "done" },
+		]);
+		const search = tool({
+			name: "search",
+			description: "searches",
+			input: z.object({ q: z.string() }),
+			handler: async () => "ok",
+		});
+		const seen: Array<Extract<Message, { role: "assistant" }>> = [];
+		const agent = defineAgent({
+			name: "am-tool-1",
+			model: "m",
+			provider: gateway,
+			tools: [search],
+			hooks: {
+				afterModel: (assistant) => {
+					seen.push(assistant);
+				},
+			},
+		});
+		await agent.run({ messages: [{ role: "user", content: "go" }] });
+		// Fires once per assistant turn — two turns total (tool-call + final text).
+		expect(seen).toHaveLength(2);
+		expect(seen[0]?.tool_calls?.[0]?.name).toBe("search");
+		expect(seen[1]?.tool_calls).toBeUndefined();
+		expect(seen[1]?.content).toBe("done");
+	});
+
+	it("retry: true with no reminder re-runs the model for the step", async () => {
+		const { gateway, state } = mockGateway([{ text: "bad" }, { text: "good" }]);
+		let attempts = 0;
+		const agent = defineAgent({
+			name: "am-retry-1",
+			model: "m",
+			provider: gateway,
+			hooks: {
+				afterModel: (): AfterModelDecision | undefined => {
+					attempts += 1;
+					if (attempts === 1) return { retry: true };
+					return undefined;
+				},
+			},
+		});
+		const result = await agent.run({ messages: [{ role: "user", content: "hi" }] });
+		expect(result.text).toBe("good");
+		expect(state.calls).toHaveLength(2);
+	});
+
+	it("retry: true with reminder threads the reminder to the next model call", async () => {
+		const { gateway, state } = mockGateway([{ text: "bad" }, { text: "good" }]);
+		let attempts = 0;
+		const REMINDER = "keep JSON strict";
+		const agent = defineAgent({
+			name: "am-retry-reminder-1",
+			model: "m",
+			provider: gateway,
+			hooks: {
+				afterModel: (): AfterModelDecision | undefined => {
+					attempts += 1;
+					if (attempts === 1) return { retry: true, reminder: REMINDER };
+					return undefined;
+				},
+			},
+		});
+		const result = await agent.run({ messages: [{ role: "user", content: "hi" }] });
+		expect(result.text).toBe("good");
+		expect(state.calls).toHaveLength(2);
+		// The retry call should include the reminder as a message before the model is re-invoked.
+		const retryInput = state.calls[1]?.input as { messages: { role: string; content: string }[] };
+		const hasReminder = retryInput.messages.some((m) => m.content.includes(REMINDER));
+		expect(hasReminder).toBe(true);
+		// The original user message is still there; the rejected assistant is not.
+		expect(retryInput.messages.some((m) => m.role === "user" && m.content === "hi")).toBe(true);
+		expect(retryInput.messages.every((m) => m.content !== "bad")).toBe(true);
+	});
+
+	it("tools from a rejected turn do NOT execute", async () => {
+		const { gateway } = mockGateway([
+			{ toolCalls: [call("search", { q: "x" })] },
+			{ text: "done" },
+		]);
+		let searchCalls = 0;
+		const search = tool({
+			name: "search",
+			description: "searches",
+			input: z.object({ q: z.string() }),
+			handler: async () => {
+				searchCalls += 1;
+				return "ran";
+			},
+		});
+		let attempts = 0;
+		const agent = defineAgent({
+			name: "am-no-tools-1",
+			model: "m",
+			provider: gateway,
+			tools: [search],
+			hooks: {
+				afterModel: (): AfterModelDecision | undefined => {
+					attempts += 1;
+					if (attempts === 1) return { retry: true };
+					return undefined;
+				},
+			},
+		});
+		await agent.run({ messages: [{ role: "user", content: "go" }] });
+		expect(searchCalls).toBe(0);
+	});
+
+	it("maxAfterModelRetries caps the retry loop — soft-fail proceeds with last message", async () => {
+		const { gateway } = mockGateway([{ text: "a" }, { text: "b" }, { text: "c" }, { text: "d" }]);
+		const agent = defineAgent({
+			name: "am-cap-1",
+			model: "m",
+			provider: gateway,
+			maxAfterModelRetries: 2,
+			hooks: {
+				afterModel: () => ({ retry: true }),
+			},
+		});
+		const events: AgentEvent[] = [];
+		const result = await (async () => {
+			const collected: AgentEvent[] = [];
+			for await (const e of agent.stream({ messages: [{ role: "user", content: "go" }] })) {
+				collected.push(e);
+			}
+			events.push(...collected);
+			return collected;
+		})();
+		const retries = result.filter((e) => e.type === "after-model-retry");
+		expect(retries).toHaveLength(2);
+		// Soft-fail: loop proceeds with the third returned assistant message and stops normally.
+		const done = events.find((e) => e.type === "done");
+		expect(done).toBeDefined();
+		expect(done && (done as { stopReason: string }).stopReason).toBe("stop");
+	});
+
+	it("retries consume from stopWhen.maxSteps", async () => {
+		const { gateway } = mockGateway([{ text: "a" }, { text: "b" }]);
+		let attempts = 0;
+		const agent = defineAgent({
+			name: "am-maxsteps-1",
+			model: "m",
+			provider: gateway,
+			stopWhen: { maxSteps: 2 },
+			hooks: {
+				afterModel: (): AfterModelDecision | undefined => {
+					attempts += 1;
+					if (attempts === 1) return { retry: true };
+					return undefined;
+				},
+			},
+		});
+		const result = await agent.run({ messages: [{ role: "user", content: "go" }] });
+		// One retry consumed one of the two maxSteps budget slots; the second model
+		// call produced "b" and the loop exits normally on a text-only step.
+		expect(result.stopReason).toBe("stop");
+		expect(result.text).toBe("b");
+	});
+
+	it("throw from afterModel routes through onError with kind:'hook'; abort terminates", async () => {
+		const { gateway } = mockGateway([{ text: "hello" }]);
+		let onErrorKind: string | undefined;
+		const agent = defineAgent({
+			name: "am-throw-1",
+			model: "m",
+			provider: gateway,
+			hooks: {
+				afterModel: () => {
+					throw new Error("hook-boom");
+				},
+				onError: (err) => {
+					onErrorKind = err.kind;
+					return { abort: true };
+				},
+			},
+		});
+		const events: AgentEvent[] = [];
+		await expect(async () => {
+			for await (const e of agent.stream({ messages: [{ role: "user", content: "go" }] })) {
+				events.push(e);
+			}
+		}).rejects.toThrow("hook-boom");
+		expect(onErrorKind).toBe("hook");
+		const done = events.find((e) => e.type === "done");
+		expect(done && (done as { stopReason: string }).stopReason).toBe("error");
+	});
+
+	it("returning undefined or void is treated as no retry (no behavior change)", async () => {
+		const { gateway, state } = mockGateway([{ text: "only" }]);
+		const agent = defineAgent({
+			name: "am-void-1",
+			model: "m",
+			provider: gateway,
+			hooks: {
+				afterModel: () => {
+					/* void */
+				},
+			},
+		});
+		const result = await agent.run({ messages: [{ role: "user", content: "hi" }] });
+		expect(result.text).toBe("only");
+		expect(state.calls).toHaveLength(1);
+	});
+
+	it("emits after-model-retry events with step, attempt, and reminder fields", async () => {
+		const { gateway } = mockGateway([{ text: "a" }, { text: "b" }]);
+		let attempts = 0;
+		const agent = defineAgent({
+			name: "am-event-1",
+			model: "m",
+			provider: gateway,
+			hooks: {
+				afterModel: (): AfterModelDecision | undefined => {
+					attempts += 1;
+					if (attempts === 1) return { retry: true, reminder: "try again" };
+					return undefined;
+				},
+			},
+		});
+		const events: AgentEvent[] = [];
+		for await (const e of agent.stream({ messages: [{ role: "user", content: "go" }] })) {
+			events.push(e);
+		}
+		const retry = events.find((e) => e.type === "after-model-retry");
+		expect(retry).toBeDefined();
+		if (retry && retry.type === "after-model-retry") {
+			expect(retry.attempt).toBe(1);
+			expect(retry.reminder).toBe("try again");
+			expect(typeof retry.step).toBe("number");
+		}
+	});
+
+	it("strictTools + afterModel returning no-retry still throws OffPaletteToolError", async () => {
+		const { gateway } = mockGateway([{ toolCalls: [call("not-in-palette")] }]);
+		const known = tool({
+			name: "search",
+			description: "searches",
+			input: z.object({}),
+			handler: async () => "ok",
+		});
+		const agent = defineAgent({
+			name: "am-strict-1",
+			model: "m",
+			provider: gateway,
+			tools: [known],
+			strictTools: true,
+			hooks: {
+				afterModel: () => undefined,
+			},
+		});
+		await expect(agent.run({ messages: [{ role: "user", content: "go" }] })).rejects.toBeInstanceOf(
+			OffPaletteToolError,
+		);
+	});
+});

--- a/packages/agent/tests/after-model.test.ts
+++ b/packages/agent/tests/after-model.test.ts
@@ -169,6 +169,36 @@ describe("afterModel hook", () => {
 		expect(done && (done as { stopReason: string }).stopReason).toBe("stop");
 	});
 
+	it("skips a retry when stopWhen.maxSteps would be exhausted (soft-fail on last message)", async () => {
+		// Regression guard: the retry path pops the assistant message and bumps
+		// `step`. If that push exits the loop at maxSteps, `finalText` would
+		// still reference the removed message and stopReason would be
+		// "max_steps" — both contradicting soft-fail semantics. The budget
+		// guard inside the retry branch avoids this: a retry request at the
+		// step boundary is ignored and the current turn is accepted.
+		const { gateway } = mockGateway([{ text: "only-turn" }]);
+		let hookCalls = 0;
+		const agent = defineAgent({
+			name: "am-budget-guard",
+			model: "m",
+			provider: gateway,
+			stopWhen: { maxSteps: 1 },
+			hooks: {
+				afterModel: (): AfterModelDecision => {
+					hookCalls += 1;
+					return { retry: true };
+				},
+			},
+		});
+		const result = await agent.run({ messages: [{ role: "user", content: "go" }] });
+		expect(hookCalls).toBe(1);
+		expect(result.stopReason).toBe("stop");
+		expect(result.text).toBe("only-turn");
+		// The assistant message is retained in history — no pop happened.
+		expect(result.messages.at(-1)?.role).toBe("assistant");
+		expect((result.messages.at(-1) as { content: string }).content).toBe("only-turn");
+	});
+
 	it("retries consume from stopWhen.maxSteps", async () => {
 		const { gateway } = mockGateway([{ text: "a" }, { text: "b" }]);
 		let attempts = 0;


### PR DESCRIPTION
Closes #58.

### Problem

`AgentHooks` exposes `beforeModel`, `afterTool`, and `onError` but no `afterModel` — consumers can observe inputs, tool execution, and errors, but cannot inspect or act on the **model's own output** before the loop commits to it. Output-side guardrails (policy filters, structured-output retries, domain invariants, toxicity passes) today require forking the loop or running guardrails outside the agent (losing retry-with-reminder semantics and allowing tool-call side effects on rejected turns).

### Solution

Add optional `AgentHooks.afterModel(assistant, ctx)` + `AfterModelDecision` return type + `maxAfterModelRetries` option. Purely additive — existing agents see zero behavior change.

```ts
hooks: {
  afterModel(assistant, ctx) {
    if (!isValidJson(assistant.content)) {
      return { retry: true, reminder: "respond with JSON only" };
    }
  }
}
```

### Semantics (from #58 non-negotiables)

| Contract | Behavior |
|---|---|
| When does it fire? | After every assistant turn — text-only, tool-call, or mixed. Consumers filter. |
| Retry counting | Retries consume from `stopWhen.maxSteps` AND from per-step `maxAfterModelRetries` (default `2`). |
| Budget exhaustion | Soft-fail — proceed with last-returned assistant message. Not a throw. |
| Reminder injection | Appended as `{ role: "user", content: reminder }` before the next model call. The rejected assistant message is **popped from history** so the model doesn't re-read its own bad output. |
| Tools on rejected turn | Do NOT execute. Hook call site is between `step-complete` and the strict-tools pre-scan / tool dispatch. |
| Hook throw | Routes through `onError({ kind: "hook", error })`. `{ abort: false }` suppresses and treats as no-retry; any other outcome terminates with `stopReason: "error"`. |

### Changes

| File | Change |
|---|---|
| `packages/agent/src/types.ts` | Add `AfterModelDecision` type; add `afterModel?` to `AgentHooks`; add `maxAfterModelRetries?` to `DefineAgentOptions`. |
| `packages/agent/src/agent.ts` | Default `maxAfterModelRetries` to `2`; propagate into `InternalAgentDef`. |
| `packages/agent/src/loop.ts` | New hook call site between `step-complete` emit and tool-dispatch; retry loop honoring per-step cap and overall `maxSteps`; throw path routes to `onError` with `kind: "hook"`. |
| `packages/agent/src/events.ts` | New `{ type: "after-model-retry", step, attempt, reminder? }` event variant. |
| `packages/agent/src/index.ts` | Re-export `AfterModelDecision`. |
| `.changeset/agent-after-model.md` | `@workkit/agent` minor bump. |

### Test plan

- [x] `bunx vitest run` (agent) — 49/49 pass, including 11 new tests in `tests/after-model.test.ts`:
  - fires on text-only turn
  - fires on tool-call turn (hook sees `tool_calls` populated)
  - `retry: true` (no reminder) re-runs the model for the step
  - `retry: true, reminder` threads the reminder as a `user` message on the retry call; rejected assistant message is NOT in history
  - rejected tool-call turn does NOT execute the tool (counter stays 0)
  - `maxAfterModelRetries: 2` caps the loop — after 2 retries, soft-fails and proceeds; emits exactly 2 `after-model-retry` events
  - retries consume from `stopWhen.maxSteps`
  - throw from `afterModel` routes through `onError` with `kind: "hook"`; `{ abort: true }` terminates with `stopReason: "error"`
  - returning `undefined` / `void` is treated as no-retry
  - `after-model-retry` event carries `step`, `attempt`, `reminder`
  - `strictTools: true` + off-palette call + `afterModel` returning no-retry still throws `OffPaletteToolError` (interop with #79/#88)
- [x] `bunx biome check packages/agent/` — 0 errors.
- [x] `bunx turbo typecheck --filter @workkit/agent` — clean.
- [x] `bun run constitution:check -- --diff-only` — 0 errors.

### Design deviations worth flagging for review

1. **Reminder role**: `{ role: "user", content: reminder }` (simpler, matches the ticket's "choose the simpler one"). No existing convention for system reminders in the loop — system is only used for `instructions`.
2. **Soft-fail vs throw** on `maxAfterModelRetries` exhaustion: **soft-fail** (proceed with last message, emit a normal `done`). Matches the ticket body which explicitly says "don't kill the run" on cap-exhaustion.
3. **`onError` `kind` value**: `"hook"` — matches the existing `afterTool`-throw path and `beforeModel`-throw path, which both emit `{ kind: "hook" }`.
4. **Void return in public type**: biome's `noConfusingVoidType` flagged the literal spec signature `void | AfterModelDecision | Promise<void | AfterModelDecision>`. Changed to `undefined | AfterModelDecision | Promise<undefined | AfterModelDecision>` (matches `onError`'s existing shape). Empty-body arrows like `afterModel: () => {}` still work via TS's void-widening for callable-to-optional-property assignment.

### Out of scope

- Built-in guardrail library (regex/JSON-schema helpers) — the hook is the primitive; helpers can land in userland or a separate package.
- Streaming `afterModel` (partial text, cancel-and-retry mid-stream) — design is materially harder; follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)