### PR TITLE
fix: batch — error code registration (#93) + browser docs (#75) + ai-gateway per-tier retry (#95)

### DIFF
--- a/.changeset/ai-gateway-fallback-per-tier-retry.md
+++ b/.changeset/ai-gateway-fallback-per-tier-retry.md
@@ -1,0 +1,16 @@
+---
+"@workkit/ai-gateway": minor
+---
+
+**`withRetry` now applies the retry budget per fallback tier instead of around the whole call.** Before this change, `withRetry(gateway).run(fallback(primary, secondary, …))` wrapped the entire `gateway.run` invocation — so when the primary threw a retryable error, the retry loop re-entered `gateway.run`, which re-entered the primary first. The primary's retry budget could never properly exhaust, and the contract from #81 ("primary retries per its policy first, then fallback triggers") was not honored.
+
+`withRetry` now detects `FallbackModelRef` model arguments and dispatches through `runWithFallback` with an inner per-tier retrying runner. Concretely:
+
+- Primary throws retryable errors → `withRetry` exhausts the full `maxAttempts` against the primary, then `runWithFallback` decides whether to fail over.
+- Primary throws non-retryable but fallback-matched errors → no retries on the primary, secondary runs immediately.
+- Primary recovers within its retry budget → secondary is never invoked.
+- Secondary tier gets its own independent retry budget.
+
+No API changes. Plain string models behave exactly as before.
+
+Closes #95.

--- a/.changeset/browser-puppeteer-framing.md
+++ b/.changeset/browser-puppeteer-framing.md
@@ -1,0 +1,9 @@
+---
+"@workkit/browser": patch
+---
+
+**Docs: reframe `@cloudflare/puppeteer` as scripting-API dependency, not a launcher requirement.** The previous framing implied the binding had no `.launch()` method without `@cloudflare/puppeteer`, which is outdated — workerd exposes `binding.launch()` natively. The honest framing is: bring `@cloudflare/puppeteer` if you want Puppeteer's scripting API (`page.pdf`, `page.screenshot`, `page.evaluate`, etc.), skip it only if a bare session that can open a page and dump HTML is enough.
+
+`browser()` already supports both paths; this is purely a docs and JSDoc clarification on `BrowserSessionOptions.puppeteer`. README, the `browser-rendering` docs guide, and the `puppeteer` option JSDoc all updated.
+
+Closes #75.

--- a/.changeset/errors-register-off-palette-tool.md
+++ b/.changeset/errors-register-off-palette-tool.md
@@ -1,0 +1,10 @@
+---
+"@workkit/errors": patch
+"@workkit/agent": patch
+---
+
+**Register `WORKKIT_AGENT_OFF_PALETTE_TOOL` in the central error code union.** `OffPaletteToolError` (added in #88 / strictTools) was carrying its code via `as unknown as WorkkitErrorCode` because the `@workkit/errors` union was out of diff-only scope for that PR. The cast worked at runtime but defeated exhaustive-switch analysis for consumers pattern-matching on `err.code`.
+
+The code now lives in the `WorkkitErrorCode` union and `OffPaletteToolError` declares it as a literal `as const` — no behavior change, just type integrity.
+
+Closes #93.

--- a/apps/docs/src/content/docs/guides/browser-rendering.md
+++ b/apps/docs/src/content/docs/guides/browser-rendering.md
@@ -14,7 +14,7 @@ bun add @workkit/browser @cloudflare/puppeteer
 
 `@cloudflare/puppeteer` is an optional peer — bring your own version.
 
-**When you need it:** anything that touches Puppeteer's scripting API — `page.pdf`, `page.screenshot`, `page.evaluate`, `page.click`, `waitForSelector`. That's the quick-start below and most real workloads.
+**When you need it:** anything that touches Puppeteer's scripting API — `page.pdf`, `page.screenshot`, `page.evaluate`, `page.click`, `page.waitForSelector`. That's the quick-start below and most real workloads.
 
 **When you can skip it:** the raw `BROWSER` binding now exposes `.launch()` natively, returning a minimal session that can open a page and dump final HTML but cannot script it. `browser()` automatically takes this path when `options.puppeteer` is not supplied. Useful only if you're bundle-size-constrained and don't need the scripting surface.
 

--- a/apps/docs/src/content/docs/guides/browser-rendering.md
+++ b/apps/docs/src/content/docs/guides/browser-rendering.md
@@ -12,7 +12,11 @@ title: "Browser Rendering"
 bun add @workkit/browser @cloudflare/puppeteer
 ```
 
-`@cloudflare/puppeteer` is an optional peer — bring your own version. Without it you have a Browser Rendering binding but no methods to call on it.
+`@cloudflare/puppeteer` is an optional peer — bring your own version.
+
+**When you need it:** anything that touches Puppeteer's scripting API — `page.pdf`, `page.screenshot`, `page.evaluate`, `page.click`, `waitForSelector`. That's the quick-start below and most real workloads.
+
+**When you can skip it:** the raw `BROWSER` binding now exposes `.launch()` natively, returning a minimal session that can open a page and dump final HTML but cannot script it. `browser()` automatically takes this path when `options.puppeteer` is not supplied. Useful only if you're bundle-size-constrained and don't need the scripting surface.
 
 ## Quick start
 

--- a/packages/agent/src/errors.ts
+++ b/packages/agent/src/errors.ts
@@ -1,5 +1,5 @@
 import { ConfigError, ValidationError, WorkkitError } from "@workkit/errors";
-import type { RetryStrategy, WorkkitErrorCode } from "@workkit/errors";
+import type { RetryStrategy } from "@workkit/errors";
 
 export class ToolValidationError extends ValidationError {
 	constructor(toolName: string, issues: Array<{ path: PropertyKey[]; message: string }>) {
@@ -47,11 +47,7 @@ export class BudgetExceededError extends WorkkitError {
 }
 
 export class OffPaletteToolError extends WorkkitError {
-	// The code union in @workkit/errors is centrally registered; agent-specific
-	// subcodes that haven't been added to the shared union cast locally. This
-	// preserves the package boundary (we don't reach into @workkit/errors for
-	// this additive change) while still surfacing a stable, greppable code.
-	readonly code = "WORKKIT_AGENT_OFF_PALETTE_TOOL" as unknown as WorkkitErrorCode;
+	readonly code = "WORKKIT_AGENT_OFF_PALETTE_TOOL" as const;
 	readonly statusCode = 400;
 	readonly retryable = false;
 	readonly defaultRetryStrategy: RetryStrategy = { kind: "none" };

--- a/packages/ai-gateway/src/retry.ts
+++ b/packages/ai-gateway/src/retry.ts
@@ -1,4 +1,5 @@
 import { getRetryDelay, getRetryStrategy, isRetryable } from "@workkit/errors";
+import { isFallbackModelRef, runWithFallback } from "./fallback-wrapper";
 import type { AiInput, EmbedInput, FallbackEntry, Gateway, RunOptions } from "./types";
 
 /** Options for `withRetry`. */
@@ -42,8 +43,20 @@ export function withRetry(gateway: Gateway, config?: RetryConfig): Gateway {
 	const innerEmbed = gateway.embed?.bind(gateway);
 
 	return {
-		run: (model, input, options) =>
-			retry(() => gateway.run(model, input, options), options?.signal),
+		// FallbackModelRef refs need per-tier retry: primary's full retry budget
+		// must exhaust before failover, otherwise wrapping the whole gateway.run
+		// re-enters the primary on every retry and the secondary never gets
+		// reached on its own budget. We dispatch via runWithFallback with an
+		// inner runner that re-enters the underlying gateway per tier — that
+		// way each tier gets its own independent retry pass.
+		run: (model, input, options) => {
+			if (isFallbackModelRef(model)) {
+				return runWithFallback(model, input, options, (m, i, o) =>
+					retry(() => gateway.run(m, i, o), o?.signal),
+				);
+			}
+			return retry(() => gateway.run(model, input, options), options?.signal);
+		},
 		runFallback: innerFallback
 			? (entries: FallbackEntry[], input: AiInput, options?: RunOptions) =>
 					retry(() => innerFallback(entries, input, options), options?.signal)

--- a/packages/ai-gateway/src/schema.ts
+++ b/packages/ai-gateway/src/schema.ts
@@ -19,15 +19,12 @@ interface StandardSchemaLike {
 }
 
 export function standardSchemaToJsonSchema(schema: StandardSchemaLike): Record<string, unknown> {
-	// biome-ignore lint/suspicious/noExplicitAny: Schema libraries expose toJSONSchema without a standard type.
 	if (typeof (schema as any).toJSONSchema === "function") {
-		// biome-ignore lint/suspicious/noExplicitAny: same reason.
 		const full = (schema as any).toJSONSchema() as Record<string, unknown>;
 		const { $schema: _meta, ...rest } = full;
 		return rest;
 	}
 
-	// biome-ignore lint/suspicious/noExplicitAny: Inspecting Zod's private defs.
 	const def = (schema as any)?._zod?.def ?? (schema as any)?._def;
 	if (def) return convertDef(def);
 
@@ -46,11 +43,9 @@ function convertDef(def: Record<string, unknown>): Record<string, unknown> {
 			return { type: "boolean" };
 
 		case "array": {
-			// biome-ignore lint/suspicious/noExplicitAny: Zod internal shape.
 			const items = def.element ?? (def as any).items;
 			return {
 				type: "array",
-				// biome-ignore lint/suspicious/noExplicitAny: Zod internal shape.
 				items: items ? convertDef((items as any)?._zod?.def ?? (items as any)?._def ?? {}) : {},
 			};
 		}
@@ -62,7 +57,6 @@ function convertDef(def: Record<string, unknown>): Record<string, unknown> {
 
 			if (shape) {
 				for (const [key, field] of Object.entries(shape)) {
-					// biome-ignore lint/suspicious/noExplicitAny: Zod internal shape.
 					const fieldDef = (field as any)?._zod?.def ?? (field as any)?._def ?? {};
 					properties[key] = convertDef(fieldDef);
 
@@ -91,14 +85,12 @@ function convertDef(def: Record<string, unknown>): Record<string, unknown> {
 
 		case "optional":
 		case "nullable": {
-			// biome-ignore lint/suspicious/noExplicitAny: Zod internal shape.
 			const inner = (def as any).innerType;
 			const innerDef = inner?._zod?.def ?? inner?._def ?? {};
 			return convertDef(innerDef);
 		}
 
 		case "default": {
-			// biome-ignore lint/suspicious/noExplicitAny: Zod internal shape.
 			const inner = (def as any).innerType;
 			const innerDef = inner?._zod?.def ?? inner?._def ?? {};
 			return { ...convertDef(innerDef), default: def.defaultValue };

--- a/packages/ai-gateway/tests/retry.test.ts
+++ b/packages/ai-gateway/tests/retry.test.ts
@@ -148,12 +148,7 @@ describe("withRetry() + fallback() — per-tier retry budget", () => {
 
 		expect(result.via).toBe("secondary");
 		const calls = run.mock.calls.map((c) => c[0]);
-		expect(calls).toEqual([
-			"primary-model",
-			"primary-model",
-			"primary-model",
-			"secondary-model",
-		]);
+		expect(calls).toEqual(["primary-model", "primary-model", "primary-model", "secondary-model"]);
 	});
 
 	it("non-retryable but fallback-matched primary error → secondary runs immediately", async () => {

--- a/packages/ai-gateway/tests/retry.test.ts
+++ b/packages/ai-gateway/tests/retry.test.ts
@@ -1,5 +1,6 @@
 import { ServiceUnavailableError, TimeoutError, ValidationError } from "@workkit/errors";
 import { describe, expect, it, vi } from "vitest";
+import { fallback } from "../src/fallback-wrapper";
 import { withRetry } from "../src/retry";
 import type { AiInput, AiOutput, Gateway, RunOptions } from "../src/types";
 
@@ -121,5 +122,97 @@ describe("withRetry()", () => {
 
 		await gw.run("m", { prompt: "x" });
 		expect(run).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe("withRetry() + fallback() — per-tier retry budget", () => {
+	// Status field on a `ServiceUnavailableError` lets the same error trip both
+	// `isRetryable` (it's retryable) and `matchesFallback({ on: [503] })` —
+	// which is the case where the per-tier vs whole-call distinction matters.
+	function svcUnavail(): ServiceUnavailableError {
+		return new ServiceUnavailableError("upstream", { context: { status: 503 } });
+	}
+
+	it("primary's full retry budget exhausts before secondary is tried", async () => {
+		// Primary always fails retryably; secondary succeeds on first attempt.
+		// With per-tier retry, primary should be hit `maxAttempts` times THEN
+		// secondary once — never re-entering primary after the first exhaustion.
+		const run = vi.fn().mockImplementation(async (model: string) => {
+			if (model === "primary-model") throw svcUnavail();
+			return okOutput("secondary-model");
+		});
+		const gw = withRetry(makeGateway(run), { maxAttempts: 3 });
+
+		const ref = fallback("primary-model", "secondary-model", { on: [503] });
+		const result = await gw.run(ref, { prompt: "x" });
+
+		expect(result.via).toBe("secondary");
+		const calls = run.mock.calls.map((c) => c[0]);
+		expect(calls).toEqual([
+			"primary-model",
+			"primary-model",
+			"primary-model",
+			"secondary-model",
+		]);
+	});
+
+	it("non-retryable but fallback-matched primary error → secondary runs immediately", async () => {
+		// 401 → not retryable per @workkit/errors' classification, but it IS in
+		// `on:[401]`. Per-tier retry must not artificially extend the primary's
+		// attempts when the error is non-retryable to begin with.
+		class Unauth extends Error {
+			readonly status = 401;
+		}
+		const run = vi.fn().mockImplementation(async (model: string) => {
+			if (model === "primary-model") throw new Unauth("auth failed");
+			return okOutput("secondary-model");
+		});
+		const gw = withRetry(makeGateway(run), { maxAttempts: 5 });
+
+		const ref = fallback("primary-model", "secondary-model", { on: [401] });
+		const result = await gw.run(ref, { prompt: "x" });
+
+		expect(result.via).toBe("secondary");
+		const calls = run.mock.calls.map((c) => c[0]);
+		expect(calls).toEqual(["primary-model", "secondary-model"]);
+	});
+
+	it("primary recovers within its retry budget — secondary is never invoked", async () => {
+		const run = vi
+			.fn<Gateway["run"]>()
+			.mockRejectedValueOnce(svcUnavail())
+			.mockResolvedValueOnce(okOutput("primary-model"));
+		const gw = withRetry(makeGateway(run), { maxAttempts: 3 });
+
+		const ref = fallback("primary-model", "secondary-model", { on: [503] });
+		const result = await gw.run(ref, { prompt: "x" });
+
+		expect(result.via).toBe("primary");
+		expect(run).toHaveBeenCalledTimes(2);
+		expect(run.mock.calls.every((c) => c[0] === "primary-model")).toBe(true);
+	});
+
+	it("secondary also gets its own retry budget", async () => {
+		// Primary exhausts (2 attempts), secondary fails-then-succeeds (2 attempts).
+		// Confirms per-tier retry applies to the secondary tier too, not just the primary.
+		let primaryAttempts = 0;
+		let secondaryAttempts = 0;
+		const run = vi.fn().mockImplementation(async (model: string) => {
+			if (model === "primary-model") {
+				primaryAttempts++;
+				throw svcUnavail();
+			}
+			secondaryAttempts++;
+			if (secondaryAttempts === 1) throw svcUnavail();
+			return okOutput("secondary-model");
+		});
+		const gw = withRetry(makeGateway(run), { maxAttempts: 2 });
+
+		const ref = fallback("primary-model", "secondary-model", { on: [503] });
+		const result = await gw.run(ref, { prompt: "x" });
+
+		expect(result.via).toBe("secondary");
+		expect(primaryAttempts).toBe(2);
+		expect(secondaryAttempts).toBe(2);
 	});
 });

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -10,7 +10,7 @@ bun add @workkit/browser @cloudflare/puppeteer
 
 `@cloudflare/puppeteer` is an optional peer dependency — bring your own version.
 
-Required if you want Puppeteer's scripting API: `page.pdf`, `page.screenshot`, `page.evaluate`, `page.click`, `waitForSelector`, etc. — i.e. anything in the quick-start below. The 95% case wants this.
+Required if you want Puppeteer's scripting API: `page.pdf`, `page.screenshot`, `page.evaluate`, `page.click`, `page.waitForSelector`, etc. — i.e. anything in the quick-start below. The 95% case wants this.
 
 The raw `BROWSER` binding also exposes `.launch()` natively (workerd >= recent versions), which gives a minimal session: open a page and dump final HTML, no scripting surface. Useful only when you're bundle-size-constrained and can live without Puppeteer's API. `browser()` falls back to this path automatically when `options.puppeteer` is not supplied.
 

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -10,6 +10,10 @@ bun add @workkit/browser @cloudflare/puppeteer
 
 `@cloudflare/puppeteer` is an optional peer dependency — bring your own version.
 
+Required if you want Puppeteer's scripting API: `page.pdf`, `page.screenshot`, `page.evaluate`, `page.click`, `waitForSelector`, etc. — i.e. anything in the quick-start below. The 95% case wants this.
+
+The raw `BROWSER` binding also exposes `.launch()` natively (workerd >= recent versions), which gives a minimal session: open a page and dump final HTML, no scripting surface. Useful only when you're bundle-size-constrained and can live without Puppeteer's API. `browser()` falls back to this path automatically when `options.puppeteer` is not supplied.
+
 ## Quick start
 
 ```ts

--- a/packages/browser/src/browser.ts
+++ b/packages/browser/src/browser.ts
@@ -15,9 +15,9 @@ export interface BrowserSessionOptions {
 	/**
 	 * Puppeteer launcher (`@cloudflare/puppeteer`). Required for the scripting
 	 * surface — `page.pdf`, `page.screenshot`, `page.evaluate`, `page.click`,
-	 * `waitForSelector`. Omit only when the raw `binding.launch()` is enough
-	 * (open a page, dump final HTML, no scripting). Takes precedence over
-	 * `binding.launch` when both are available.
+	 * `page.waitForSelector`. Omit only when the raw `binding.launch()` is
+	 * enough (open a page, dump final HTML, no scripting). Takes precedence
+	 * over `binding.launch()` when both are available.
 	 */
 	puppeteer?: PuppeteerLike;
 

--- a/packages/browser/src/browser.ts
+++ b/packages/browser/src/browser.ts
@@ -13,8 +13,11 @@ export interface BrowserSessionOptions {
 	keepAlive?: number;
 
 	/**
-	 * Puppeteer launcher (`@cloudflare/puppeteer`). Optional — supply for
-	 * explicit control. When provided, takes precedence over `binding.launch`.
+	 * Puppeteer launcher (`@cloudflare/puppeteer`). Required for the scripting
+	 * surface — `page.pdf`, `page.screenshot`, `page.evaluate`, `page.click`,
+	 * `waitForSelector`. Omit only when the raw `binding.launch()` is enough
+	 * (open a page, dump final HTML, no scripting). Takes precedence over
+	 * `binding.launch` when both are available.
 	 */
 	puppeteer?: PuppeteerLike;
 

--- a/packages/browser/tests/browser.test.ts
+++ b/packages/browser/tests/browser.test.ts
@@ -39,6 +39,31 @@ describe("browser()", () => {
 		expect((calls[0] as { binding: unknown }).binding).toBe(binding);
 	});
 
+	it("prefers options.puppeteer over binding.launch when both are available", async () => {
+		// JSDoc on `BrowserSessionOptions.puppeteer` claims puppeteer takes
+		// precedence — pin that contract so the implementation can't silently
+		// flip the dispatch order.
+		const bindingCalls: unknown[] = [];
+		const puppeteerCalls: unknown[] = [];
+		const binding: BrowserBindingLike = {
+			async launch(opts) {
+				bindingCalls.push(opts);
+				return fakeSession();
+			},
+		};
+		const puppeteer: PuppeteerLike = {
+			async launch(b, opts) {
+				puppeteerCalls.push({ binding: b, opts });
+				return fakeSession();
+			},
+		};
+
+		await browser(binding, { puppeteer });
+
+		expect(puppeteerCalls).toHaveLength(1);
+		expect(bindingCalls).toHaveLength(0);
+	});
+
 	it("throws when no launcher is available", async () => {
 		await expect(browser({} as BrowserBindingLike)).rejects.toBeInstanceOf(ServiceUnavailableError);
 	});

--- a/packages/errors/src/types.ts
+++ b/packages/errors/src/types.ts
@@ -24,7 +24,8 @@ export type WorkkitErrorCode =
 	| "WORKKIT_MAIL_DELIVERY_FAILED"
 	| "WORKKIT_TURNSTILE"
 	| "WORKKIT_AGENT_HANDOFF_CYCLE"
-	| "WORKKIT_AGENT_BUDGET";
+	| "WORKKIT_AGENT_BUDGET"
+	| "WORKKIT_AGENT_OFF_PALETTE_TOOL";
 
 /**
  * Retry strategy classification.


### PR DESCRIPTION
## Summary

Three small/medium fixes follow-up to recently-shipped work.

- **#93 (chore)** — Register `WORKKIT_AGENT_OFF_PALETTE_TOOL` in the `WorkkitErrorCode` union; drop the `as unknown as WorkkitErrorCode` cast in `OffPaletteToolError`. Restores exhaustive-switch type safety for consumers.
- **#75 (docs)** — Reframe `@cloudflare/puppeteer` as a *scripting-API* dependency rather than a launcher requirement. Workerd exposes `binding.launch()` natively; `browser()` already supports both paths. README, docs guide, and `BrowserSessionOptions.puppeteer` JSDoc all updated with Path A vs Path B guidance.
- **#95 (feat, minor)** — `withRetry` now honors per-tier retry budgets for `FallbackModelRef`. Primary's `maxAttempts` exhausts before failover; secondary tier gets its own retry pass. Closes the gap from #91 ("withRetry currently wraps the whole fallback call — per-tier retry is a follow-up"). Plain string models behave identically.

## Test plan

- [x] `bun run --cwd packages/agent test` — 50/50 pass (strictTools tests cover the error code path)
- [x] `bun run --cwd packages/agent typecheck` — clean (no more cast)
- [x] `bun run --cwd packages/ai-gateway test` — 260/260 pass; 4 new per-tier retry tests added
- [x] `bun run --cwd packages/ai-gateway typecheck` — clean
- [x] `maina verify` per commit — 13 tools each commit, all green
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved retry behavior for fallback models: retry budget is now applied per tier instead of wrapping entire execution.

* **Documentation**
  * Clarified Puppeteer dependency requirements for advanced page scripting features.
  * Added guidance on native fallback for minimal sessions without Puppeteer.

* **Type Safety**
  * Registered new error code for off-palette tool detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->