### PR TITLE
fix: workerd boot crash (#64) + forceTextAfterTool agent option (#97)

### DIFF
--- a/.changeset/agent-force-text-after-tool.md
+++ b/.changeset/agent-force-text-after-tool.md
@@ -1,0 +1,20 @@
+---
+"@workkit/agent": minor
+---
+
+**Add `forceTextAfterTool` agent option for post-tool `toolChoice: "none"` enforcement.** When enabled, the loop sends `toolChoice: "none"` on the assistant turn that immediately follows a tool execution — forcing a plain-text response. Works around models (notably Llama 3.x routed through Workers AI) that loop on identical tool calls instead of transitioning to text after the tool has already returned.
+
+```ts
+defineAgent({
+  name: "technical",
+  model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+  provider: gateway,
+  tools: [getQuote, getOptionChain, computeGreeks],
+  forceTextAfterTool: true, // <- post-tool turn forced to text
+  stopWhen: { maxSteps: 2 },
+});
+```
+
+Default: `false` — preserves existing behavior. Reset on handoff: a freshly-entered handoff target starts with `toolChoice: "auto"` regardless of the previous agent's tool calls. The flag is preserved across `afterModel` retries (the retry is still the post-tool step), so a `forceTextAfterTool` retry doesn't accidentally re-enable tool calls.
+
+Closes #97.

--- a/.changeset/agent-notify-workerd-createrequire.md
+++ b/.changeset/agent-notify-workerd-createrequire.md
@@ -1,0 +1,10 @@
+---
+"@workkit/agent": patch
+"@workkit/notify": patch
+---
+
+**Fix module-init crash in workerd: drop top-level `createRequire(import.meta.url)` from the bundle.** Bunup's default Node-target build emitted a top-level `import { createRequire } from "node:module"; var __require = createRequire(import.meta.url);` shim. Under workerd, `import.meta.url` is `undefined` for non-entry-point modules, so `createRequire(undefined)` threw synchronously at module load — blocking any Cloudflare Worker that imported (directly or transitively) `@workkit/agent` or `@workkit/notify` from booting.
+
+Both packages now build with `target: "browser"`, which switches bunup to a self-contained `__require` shim that has no top-level side effects. The shim only throws if a caller actually performs a dynamic `require()` — which neither package does. No source changes; no API changes.
+
+Closes #64.

--- a/packages/agent/bunup.config.ts
+++ b/packages/agent/bunup.config.ts
@@ -6,5 +6,6 @@ export default defineConfig({
 	dts: true,
 	sourcemap: "linked",
 	clean: true,
+	target: "browser",
 	external: ["@workkit/ai-gateway", "@workkit/errors", "@standard-schema/spec"],
 });

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -46,6 +46,7 @@ export function defineAgent(options: DefineAgentOptions): Agent {
 		hooks: options.hooks ?? {},
 		strictTools: options.strictTools ?? false,
 		maxAfterModelRetries: options.maxAfterModelRetries ?? 2,
+		forceTextAfterTool: options.forceTextAfterTool ?? false,
 	};
 
 	sharedRegistry.register(internal);

--- a/packages/agent/src/loop.ts
+++ b/packages/agent/src/loop.ts
@@ -27,6 +27,7 @@ export interface InternalAgentDef {
 	hooks: AgentHooks;
 	strictTools: boolean;
 	maxAfterModelRetries: number;
+	forceTextAfterTool: boolean;
 }
 
 const ZERO_USAGE: TokenUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
@@ -98,6 +99,12 @@ export async function runLoop(args: RunLoopArgs): Promise<{
 	// Per-step tracking for `afterModel` retry-with-reminder. Resets whenever
 	// the step advances into tool dispatch (i.e. a model turn was accepted).
 	let afterModelRetryCount = 0;
+	// Set when the previous step's assistant turn executed at least one tool
+	// call. The NEXT iteration uses this with `forceTextAfterTool` to send
+	// `toolChoice: "none"` and force a text response. Preserved across
+	// `afterModel` retries (the retry is still the post-tool step) and reset
+	// on handoff (the new agent gets a fresh `toolChoice: "auto"`).
+	let postToolStep = false;
 
 	while (true) {
 		if (ctx.signal?.aborted) {
@@ -126,6 +133,7 @@ export async function runLoop(args: RunLoopArgs): Promise<{
 			throw error;
 		}
 
+		const forceNoneNow = postToolStep && currentAgent.forceTextAfterTool;
 		const runOptions: RunOptions = {
 			signal: ctx.signal,
 			toolOptions:
@@ -136,7 +144,7 @@ export async function runLoop(args: RunLoopArgs): Promise<{
 								description: t.description,
 								parameters: toJsonSchema(t.input).schema,
 							})),
-							toolChoice: "auto",
+							toolChoice: forceNoneNow ? "none" : "auto",
 						}
 					: undefined,
 		};
@@ -242,6 +250,9 @@ export async function runLoop(args: RunLoopArgs): Promise<{
 
 		const toolCalls: GatewayToolCall[] = output.toolCalls ?? [];
 		if (toolCalls.length === 0) {
+			// Pure-text turn — clear the post-tool flag so a future tool call
+			// triggers `toolChoice: "none"` only on the immediate next step.
+			postToolStep = false;
 			emit({ type: "done", stopReason: "stop", usage });
 			return { messages, usage, stopReason: "stop", finalText };
 		}
@@ -371,6 +382,11 @@ export async function runLoop(args: RunLoopArgs): Promise<{
 			}
 		}
 
+		// Mark the NEXT step as a post-tool step so `forceTextAfterTool` can
+		// send `toolChoice: "none"`. Reset on handoff — the new agent has its
+		// own tool palette and shouldn't be forced into text on its first turn
+		// just because the previous agent called a tool.
+		postToolStep = !switched;
 		step += 1;
 		if (switched) continue;
 	}

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -102,6 +102,17 @@ export interface DefineAgentOptions {
 	 * Default: `2`.
 	 */
 	maxAfterModelRetries?: number;
+	/**
+	 * After every assistant turn that emits at least one tool call, invoke the
+	 * NEXT assistant turn with `toolChoice: "none"` — forcing a plain-text
+	 * response. Mitigates models (notably Llama 3.x on Workers AI) that loop
+	 * on identical tool calls instead of transitioning to text after the tool
+	 * has already returned. Default: `false`.
+	 *
+	 * Reset on handoff: a freshly-entered handoff target starts with
+	 * `toolChoice: "auto"` regardless of the previous agent's tool calls.
+	 */
+	forceTextAfterTool?: boolean;
 }
 
 export interface RunArgs {

--- a/packages/agent/tests/force-text-after-tool.test.ts
+++ b/packages/agent/tests/force-text-after-tool.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { defineAgent } from "../src/agent";
+import { tool } from "../src/tool";
+import { call, mockGateway } from "./_mocks";
+
+function searchTool(
+	handler: (input: { q: string }) => Promise<string> = async () => "search-result",
+) {
+	return tool({
+		name: "search",
+		description: "searches",
+		input: z.object({ q: z.string() }),
+		handler,
+	});
+}
+
+describe("forceTextAfterTool option", () => {
+	it("default (false): toolChoice stays 'auto' on the post-tool step", async () => {
+		const { gateway, state } = mockGateway([
+			{ toolCalls: [call("search", { q: "x" })] },
+			{ text: "done" },
+		]);
+		const agent = defineAgent({
+			name: "default",
+			model: "m",
+			provider: gateway,
+			tools: [searchTool()],
+			stopWhen: { maxSteps: 3 },
+		});
+
+		const result = await agent.run({ messages: [{ role: "user", content: "go" }] });
+
+		expect(result.text).toBe("done");
+		expect(state.calls).toHaveLength(2);
+		expect(state.calls[0]?.options?.toolOptions?.toolChoice).toBe("auto");
+		expect(state.calls[1]?.options?.toolOptions?.toolChoice).toBe("auto");
+	});
+
+	it("forceTextAfterTool=true: post-tool step uses toolChoice 'none'", async () => {
+		const { gateway, state } = mockGateway([
+			{ toolCalls: [call("search", { q: "x" })] },
+			{ text: "synthesized answer" },
+		]);
+		const agent = defineAgent({
+			name: "force-text",
+			model: "m",
+			provider: gateway,
+			tools: [searchTool()],
+			forceTextAfterTool: true,
+			stopWhen: { maxSteps: 3 },
+		});
+
+		const result = await agent.run({ messages: [{ role: "user", content: "go" }] });
+
+		expect(result.text).toBe("synthesized answer");
+		expect(result.stopReason).toBe("stop");
+		expect(state.calls).toHaveLength(2);
+		// First step: tool palette open.
+		expect(state.calls[0]?.options?.toolOptions?.toolChoice).toBe("auto");
+		// Post-tool step: tools still in the message but toolChoice='none'.
+		expect(state.calls[1]?.options?.toolOptions?.toolChoice).toBe("none");
+		expect(state.calls[1]?.options?.toolOptions?.tools?.length).toBe(1);
+	});
+
+	it("forceTextAfterTool only forces the IMMEDIATE next step, not all subsequent steps", async () => {
+		// tool → text-blocked → another text → user could continue but loop stops at no-tool.
+		// This case is mostly defensive: after the post-tool 'none' step emits text and we stop,
+		// there are no further model calls. So we test the 3-step shape with two tool turns:
+		//   step 1: tool → step 2: text-only ('none') → STOP
+		// And verify a fresh agent call resets the post-tool flag (not carried across runs).
+		const { gateway, state } = mockGateway([
+			{ toolCalls: [call("search", { q: "x" })] },
+			{ text: "first answer" },
+			{ toolCalls: [call("search", { q: "y" })] },
+			{ text: "second answer" },
+		]);
+		const agent = defineAgent({
+			name: "fresh-run",
+			model: "m",
+			provider: gateway,
+			tools: [searchTool()],
+			forceTextAfterTool: true,
+			stopWhen: { maxSteps: 3 },
+		});
+
+		await agent.run({ messages: [{ role: "user", content: "first" }] });
+		await agent.run({ messages: [{ role: "user", content: "second" }] });
+
+		expect(state.calls).toHaveLength(4);
+		// Run 1: auto, none.
+		expect(state.calls[0]?.options?.toolOptions?.toolChoice).toBe("auto");
+		expect(state.calls[1]?.options?.toolOptions?.toolChoice).toBe("none");
+		// Run 2 starts fresh: auto, none.
+		expect(state.calls[2]?.options?.toolOptions?.toolChoice).toBe("auto");
+		expect(state.calls[3]?.options?.toolOptions?.toolChoice).toBe("none");
+	});
+
+	it("when tools array is empty, forceTextAfterTool is a no-op (no toolOptions)", async () => {
+		const { gateway, state } = mockGateway([{ text: "ok" }]);
+		const agent = defineAgent({
+			name: "no-tools",
+			model: "m",
+			provider: gateway,
+			forceTextAfterTool: true,
+		});
+
+		await agent.run({ messages: [{ role: "user", content: "go" }] });
+
+		expect(state.calls[0]?.options?.toolOptions).toBeUndefined();
+	});
+
+	it("afterModel retry on the post-tool step preserves toolChoice='none'", async () => {
+		// Step 1: tool call. Step 2: post-tool, model returns text. afterModel
+		// rejects the first text, retries → step 2-retry should ALSO use 'none',
+		// otherwise the retry would re-enable tool calls and the whole point
+		// of forceTextAfterTool is undermined.
+		let afterModelCalls = 0;
+		const { gateway, state } = mockGateway([
+			{ toolCalls: [call("search", { q: "x" })] },
+			{ text: "first text (rejected)" },
+			{ text: "retry text (accepted)" },
+		]);
+		const agent = defineAgent({
+			name: "retry-keeps-none",
+			model: "m",
+			provider: gateway,
+			tools: [searchTool()],
+			forceTextAfterTool: true,
+			stopWhen: { maxSteps: 4 },
+			hooks: {
+				afterModel: () => {
+					afterModelCalls += 1;
+					return afterModelCalls === 2 ? { retry: true, reminder: "try again" } : undefined;
+				},
+			},
+		});
+
+		await agent.run({ messages: [{ role: "user", content: "go" }] });
+
+		// step 1 (tool=auto), step 2 (tool=none, rejected), step 2-retry (tool=none, accepted)
+		expect(state.calls.map((c) => c.options?.toolOptions?.toolChoice)).toEqual([
+			"auto",
+			"none",
+			"none",
+		]);
+	});
+});

--- a/packages/notify/bunup.config.ts
+++ b/packages/notify/bunup.config.ts
@@ -11,5 +11,6 @@ export default defineConfig({
 	dts: true,
 	sourcemap: "linked",
 	clean: true,
+	target: "browser",
 	external: ["@workkit/errors", "@standard-schema/spec", "@react-email/render"],
 });


### PR DESCRIPTION
## Summary

Stacked on top of #99 — branched from `fix/issues-batch-1` so it inherits the lint fix. Will rebase onto master once #99 lands.

- **#64 (fix)** — `@workkit/agent` and `@workkit/notify` boot-crash on Cloudflare Workers. Bunup's default Node-target build emits `import { createRequire } from "node:module"; var __require = createRequire(import.meta.url);` at the top of shared chunks. Workerd has `import.meta.url === undefined` for non-entry-point modules, so `createRequire(undefined)` throws synchronously at module load. Switching both packages to `target: "browser"` swaps in a no-side-effect `__require` shim. Same fix the `@workkit/d1` package already uses.
- **#97 (feat, minor)** — New `forceTextAfterTool` option on `defineAgent`. When the previous assistant turn called a tool, the next turn ships with `toolChoice: "none"` so the model is forced to produce text. Mitigates Llama 3.x on Workers AI looping on identical tool calls instead of synthesizing an answer (downstream impact: entryexit.ai, where #94 unblocked tool execution but the post-tool step still degenerated). Default `false`. Reset on handoff. Preserved across `afterModel` retries.

## Test plan

- [x] `bun run --cwd packages/agent test` — 55/55 (5 new for `forceTextAfterTool`)
- [x] `bun run --cwd packages/agent typecheck` — clean
- [x] `bun run --cwd packages/notify test` — 174/174
- [x] Rebuilt `@workkit/agent` and `@workkit/notify` with `target: "browser"` — verified no `node:module` import and no top-level `createRequire(import.meta.url)` in any dist chunk
- [x] `maina verify` per commit — 13 tools, all green
- [ ] CodeRabbit review
- [ ] Smoke deploy on entryexit.ai (downstream consumer tests `forceTextAfterTool` end-to-end against Llama 3.3)

## Follow-ups not in this PR

- Other worker-deployed packages (ai, ai-gateway, api, auth, browser, etc.) don't currently emit the createRequire shim, but applying `target: "browser"` to all of them preventatively would close the door for future regressions. Filed mentally; can be a one-shot follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)