### PR TITLE
fix(ai-gateway): workers-ai Llama models actually execute tool calls (#94)

### DIFF
--- a/.changeset/ai-gateway-workers-ai-llama-tools.md
+++ b/.changeset/ai-gateway-workers-ai-llama-tools.md
@@ -1,0 +1,15 @@
+---
+"@workkit/ai-gateway": patch
+---
+
+**Fix: Workers AI Llama models actually execute tool calls.** Closes #94.
+
+The `workers-ai` provider already injected `tools` into the payload, but `extractWorkersAiToolCalls` only understood the OpenAI-compat shape (`{id, type: "function", function: {name, arguments: string}}`). `@cf/meta/llama-*` returns tool calls in a **flat shape** (`{name, arguments: object}` — no `function` wrapper, no `id`), which the parser silently dropped. Net effect: callers wiring tools on Llama models saw `toolCalls: []` and a polite "I'm not able to call any tools" text reply.
+
+This patch normalizes Llama's flat shape into the OpenAI-compat envelope before parsing, so both shapes flow through the same `parseRawToolCalls` path and consumers get populated `AiOutput.toolCalls` regardless of which provider responded.
+
+Also fixes the streaming counterpart: `streamWorkersAi` was ignoring `options` entirely, so tool schemas were never injected on streams and any streamed `tool_calls` were dropped. It now threads `toolOptions` through and emits `tool_use` events for each Llama tool call (deduped by id in case the provider re-emits across SSE frames).
+
+**Behavior change note:** calls that previously silently no-opped on `tools` against a Llama model will now actually invoke tools. Low risk — this is the documented, typed behavior.
+
+Pairs well with `@workkit/agent`'s `strictTools: true` (shipped in a prior release) — Llama hallucinates tool names more than Claude does, and strict mode turns a potential runaway step-budget into a fail-fast `OffPaletteToolError`.

--- a/packages/ai-gateway/src/providers/workers-ai.ts
+++ b/packages/ai-gateway/src/providers/workers-ai.ts
@@ -77,5 +77,25 @@ function extractWorkersAiToolCalls(raw: unknown): GatewayToolCall[] | undefined 
 	const obj = raw as Record<string, unknown>;
 	const rawCalls = obj.tool_calls as Array<Record<string, unknown>> | undefined;
 	if (!Array.isArray(rawCalls) || rawCalls.length === 0) return undefined;
-	return parseRawToolCalls(rawCalls);
+	// Workers AI's `@cf/meta/llama-*` endpoint returns tool_calls in a flat
+	// shape — `{name, arguments}` at the top level, no `function` nesting,
+	// no `id`. Normalize to the OpenAI-compat wrapper so `parseRawToolCalls`
+	// handles both paths (id fallback + string/object arg normalization)
+	// without growing provider-specific branches.
+	const normalized = rawCalls.map(normalizeWorkersAiToolCall);
+	return parseRawToolCalls(normalized);
+}
+
+function normalizeWorkersAiToolCall(raw: Record<string, unknown>): Record<string, unknown> {
+	// Already OpenAI-compat (`{id, type, function: {...}}`) — pass through.
+	if (raw.function && typeof raw.function === "object") return raw;
+	// Llama-native flat shape — wrap `{name, arguments}` into the expected envelope.
+	if (typeof raw.name === "string") {
+		return {
+			id: typeof raw.id === "string" ? raw.id : undefined,
+			type: "function",
+			function: { name: raw.name, arguments: raw.arguments },
+		};
+	}
+	return raw;
 }

--- a/packages/ai-gateway/src/providers/workers-ai.ts
+++ b/packages/ai-gateway/src/providers/workers-ai.ts
@@ -80,22 +80,37 @@ function extractWorkersAiToolCalls(raw: unknown): GatewayToolCall[] | undefined 
 	// Workers AI's `@cf/meta/llama-*` endpoint returns tool_calls in a flat
 	// shape — `{name, arguments}` at the top level, no `function` nesting,
 	// no `id`. Normalize to the OpenAI-compat wrapper so `parseRawToolCalls`
-	// handles both paths (id fallback + string/object arg normalization)
-	// without growing provider-specific branches.
-	const normalized = rawCalls.map(normalizeWorkersAiToolCall);
+	// handles both paths (string/object arg normalization) without growing
+	// provider-specific branches.
+	const normalized = rawCalls.map((raw, idx) => normalizeWorkersAiToolCall(raw, idx));
 	return parseRawToolCalls(normalized);
 }
 
-function normalizeWorkersAiToolCall(raw: Record<string, unknown>): Record<string, unknown> {
+/**
+ * Fallback-id prefix for Llama tool_calls that arrive without a provider id.
+ * Kept deliberately distinct from OpenAI's `call_*` id namespace so a
+ * response mixing id'd and un-id'd calls cannot produce duplicate ids
+ * downstream (e.g. if the model emits `{id: "call_0"}` alongside a
+ * later un-id'd entry — `parseRawToolCalls`'s generic `call_${i}` fallback
+ * would collide).
+ */
+const WORKERS_AI_ANON_ID_PREFIX = "wkai_anon_";
+
+function normalizeWorkersAiToolCall(
+	raw: Record<string, unknown>,
+	index: number,
+): Record<string, unknown> {
 	// Already OpenAI-compat (`{id, type, function: {...}}`) — pass through.
 	if (raw.function && typeof raw.function === "object") return raw;
 	// Llama-native flat shape — wrap `{name, arguments}` into the expected envelope.
 	if (typeof raw.name === "string") {
 		return {
-			id: typeof raw.id === "string" ? raw.id : undefined,
+			id: typeof raw.id === "string" ? raw.id : `${WORKERS_AI_ANON_ID_PREFIX}${index}`,
 			type: "function",
 			function: { name: raw.name, arguments: raw.arguments },
 		};
 	}
 	return raw;
 }
+
+export { WORKERS_AI_ANON_ID_PREFIX };

--- a/packages/ai-gateway/src/stream.ts
+++ b/packages/ai-gateway/src/stream.ts
@@ -1,6 +1,7 @@
 import { ServiceUnavailableError } from "@workkit/errors";
 import { buildAnthropicBody } from "./providers/anthropic";
 import { buildOpenAiBody } from "./providers/openai";
+import { applyToolsWorkersAi } from "./providers/workers-ai";
 import type {
 	AiInput,
 	AnthropicProviderConfig,
@@ -68,10 +69,13 @@ async function streamWorkersAi(
 	providerConfig: WorkersAiProviderConfig,
 	model: string,
 	input: AiInput,
-	_options: RunOptions | undefined,
+	options: RunOptions | undefined,
 ): Promise<ReadableStream<GatewayStreamEvent>> {
+	// Thread toolOptions into the payload so Llama sees the tool list on the
+	// streaming path too. Non-streaming already does this in executeWorkersAi.
+	const withTools = applyToolsWorkersAi(input, options?.toolOptions);
 	const raw = (await providerConfig.binding.run(model, {
-		...(input as Record<string, unknown>),
+		...withTools,
 		stream: true,
 	})) as unknown;
 
@@ -82,12 +86,50 @@ async function streamWorkersAi(
 	}
 
 	// Workers AI stream has no underlying fetch to abort on cancel.
+	const emittedProviderIds = new Set<string>();
+	let fallbackIdCounter = 0;
 	return transformSse(raw, noop, (event, emit) => {
 		if (event.data === "[DONE]") return;
 		const obj = tryParseJson(event.data);
 		const delta = typeof obj?.response === "string" ? obj.response : undefined;
 		if (delta) emit({ type: "text", delta });
+
+		// Llama on Workers AI streams emits tool_calls as fully-formed objects
+		// (not delta-fragmented like OpenAI). Dedupe only when the provider
+		// supplied an id — otherwise two legitimately distinct un-id'd calls
+		// (same name, different arguments) would be silently collapsed.
+		// `fallbackIdCounter` is stream-scoped so IDs stay unique across frames.
+		const rawCalls = obj?.tool_calls as Array<Record<string, unknown>> | undefined;
+		if (!Array.isArray(rawCalls) || rawCalls.length === 0) return;
+		for (const rc of rawCalls) {
+			const name = typeof rc.name === "string" ? rc.name : undefined;
+			if (!name) continue;
+			let id: string;
+			if (typeof rc.id === "string") {
+				if (emittedProviderIds.has(rc.id)) continue;
+				emittedProviderIds.add(rc.id);
+				id = rc.id;
+			} else {
+				id = `call_${fallbackIdCounter++}`;
+			}
+			const args =
+				rc.arguments && typeof rc.arguments === "object"
+					? (rc.arguments as Record<string, unknown>)
+					: typeof rc.arguments === "string"
+						? safeJsonParse(rc.arguments)
+						: {};
+			emit({ type: "tool_use", id, name, input: args });
+		}
 	});
+}
+
+function safeJsonParse(s: string): Record<string, unknown> {
+	try {
+		const parsed = JSON.parse(s);
+		return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {};
+	} catch {
+		return {};
+	}
 }
 
 function extractWorkersAiText(raw: unknown): string {

--- a/packages/ai-gateway/src/stream.ts
+++ b/packages/ai-gateway/src/stream.ts
@@ -1,7 +1,11 @@
 import { ServiceUnavailableError } from "@workkit/errors";
 import { buildAnthropicBody } from "./providers/anthropic";
 import { buildOpenAiBody } from "./providers/openai";
-import { applyToolsWorkersAi } from "./providers/workers-ai";
+import {
+	WORKERS_AI_ANON_ID_PREFIX,
+	applyToolsWorkersAi,
+	applyWorkersAiResponseFormat,
+} from "./providers/workers-ai";
 import type {
 	AiInput,
 	AnthropicProviderConfig,
@@ -71,9 +75,12 @@ async function streamWorkersAi(
 	input: AiInput,
 	options: RunOptions | undefined,
 ): Promise<ReadableStream<GatewayStreamEvent>> {
-	// Thread toolOptions into the payload so Llama sees the tool list on the
-	// streaming path too. Non-streaming already does this in executeWorkersAi.
-	const withTools = applyToolsWorkersAi(input, options?.toolOptions);
+	// Thread both response-format and tool options into the payload so the
+	// streaming path stays in sync with the non-streaming RunOptions contract
+	// (`executeWorkersAi` applies both). Ordering matches the non-streaming
+	// path: response format first, then tools.
+	const withFormat = applyWorkersAiResponseFormat(input, options?.responseFormat);
+	const withTools = applyToolsWorkersAi(withFormat, options?.toolOptions);
 	const raw = (await providerConfig.binding.run(model, {
 		...withTools,
 		stream: true,
@@ -110,7 +117,9 @@ async function streamWorkersAi(
 				emittedProviderIds.add(rc.id);
 				id = rc.id;
 			} else {
-				id = `call_${fallbackIdCounter++}`;
+				// Distinct namespace from OpenAI's `call_*` ids so a frame mixing
+				// provider-supplied `call_0` and un-id'd calls can't collide.
+				id = `${WORKERS_AI_ANON_ID_PREFIX}${fallbackIdCounter++}`;
 			}
 			const args =
 				rc.arguments && typeof rc.arguments === "object"

--- a/packages/ai-gateway/tests/stream.test.ts
+++ b/packages/ai-gateway/tests/stream.test.ts
@@ -69,6 +69,134 @@ describe("gateway.stream() — Workers AI", () => {
 		expect(run).toHaveBeenCalledTimes(1);
 		expect(run.mock.calls[0][1]).toMatchObject({ prompt: "hi", stream: true });
 	});
+
+	it("injects toolOptions into the binding payload on streaming calls", async () => {
+		const run = vi.fn().mockResolvedValue(sseStream(["data: [DONE]\n\n"]));
+		const gw = createGateway({
+			providers: { ai: { type: "workers-ai", binding: { run } } },
+			defaultProvider: "ai",
+		});
+
+		await collect(
+			await gw.stream!(
+				"@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+				{ messages: [{ role: "user", content: "VIX?" }] },
+				{
+					toolOptions: {
+						tools: [
+							{
+								name: "get_macro_indicators",
+								description: "Get macro indicators",
+								parameters: { type: "object", properties: {} },
+							},
+						],
+						toolChoice: "auto",
+					},
+				},
+			),
+		);
+
+		const called = run.mock.calls[0][1];
+		expect(called.stream).toBe(true);
+		expect(called.tools).toEqual([
+			{
+				type: "function",
+				function: {
+					name: "get_macro_indicators",
+					description: "Get macro indicators",
+					parameters: { type: "object", properties: {} },
+				},
+			},
+		]);
+		expect(called.tool_choice).toBe("auto");
+	});
+
+	it("emits tool_use events for Llama's flat tool_calls on the stream", async () => {
+		const toolCall = JSON.stringify({
+			response: "",
+			tool_calls: [{ name: "get_macro_indicators", arguments: { indicator: "VIX" } }],
+		});
+		const bindingStream = sseStream([`data: ${toolCall}\n\n`, "data: [DONE]\n\n"]);
+		const run = vi.fn().mockResolvedValue(bindingStream);
+
+		const gw = createGateway({
+			providers: { ai: { type: "workers-ai", binding: { run } } },
+			defaultProvider: "ai",
+		});
+
+		const events = await collect(
+			await gw.stream!("@cf/meta/llama-3.3-70b-instruct-fp8-fast", {
+				messages: [{ role: "user", content: "q" }],
+			}),
+		);
+
+		const toolEvents = events.filter((e) => e.type === "tool_use") as Array<
+			Extract<GatewayStreamEvent, { type: "tool_use" }>
+		>;
+		expect(toolEvents).toHaveLength(1);
+		expect(toolEvents[0].name).toBe("get_macro_indicators");
+		expect(toolEvents[0].input).toEqual({ indicator: "VIX" });
+		expect(typeof toolEvents[0].id).toBe("string");
+	});
+
+	it("dedupes tool_calls with the same id across repeated SSE frames", async () => {
+		const body = JSON.stringify({
+			response: "",
+			tool_calls: [{ id: "call_X", name: "f", arguments: { a: 1 } }],
+		});
+		const bindingStream = sseStream([`data: ${body}\n\n`, `data: ${body}\n\n`, "data: [DONE]\n\n"]);
+		const run = vi.fn().mockResolvedValue(bindingStream);
+
+		const gw = createGateway({
+			providers: { ai: { type: "workers-ai", binding: { run } } },
+			defaultProvider: "ai",
+		});
+
+		const events = await collect(
+			await gw.stream!("@cf/meta/llama-3.3-70b-instruct-fp8-fast", { prompt: "q" }),
+		);
+
+		const toolEvents = events.filter((e) => e.type === "tool_use");
+		expect(toolEvents).toHaveLength(1);
+	});
+
+	it("does NOT dedupe un-id'd tool_calls across frames (each fires with a unique fallback id)", async () => {
+		// Regression guard: Llama often omits `id`. Two legitimately distinct
+		// un-id'd calls (same name, different arguments) across frames must both
+		// fire. Dedupe must only apply when the provider supplied an id.
+		const frame1 = JSON.stringify({
+			response: "",
+			tool_calls: [{ name: "lookup", arguments: { q: "VIX" } }],
+		});
+		const frame2 = JSON.stringify({
+			response: "",
+			tool_calls: [{ name: "lookup", arguments: { q: "DXY" } }],
+		});
+		const bindingStream = sseStream([
+			`data: ${frame1}\n\n`,
+			`data: ${frame2}\n\n`,
+			"data: [DONE]\n\n",
+		]);
+		const run = vi.fn().mockResolvedValue(bindingStream);
+
+		const gw = createGateway({
+			providers: { ai: { type: "workers-ai", binding: { run } } },
+			defaultProvider: "ai",
+		});
+
+		const events = await collect(
+			await gw.stream!("@cf/meta/llama-3.3-70b-instruct-fp8-fast", { prompt: "q" }),
+		);
+
+		const toolEvents = events.filter((e) => e.type === "tool_use") as Array<
+			Extract<GatewayStreamEvent, { type: "tool_use" }>
+		>;
+		expect(toolEvents).toHaveLength(2);
+		expect(toolEvents[0].input).toEqual({ q: "VIX" });
+		expect(toolEvents[1].input).toEqual({ q: "DXY" });
+		// Fallback ids are distinct so downstream tool-call threading doesn't collide.
+		expect(toolEvents[0].id).not.toBe(toolEvents[1].id);
+	});
 });
 
 describe("gateway.stream() — Anthropic", () => {

--- a/packages/ai-gateway/tests/stream.test.ts
+++ b/packages/ai-gateway/tests/stream.test.ts
@@ -160,6 +160,52 @@ describe("gateway.stream() — Workers AI", () => {
 		expect(toolEvents).toHaveLength(1);
 	});
 
+	it("applies responseFormat to the streaming payload (parity with non-streaming executeWorkersAi)", async () => {
+		const run = vi.fn().mockResolvedValue(sseStream(["data: [DONE]\n\n"]));
+		const gw = createGateway({
+			providers: { ai: { type: "workers-ai", binding: { run } } },
+			defaultProvider: "ai",
+		});
+
+		await collect(await gw.stream!("@cf/m", { prompt: "hi" }, { responseFormat: "json" }));
+
+		expect(run.mock.calls[0][1]).toMatchObject({
+			stream: true,
+			response_format: { type: "json_object" },
+		});
+	});
+
+	it("fallback ids in the stream use a distinct namespace from OpenAI-style 'call_*'", async () => {
+		// Regression guard for review feedback on #94: the streaming fallback
+		// counter was `call_${n}`, which could collide with a provider-supplied
+		// `call_0` from a sibling frame. Distinct prefix avoids collision.
+		const frame = JSON.stringify({
+			response: "",
+			tool_calls: [
+				{ id: "call_0", name: "lookup", arguments: { q: "VIX" } },
+				{ name: "lookup", arguments: { q: "DXY" } },
+			],
+		});
+		const bindingStream = sseStream([`data: ${frame}\n\n`, "data: [DONE]\n\n"]);
+		const run = vi.fn().mockResolvedValue(bindingStream);
+
+		const gw = createGateway({
+			providers: { ai: { type: "workers-ai", binding: { run } } },
+			defaultProvider: "ai",
+		});
+
+		const events = await collect(
+			await gw.stream!("@cf/meta/llama-3.3-70b-instruct-fp8-fast", { prompt: "q" }),
+		);
+		const toolEvents = events.filter((e) => e.type === "tool_use") as Array<
+			Extract<GatewayStreamEvent, { type: "tool_use" }>
+		>;
+		expect(toolEvents).toHaveLength(2);
+		expect(toolEvents[0].id).toBe("call_0");
+		expect(toolEvents[1].id).not.toBe("call_0");
+		expect(toolEvents[1].id.startsWith("call_")).toBe(false);
+	});
+
 	it("does NOT dedupe un-id'd tool_calls across frames (each fires with a unique fallback id)", async () => {
 		// Regression guard: Llama often omits `id`. Two legitimately distinct
 		// un-id'd calls (same name, different arguments) across frames must both

--- a/packages/ai-gateway/tests/tool-use.test.ts
+++ b/packages/ai-gateway/tests/tool-use.test.ts
@@ -100,6 +100,78 @@ describe("gateway tool use — Workers AI", () => {
 
 		expect(result.toolCalls).toBeUndefined();
 	});
+
+	it("parses Llama's flat tool_call shape {name, arguments} without a function wrapper", async () => {
+		// Workers AI's @cf/meta/llama-3.3 endpoint returns tool_calls with a
+		// flat shape — no `id`, no `function` nesting, `arguments` already an
+		// object. The pre-existing OpenAI-compat parser dropped these silently.
+		const mockAi = {
+			run: vi.fn().mockResolvedValue({
+				response: "",
+				tool_calls: [{ name: "get_macro_indicators", arguments: { indicator: "VIX" } }],
+			}),
+		};
+		const gw = createGateway({
+			providers: { ai: { type: "workers-ai", binding: mockAi } },
+			defaultProvider: "ai",
+		});
+
+		const result = await gw.run(
+			"@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+			{ messages: [{ role: "user", content: "What is the current VIX?" }] } as AiInput,
+			{ toolOptions: sampleTools },
+		);
+
+		expect(result.toolCalls).toHaveLength(1);
+		expect(result.toolCalls![0].name).toBe("get_macro_indicators");
+		expect(result.toolCalls![0].arguments).toEqual({ indicator: "VIX" });
+		// No id from the model — a stable fallback keeps tool_call_id threading working.
+		expect(typeof result.toolCalls![0].id).toBe("string");
+		expect(result.toolCalls![0].id.length).toBeGreaterThan(0);
+	});
+
+	it("generates distinct fallback ids when Llama returns multiple tool_calls without ids", async () => {
+		const mockAi = {
+			run: vi.fn().mockResolvedValue({
+				response: "",
+				tool_calls: [
+					{ name: "get_macro_indicators", arguments: { indicator: "VIX" } },
+					{ name: "get_macro_indicators", arguments: { indicator: "DXY" } },
+				],
+			}),
+		};
+		const gw = createGateway({
+			providers: { ai: { type: "workers-ai", binding: mockAi } },
+			defaultProvider: "ai",
+		});
+
+		const result = await gw.run("@cf/meta/llama-3.3-70b-instruct-fp8-fast", {
+			messages: [{ role: "user", content: "list VIX and DXY" }],
+		} as AiInput);
+
+		expect(result.toolCalls).toHaveLength(2);
+		expect(result.toolCalls![0].id).not.toBe(result.toolCalls![1].id);
+	});
+
+	it("keeps both response text and tool_calls when Llama returns both", async () => {
+		const mockAi = {
+			run: vi.fn().mockResolvedValue({
+				response: "Looking up VIX now.",
+				tool_calls: [{ name: "get_macro_indicators", arguments: { indicator: "VIX" } }],
+			}),
+		};
+		const gw = createGateway({
+			providers: { ai: { type: "workers-ai", binding: mockAi } },
+			defaultProvider: "ai",
+		});
+
+		const result = await gw.run("llama", {
+			messages: [{ role: "user", content: "q" }],
+		} as AiInput);
+
+		expect(result.text).toBe("Looking up VIX now.");
+		expect(result.toolCalls).toHaveLength(1);
+	});
 });
 
 describe("gateway tool use — OpenAI format", () => {

--- a/packages/ai-gateway/tests/tool-use.test.ts
+++ b/packages/ai-gateway/tests/tool-use.test.ts
@@ -130,6 +130,35 @@ describe("gateway tool use — Workers AI", () => {
 		expect(result.toolCalls![0].id.length).toBeGreaterThan(0);
 	});
 
+	it("fallback ids for Llama un-id'd calls use a distinct namespace (no collision with OpenAI-style 'call_*')", async () => {
+		// Regression guard for review feedback on #94: if a response mixes
+		// provider-supplied `call_0` with un-id'd calls, a generic `call_*`
+		// fallback counter could collide. Use a distinct prefix instead.
+		const mockAi = {
+			run: vi.fn().mockResolvedValue({
+				response: "",
+				tool_calls: [
+					{ id: "call_0", name: "search", arguments: { q: "a" } },
+					{ name: "search", arguments: { q: "b" } },
+				],
+			}),
+		};
+		const gw = createGateway({
+			providers: { ai: { type: "workers-ai", binding: mockAi } },
+			defaultProvider: "ai",
+		});
+
+		const result = await gw.run("@cf/meta/llama-3.3-70b-instruct-fp8-fast", {
+			messages: [{ role: "user", content: "q" }],
+		} as AiInput);
+
+		expect(result.toolCalls).toHaveLength(2);
+		expect(result.toolCalls![0].id).toBe("call_0");
+		// Fallback id must NOT match the `call_*` namespace that OpenAI/providers use.
+		expect(result.toolCalls![1].id).not.toBe("call_0");
+		expect(result.toolCalls![1].id.startsWith("call_")).toBe(false);
+	});
+
 	it("generates distinct fallback ids when Llama returns multiple tool_calls without ids", async () => {
 		const mockAi = {
 			run: vi.fn().mockResolvedValue({


### PR DESCRIPTION
Closes #94.

## Summary

Two surgical fixes, one per path, to make `tools` actually work on `@cf/meta/llama-*` models through the `workers-ai` provider.

- **Non-streaming** (`providers/workers-ai.ts`): `extractWorkersAiToolCalls` normalizes Llama's flat `{name, arguments}` shape into the OpenAI-compat envelope before handing to `parseRawToolCalls`. The pre-existing parser required the nested `{id, type: "function", function: {...}}` shape and silently dropped the flat one — which is literally what every Llama endpoint returns today.
- **Streaming** (`stream.ts`): `streamWorkersAi` was ignoring `options` entirely. Now threads `toolOptions` via `applyToolsWorkersAi` so tool schemas actually reach the binding, and parses `tool_calls` from each SSE frame to emit `tool_use` events. Dedupes only on provider-supplied `id`; a stream-scoped monotonic counter supplies fallback ids so two legitimately distinct un-id'd calls across frames don't silently collapse.

## Test plan

- [x] 4 new non-streaming cases: flat-shape parse, id fallback, multi-call distinct fallback ids, mixed text + tool_calls
- [x] 3 new streaming cases: tool payload injection, tool_use event emission, dedupe on provider id / no-collapse on fallback id
- [x] Existing OpenAI-compat path tests still green (regression guard)
- [x] Full ai-gateway suite: 253/253
- [x] Full monorepo: 35 tasks green, no regressions in agent/ai/chat consumers
- [x] Typecheck clean
- [x] Biome clean
- [x] Constitution (diff-only): 0 errors

## Behavior change note

Calls that previously silently no-opped on `tools` against a Llama model will now actually invoke tools. Low risk — this is the documented, typed behavior, and the only consumers who were exercising this path were getting `toolCallCount: 0` anyway.

## Pairs well with

`@workkit/agent`'s `strictTools: true` (shipped prior): Llama hallucinates tool names more than Claude does, and strict mode turns a runaway step budget into a fail-fast `OffPaletteToolError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed Workers AI Llama models to properly execute tool calls that were previously being silently dropped.
* Updated streaming behavior to correctly pass tool options through to the provider configuration.
* Implemented deduplication for tool calls when providers re-emit across SSE streaming frames.

## Tests
* Added comprehensive test coverage for Workers AI streaming and tool-call behavior verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->