### PR TITLE
docs: mail vs notify positioning (#56) + fix(ci): serial release creation (#77)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,12 +30,85 @@ jobs:
       - run: bun run build
       - run: bun run test
       - name: Create Release Pull Request or Publish
+        id: changesets
         uses: changesets/action@v1
         with:
           publish: bun run release
           version: bun run version-packages
           title: "chore: version packages"
           commit: "chore: version packages"
+          # Disable the action's built-in GitHub release creation — it races
+          # when 2+ packages publish in the same run and the GitHub Releases
+          # API rejects the batch with `tag_name: already_exists` for all but
+          # one of the packages. Drive release creation ourselves below,
+          # serially, so the same race can't happen. (See #77.)
+          createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub releases for each published package
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PUBLISHED: ${{ steps.changesets.outputs.publishedPackages }}
+        run: |
+          set -euo pipefail
+          # `publishedPackages` is a JSON array like:
+          #   [{ "name": "@workkit/agent", "version": "0.2.0" }, ...]
+          # `changeset publish` already pushed the per-package tags
+          # (e.g. `@workkit/agent@0.2.0`) before this step runs.
+          echo "$PUBLISHED" | jq -c '.[]' | while read -r pkg; do
+            name=$(echo "$pkg" | jq -r '.name')
+            version=$(echo "$pkg" | jq -r '.version')
+            tag="${name}@${version}"
+
+            # Idempotency: skip if a release for this tag already exists. This
+            # also makes the backfill story trivial — re-running the workflow
+            # (or invoking this step manually) only fills in what's missing.
+            if gh release view "$tag" >/dev/null 2>&1; then
+              echo "✓ release already exists: $tag"
+              continue
+            fi
+
+            # Resolve the package directory from its name so we can read the
+            # CHANGELOG. Walk both `packages/*` and `integrations/*` (the only
+            # workspace globs that ship to npm).
+            pkgdir=""
+            for dir in packages/* integrations/*; do
+              if [ -f "$dir/package.json" ] && [ "$(jq -r .name "$dir/package.json")" = "$name" ]; then
+                pkgdir="$dir"
+                break
+              fi
+            done
+
+            # Extract just the section for THIS version from the changelog.
+            # Format produced by `@changesets/cli/changelog`:
+            #   # <package name>
+            #   ## <version>
+            #   ### <change-kind>
+            #   - <commit>: <summary>
+            #   ## <previous version>
+            #   ...
+            notes_file=$(mktemp)
+            if [ -n "$pkgdir" ] && [ -f "$pkgdir/CHANGELOG.md" ]; then
+              awk -v ver="$version" '
+                /^## / {
+                  if (in_section) exit
+                  # Match "## <ver>" exactly (token-aware, not substring).
+                  if ($2 == ver) { in_section = 1; next }
+                }
+                in_section
+              ' "$pkgdir/CHANGELOG.md" > "$notes_file"
+            fi
+            # Empty changelog falls back to a one-line auto-note rather than
+            # creating a blank release body.
+            if [ ! -s "$notes_file" ]; then
+              echo "Release ${tag} (no changelog entry found)" > "$notes_file"
+            fi
+
+            echo "→ creating release: $tag"
+            gh release create "$tag" \
+              --title "$tag" \
+              --notes-file "$notes_file"
+          done

--- a/apps/docs/src/content/docs/contributing.md
+++ b/apps/docs/src/content/docs/contributing.md
@@ -260,6 +260,35 @@ When creating a changeset:
 - `minor` -- New features, non-breaking additions
 - `major` -- Breaking changes
 
+### Manually backfilling a missing GitHub release
+
+The release workflow creates GitHub releases serially in its own step (so the multi-package race that bit us in #77 can't recur). The step is idempotent — re-running the `Release` workflow on the same merge commit only fills in releases that don't yet exist.
+
+If you ever need to create a single release by hand (e.g. the `gh release create` call inside the workflow failed for one package due to a transient API hiccup):
+
+```bash
+PKG=@workkit/agent
+VER=0.2.0
+TAG="${PKG}@${VER}"
+
+# 1. Push the tag if `changeset publish` didn't (rare — it normally does).
+if ! git ls-remote --tags origin | grep -q "refs/tags/${TAG}$"; then
+  git tag "$TAG" "$(git rev-parse HEAD)"
+  git push origin "$TAG"
+fi
+
+# 2. Pull just this version's section out of the package CHANGELOG.
+PKGDIR=packages/agent  # or integrations/<name>
+NOTES=$(mktemp)
+awk -v ver="$VER" '
+  /^## / { if (in_section) exit; if ($2 == ver) { in_section = 1; next } }
+  in_section
+' "$PKGDIR/CHANGELOG.md" > "$NOTES"
+
+# 3. Create the release.
+gh release create "$TAG" --title "$TAG" --notes-file "$NOTES"
+```
+
 ## Code Style
 
 - Biome for linting and formatting: `bun run lint`

--- a/apps/docs/src/content/docs/guides/email.md
+++ b/apps/docs/src/content/docs/guides/email.md
@@ -6,7 +6,16 @@ title: "Email"
 
 `@workkit/mail` is a typed email primitive for Cloudflare Workers — outbound send via the [`SendEmail` binding](https://developers.cloudflare.com/email-routing/email-workers/send-email/), inbound parsing for [Email Routing](https://developers.cloudflare.com/email-routing/email-workers/), pattern-matching router, and MIME composition with attachments. No third-party API dependency.
 
-For high-level dispatch (preferences, opt-out, fallback chains), see [Notifications](/workkit/guides/notifications/) — `@workkit/notify` runs *on top* of `@workkit/mail` (or any transport).
+## When to use `@workkit/mail` vs `@workkit/notify`
+
+Both packages now share the Cloudflare `send_email` binding as the default transport — `@workkit/notify`'s `cloudflareEmailProvider` delegates to `@workkit/mail`'s `mail()` under the hood. Pick by what you need:
+
+| You want… | Use |
+|---|---|
+| Send one email, parse one inbound, route inbound by address | **`@workkit/mail`** (this guide) |
+| Multi-channel dispatch (email + in-app + WhatsApp), preferences, opt-out registry, quiet hours, idempotency, fallback chains, delivery records, test mode | **`@workkit/notify`** ([Notifications](/workkit/guides/notifications/)) |
+
+You don't need to know that notify delegates to mail — pick the package whose surface matches your problem and the other stays out of your way.
 
 ## Install
 

--- a/apps/docs/src/content/docs/guides/notifications.md
+++ b/apps/docs/src/content/docs/guides/notifications.md
@@ -6,6 +6,15 @@ title: "Notifications"
 
 `@workkit/notify` is a unified notification dispatch primitive for Cloudflare Workers. One API, pluggable transport adapters that ship as **subpath imports** of the same package — bring the runtime cost of an adapter only when you import it.
 
+## When to use `@workkit/notify` vs `@workkit/mail`
+
+Both packages now share the Cloudflare `send_email` binding as the default email transport — `@workkit/notify`'s `cloudflareEmailProvider` delegates to `@workkit/mail`'s `mail()` under the hood. Pick by what you need:
+
+| You want… | Use |
+|---|---|
+| Multi-channel dispatch (email + in-app + WhatsApp), preferences, opt-out registry, quiet hours, idempotency, fallback chains, delivery records, test mode | **`@workkit/notify`** (this guide) |
+| Send one email, parse one inbound, route inbound by address | **`@workkit/mail`** ([Email](/workkit/guides/email/)) |
+
 | Subpath | Adapter | Optional peer |
 |---|---|---|
 | `@workkit/notify/email` | Resend HTTP API + React Email | `@react-email/render` |
@@ -110,32 +119,74 @@ export const queue = createNotifyConsumer(
 
 ## Email adapter
 
+Provider-pluggable. **Cloudflare `send_email` is the default** — zero config, ships with every Worker deployment, no third-party API key. Resend is the first-class alternative when you need delivery webhooks and auto-opt-out from hard bounces.
+
+### Default: Cloudflare `send_email` binding
+
+```toml
+# wrangler.toml
+[[send_email]]
+name = "SEND_EMAIL"
+```
+
 ```ts
-import { emailAdapter } from "@workkit/notify/email";
+import { emailAdapter, cloudflareEmailProvider } from "@workkit/notify/email";
+
+const email = emailAdapter({
+  provider: cloudflareEmailProvider({
+    binding: env.SEND_EMAIL,
+    from: "Reports <reports@entryexit.ai>",
+    replyTo: "support@entryexit.ai",                // optional
+  }),
+  bucket: env.REPORTS,                              // optional, only for attachments
+  markUnsubscribable: ["pre-market-brief"],         // attaches List-Unsubscribe headers
+});
+```
+
+- Delegates to `@workkit/mail`'s `mail()` — zero MIME duplication.
+- Requires `@workkit/mail` (optional peer): `bun add @workkit/mail`.
+- No delivery webhooks on the binding → `autoOptOut` is not available on this provider; bounce synthesis from inbound DSN routing is tracked as a roadmap item.
+- Plain-text fallback auto-generated.
+- Attachment cap default 40MB; bounded R2 fetch concurrency 4.
+
+### Alternative: Resend
+
+```ts
+import { emailAdapter, resendEmailProvider } from "@workkit/notify/email";
 import { optOut } from "@workkit/notify";
 
 const email = emailAdapter({
-  apiKey: env.RESEND_API_KEY,
-  from: "Reports <reports@entryexit.ai>",
-  bucket: env.REPORTS,                              // for attachments
-  webhook: { maxAgeMs: 5 * 60 * 1000 },
-  autoOptOut: {
-    enabled: true,
-    hook: async (emailAddress, _channel, _notificationId, reason) => {
-      const userId = await lookupUserIdByEmail(emailAddress);
-      if (userId) await optOut(env.DB, userId, "email", null, reason);
+  provider: resendEmailProvider({
+    apiKey: env.RESEND_API_KEY,
+    from: "Reports <reports@entryexit.ai>",
+    webhook: { maxAgeMs: 5 * 60 * 1000 },
+    autoOptOut: {
+      enabled: true,
+      hook: async (emailAddress, channel, _notificationId, reason) => {
+        const userId = await lookupUserIdByEmail(emailAddress);
+        if (userId) await optOut(env.DB, userId, channel, null, reason);
+      },
     },
-  },
-  markUnsubscribable: ["pre-market-brief"],         // attaches List-Unsubscribe headers
+  }),
+  bucket: env.REPORTS,
+  markUnsubscribable: ["pre-market-brief"],
 });
 ```
 
 - Direct `fetch` to Resend (no SDK).
 - Optional `@react-email/render` peer for React Email components.
-- Plain-text fallback auto-generated.
 - Svix-format webhook verification (`v1,<base64>` HMAC-SHA256), 5-min replay window.
 - Hard bounce + complaint → automatic opt-out via injected hook (configurable, default on).
 - Attachment cap default 40MB; bounded R2 fetch concurrency 4.
+
+### Migrating from the pre-provider shape
+
+The pre-#52 shape took provider-specific options directly on `emailAdapter()`. Wrap them in the new `provider: …` field:
+
+```diff
+- emailAdapter({ apiKey: env.RESEND_API_KEY, from: "…", autoOptOut: { hook } })
++ emailAdapter({ provider: resendEmailProvider({ apiKey: env.RESEND_API_KEY, from: "…", autoOptOut: { hook } }) })
+```
 
 ## In-app adapter
 

--- a/apps/docs/src/content/docs/guides/notifications.md
+++ b/apps/docs/src/content/docs/guides/notifications.md
@@ -15,9 +15,9 @@ Both packages now share the Cloudflare `send_email` binding as the default email
 | Multi-channel dispatch (email + in-app + WhatsApp), preferences, opt-out registry, quiet hours, idempotency, fallback chains, delivery records, test mode | **`@workkit/notify`** (this guide) |
 | Send one email, parse one inbound, route inbound by address | **`@workkit/mail`** ([Email](/workkit/guides/email/)) |
 
-| Subpath | Adapter | Optional peer |
+| Subpath | Adapter | Optional peers |
 |---|---|---|
-| `@workkit/notify/email` | Resend HTTP API + React Email | `@react-email/render` |
+| `@workkit/notify/email` | Provider-pluggable: Cloudflare `send_email` (default) or Resend HTTP API | `@workkit/mail` (CF provider), `@react-email/render` (React templates) |
 | `@workkit/notify/inapp` | D1-backed feed + SSE streaming | — |
 | `@workkit/notify/whatsapp` | Meta WA Cloud API (default) + Twilio/Gupshup stubs | — |
 
@@ -139,7 +139,7 @@ const email = emailAdapter({
     replyTo: "support@entryexit.ai",                // optional
   }),
   bucket: env.REPORTS,                              // optional, only for attachments
-  markUnsubscribable: ["pre-market-brief"],         // attaches List-Unsubscribe headers
+  markUnsubscribable: ["pre-market-brief"],         // marks this notification as unsubscribable
 });
 ```
 


### PR DESCRIPTION
## Summary

- **#56 (docs)** — `apps/docs` guides for `@workkit/mail` and `@workkit/notify` were stale post-#52 (when `cloudflareEmailProvider` became the default). Added a "When to use which" decision table to both guides; rewrote the notifications guide's email adapter section to lead with `cloudflareEmailProvider` and demote Resend to "Alternative providers"; included a migration diff from the pre-provider shape. No code changes.
- **#77 (fix, CI)** — Release workflow has been losing GitHub releases on multi-package publishes (PRs #66 and #73 both hit it: npm publish OK but only 1 of 3 GitHub releases created). Root cause: `changesets/action@v1`'s built-in release creator races on `POST /releases` calls — GitHub returns `tag_name: already_exists` on all but one. Set `createGithubReleases: false` on the action and added a serial `gh release create` loop driven by `publishedPackages`. The new step is idempotent (re-running the workflow safely fills in any missing releases). Manual backfill recipe also documented in the contributing guide.

## Test plan

- [x] `bun run --cwd packages/agent test` clean (no agent code changed; sanity)
- [x] `maina verify` per commit — 13 tools, all green
- [ ] Real-world validation of #77 lands on the next multi-package release (the fix can't be exercised in PR CI; ship it and watch the next release)
- [ ] CodeRabbit review

## Risk on #77

- The release workflow change only takes effect on the *next* release. If the new serial step has a bug, npm publish has already succeeded by then — recovery is to run the documented manual backfill or re-trigger the `Release` workflow on the same merge commit (the loop is idempotent).
- Worst case if I miscoded the awk extraction: GitHub releases get created with empty notes (we explicitly fall back to `Release ${tag} (no changelog entry found)` rather than blank). No lost data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified when to use `@workkit/mail` vs `@workkit/notify` with detailed comparison tables showing use-cases and features for each package.
  * Updated email adapter documentation to reflect new provider-based configuration approach.
  * Added migration guide for updating email adapter setup to the new provider pattern.
  * Added guide for manually backfilling missing GitHub releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->