### PR TITLE
feat: bounce handling — parseBounceDSN (#53) + createBounceRoute (#54)

### DIFF
--- a/.changeset/mail-parse-bounce-dsn.md
+++ b/.changeset/mail-parse-bounce-dsn.md
@@ -1,0 +1,23 @@
+---
+"@workkit/mail": minor
+---
+
+**Add `parseBounceDSN` for RFC 3464 hard/soft bounce detection.** New pure parser turns an `InboundEmail` carrying a delivery-status notification into a structured `BounceInfo`. Detects multipart/report layout and the single-part-in-body variant; classifies via RFC 3463 status-code prefix (`5.x` → hard, `4.x` → soft), with a `Diagnostic-Code` SMTP-class fallback for DSNs that omit `Status`. Returns `null` for non-DSN mail (regular inbound, auto-replies), for DSNs with non-`failed` `Action` (delayed / relayed / delivered), and for malformed DSNs missing `Final-Recipient`.
+
+```ts
+import { parseBounceDSN, createEmailRouter } from "@workkit/mail";
+
+createEmailRouter().match(
+  (e) => e.to === "bounces@yourdomain.com",
+  async (email) => {
+    const bounce = parseBounceDSN(email);
+    if (bounce?.kind === "hard") {
+      // suppress further sends to bounce.recipient
+    }
+  },
+);
+```
+
+Foundational for `@workkit/notify`'s upcoming `createBounceRoute` helper, which wires this into the `autoOptOut` hook so the Cloudflare `send_email` transport gets bounce-driven opt-out parity with Resend.
+
+Closes #53.

--- a/.changeset/notify-create-bounce-route.md
+++ b/.changeset/notify-create-bounce-route.md
@@ -1,0 +1,31 @@
+---
+"@workkit/notify": minor
+---
+
+**Add `createBounceRoute` to `@workkit/notify/email` for Cloudflare-transport bounce handling.** The Cloudflare `send_email` binding has no delivery-webhook surface, so the Resend-style `autoOptOut` path isn't available on `cloudflareEmailProvider`. This helper closes the gap: feed an inbound DSN routed via Cloudflare Email Routing into the same `EmailOptOutHook` shape your Resend setup uses.
+
+```ts
+import { createEmailRouter } from "@workkit/mail";
+import { createBounceRoute } from "@workkit/notify/email";
+import { optOut } from "@workkit/notify";
+
+const bounces = createBounceRoute({
+  optOutHook: async (address, channel, _nid, reason) => {
+    const userId = await lookupUserIdByEmail(address);
+    if (userId) await optOut(env.DB, userId, channel, null, reason);
+  },
+});
+
+export default {
+  email: createEmailRouter()
+    .match((e) => e.to === "bounces@yourdomain.com", bounces)
+    .default((e) => e.setReject("Unknown recipient"))
+    .handle,
+};
+```
+
+Hard bounces (RFC 3463 `5.x`) fire the opt-out hook with `reason: "hard-bounce"`; soft bounces (`4.x`) no-op so transient failures don't silently drop subscribers; non-DSN messages route through the optional `onNonBounce` callback (or are dropped). Hook errors propagate so the MTA retries.
+
+Built on `parseBounceDSN` from `@workkit/mail` (same release).
+
+Closes #54.

--- a/apps/docs/src/content/docs/guides/notifications.md
+++ b/apps/docs/src/content/docs/guides/notifications.md
@@ -179,6 +179,43 @@ const email = emailAdapter({
 - Hard bounce + complaint → automatic opt-out via injected hook (configurable, default on).
 - Attachment cap default 40MB; bounded R2 fetch concurrency 4.
 
+### Bounces on the Cloudflare transport
+
+The `send_email` binding has no delivery webhook — there's no Resend-style stream of `email.bounced` events to drive `autoOptOut`. The recovery path is to point a bounce mailbox at a Worker, parse the inbound DSN, and feed the result into your opt-out store.
+
+1. Reserve a bounce address in the domain you're sending from (e.g. `bounces@yourdomain.com`) and route it to your Worker via Cloudflare Email Routing.
+2. Set the outbound envelope-sender / `Return-Path` to that address (most providers accept it on `headers["Return-Path"]`).
+3. Wire the inbound handler:
+
+```ts
+import { createEmailRouter } from "@workkit/mail";
+import { createBounceRoute } from "@workkit/notify/email";
+import { optOut } from "@workkit/notify";
+
+const bounces = createBounceRoute({
+  optOutHook: async (emailAddress, channel, _nid, reason) => {
+    const userId = await lookupUserIdByEmail(emailAddress);
+    if (userId) await optOut(env.DB, userId, channel, null, reason);
+  },
+  // Optional. Fires when a non-DSN message lands on the bounce mailbox
+  // (auto-replies, misrouted threads). Default: silently drop.
+  onNonBounce: (email) => console.warn("non-bounce on bounces@", email.from),
+});
+
+export default {
+  email: createEmailRouter()
+    .match((e) => e.to === "bounces@yourdomain.com", bounces)
+    .default((e) => e.setReject("Unknown recipient"))
+    .handle,
+};
+```
+
+Behavior:
+- **Hard bounce** (RFC 3463 `5.x`) → `optOutHook` fires with `reason: "hard-bounce"`.
+- **Soft bounce** (`4.x`) → no opt-out (transient failures shouldn't drop legit subscribers).
+- **Non-DSN** → `onNonBounce` (or silent no-op).
+- **Hook throws** → error propagates so the MTA can retry.
+
 ### Migrating from the pre-provider shape
 
 The pre-#52 shape took provider-specific options directly on `emailAdapter()`. Wrap them in the new `provider: …` field:

--- a/packages/mail/src/bounces.ts
+++ b/packages/mail/src/bounces.ts
@@ -1,0 +1,200 @@
+/**
+ * RFC 3464 (multipart/report) DSN parser.
+ *
+ * Cloudflare's `send_email` binding has no delivery-webhook surface — the
+ * only way a Worker learns that an outbound message bounced is when the
+ * remote MTA returns a delivery-status notification (DSN) to the sender
+ * domain. With Cloudflare Email Routing pointing at a Worker, that DSN
+ * arrives as a normal inbound email; this helper detects it and turns it
+ * into a structured `BounceInfo` so the caller (typically
+ * `@workkit/notify`'s `createBounceRoute`) can drive opt-out.
+ *
+ * Pure parser — `InboundEmail` in, `BounceInfo | null` out. No I/O.
+ */
+
+import type { InboundEmail, ParsedAttachment } from "./types";
+
+export type BounceKind = "hard" | "soft";
+
+export interface BounceInfo {
+	readonly kind: BounceKind;
+	/** Failed recipient address — parsed from the DSN's `Final-Recipient` field. */
+	readonly recipient: string;
+	/** RFC 3463 enhanced status code (e.g. "5.1.1"), when present. */
+	readonly status?: string;
+	/** Verbatim `Diagnostic-Code` field, when present. */
+	readonly diagnosticCode?: string;
+	/** Original message id (correlation back to the send), when extractable. */
+	readonly originalMessageId?: string;
+	/** `Reporting-MTA` field, when present. */
+	readonly reportingMta?: string;
+}
+
+/**
+ * Detect and parse an RFC 3464 delivery-status notification.
+ *
+ * Returns `null` for non-DSN inbound mail (regular messages, auto-replies,
+ * vacation responders, malformed DSNs). Returns `null` for DSNs whose
+ * `Action` is not `failed` (delayed / relayed / delivered are not bounces).
+ *
+ * Hard vs soft classification follows the RFC 3463 status-code prefix:
+ * `5.x` → hard, `4.x` → soft. Without a status code, falls back to the
+ * SMTP class encoded in `Diagnostic-Code` (e.g. `550` → hard, `421` →
+ * soft). Ambiguous cases default to `soft` — auto-opt-out is destructive,
+ * so we lean conservative.
+ */
+export function parseBounceDSN(email: InboundEmail): BounceInfo | null {
+	const fields = extractDsnFields(email);
+	if (!fields) return null;
+
+	// `Action` is mandatory per RFC 3464. Only `failed` is a bounce.
+	const action = fields.get("action")?.toLowerCase().trim();
+	if (action !== "failed") return null;
+
+	const finalRecipientField = fields.get("final-recipient");
+	if (!finalRecipientField) return null;
+	const recipient = parseRecipient(finalRecipientField);
+	if (!recipient) return null;
+
+	const status = fields.get("status")?.trim();
+	const diagnosticCode = fields.get("diagnostic-code")?.trim();
+	const reportingMta = fields.get("reporting-mta")?.split(";").pop()?.trim();
+	const originalMessageId =
+		fields.get("original-message-id")?.trim() ?? extractOriginalMessageId(email);
+
+	return {
+		kind: classify(status, diagnosticCode),
+		recipient,
+		...(status ? { status } : {}),
+		...(diagnosticCode ? { diagnosticCode } : {}),
+		...(originalMessageId ? { originalMessageId } : {}),
+		...(reportingMta ? { reportingMta } : {}),
+	};
+}
+
+/**
+ * Locate the `message/delivery-status` part of a DSN and parse its
+ * RFC 822-style fields into a lower-cased name-keyed map.
+ *
+ * Looks in three places, in priority order:
+ * 1. An attachment whose content-type contains `delivery-status` (the
+ *    canonical multipart/report layout — postal-mime surfaces this part
+ *    as an attachment).
+ * 2. The plain-text body, if it carries the canonical DSN markers
+ *    (`Final-Recipient:` + `Action:`). Some MTAs collapse single-part
+ *    DSNs into the body when the report-type wrapper is dropped.
+ * 3. Fail closed (return `null`) if neither path yields a DSN.
+ */
+function extractDsnFields(email: InboundEmail): Map<string, string> | null {
+	for (const att of email.attachments) {
+		if (isDeliveryStatusAttachment(att)) {
+			const text = decodeAttachmentText(att);
+			if (text) return parseFields(text);
+		}
+	}
+
+	const body = email.text;
+	if (body && /^\s*Final-Recipient\s*:/im.test(body) && /^\s*Action\s*:/im.test(body)) {
+		return parseFields(body);
+	}
+
+	return null;
+}
+
+function isDeliveryStatusAttachment(att: ParsedAttachment): boolean {
+	return /delivery-status/i.test(att.contentType ?? "");
+}
+
+function decodeAttachmentText(att: ParsedAttachment): string | null {
+	if (typeof att.content === "string") return att.content;
+	try {
+		return new TextDecoder().decode(att.content);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Parse RFC 822-style field lines into a Map. Folded continuation lines
+ * (lines starting with whitespace) are joined onto the previous field
+ * per RFC 5322 §2.2.3. Everything outside the per-recipient field group
+ * (the leading per-message group) and inside it is flattened into the
+ * same map; for the single-recipient DSNs we care about, that's lossless
+ * and matches the RFC 3464 examples.
+ */
+function parseFields(raw: string): Map<string, string> {
+	const out = new Map<string, string>();
+	const lines = raw.replace(/\r\n/g, "\n").split("\n");
+	let current: { name: string; value: string } | null = null;
+
+	const commit = () => {
+		if (current) out.set(current.name, current.value.trim());
+	};
+
+	for (const line of lines) {
+		if (line === "") continue;
+		// Folded continuation: append to the in-flight field.
+		if (/^[ \t]/.test(line) && current) {
+			current.value += ` ${line.trim()}`;
+			continue;
+		}
+		const match = line.match(/^([A-Za-z][A-Za-z0-9-]*)\s*:\s*(.*)$/);
+		const name = match?.[1];
+		const value = match?.[2];
+		if (!name) continue;
+		commit();
+		current = { name: name.toLowerCase(), value: value ?? "" };
+	}
+	commit();
+	return out;
+}
+
+/**
+ * `Final-Recipient` is `address-type; address` (RFC 3464 §2.3.2). The
+ * common type is `rfc822` — a bare email address. Strip surrounding
+ * whitespace and angle brackets so the caller sees a clean address.
+ */
+function parseRecipient(field: string): string | null {
+	const semi = field.indexOf(";");
+	const addr = (semi >= 0 ? field.slice(semi + 1) : field).trim();
+	if (!addr) return null;
+	return addr.replace(/^<|>$/g, "").trim() || null;
+}
+
+/**
+ * Try to recover the original Message-ID. Prefer the explicit
+ * `Original-Message-ID` DSN field (already pulled by the caller); when
+ * that's absent, scan the `message/rfc822` (or `text/rfc822-headers`)
+ * attachment that DSNs typically include for a `Message-ID:` header.
+ */
+function extractOriginalMessageId(email: InboundEmail): string | undefined {
+	for (const att of email.attachments) {
+		const ct = att.contentType ?? "";
+		if (!/rfc822/i.test(ct)) continue;
+		const text = decodeAttachmentText(att);
+		if (!text) continue;
+		// Only inspect the header block — stop at the first blank line.
+		const headerBlock = text.split(/\r?\n\r?\n/, 1)[0] ?? "";
+		const fields = parseFields(headerBlock);
+		const id = fields.get("message-id");
+		if (id) return id;
+	}
+	return undefined;
+}
+
+function classify(status: string | undefined, diagnostic: string | undefined): BounceKind {
+	if (status) {
+		if (status.startsWith("5.")) return "hard";
+		if (status.startsWith("4.")) return "soft";
+	}
+	if (diagnostic) {
+		// `Diagnostic-Code: smtp; 550 5.1.1 …` — the leading 3-digit
+		// SMTP reply code is a reliable secondary signal.
+		const m = diagnostic.match(/\b([45])\d{2}\b/);
+		const cls = m?.[1];
+		if (cls) return cls === "5" ? "hard" : "soft";
+	}
+	// Default: soft. Hard implies "stop sending" (auto-opt-out); when in
+	// doubt we'd rather retry than silently drop a real subscriber.
+	return "soft";
+}

--- a/packages/mail/src/index.ts
+++ b/packages/mail/src/index.ts
@@ -14,6 +14,10 @@ export { composeMessage } from "./compose";
 export { parseEmail } from "./parser";
 export type { ParsedEmail } from "./parser";
 
+// Bounces (RFC 3464 DSN parser)
+export { parseBounceDSN } from "./bounces";
+export type { BounceInfo, BounceKind } from "./bounces";
+
 // Validation
 export { validateAddress, isValidAddress } from "./validation";
 

--- a/packages/mail/tests/bounces.test.ts
+++ b/packages/mail/tests/bounces.test.ts
@@ -1,0 +1,343 @@
+import { describe, expect, it } from "vitest";
+import { parseBounceDSN } from "../src/bounces";
+import { parseEmail } from "../src/parser";
+import type { InboundEmail, ParsedAttachment } from "../src/types";
+
+/**
+ * Build an InboundEmail-shaped object from a raw multipart/report MIME
+ * string by routing through `parseEmail`. The convenience methods
+ * (`forward` / `reply` / `setReject`) are stubbed because `parseBounceDSN`
+ * never calls them — it's a pure parser over the typed fields.
+ */
+async function inboundFromRaw(raw: string): Promise<InboundEmail> {
+	const parsed = await parseEmail(raw);
+	const headers = headersFromRaw(raw);
+	return {
+		from: parsed.from,
+		to: parsed.to,
+		subject: parsed.subject,
+		text: parsed.text,
+		html: parsed.html,
+		headers,
+		rawSize: raw.length,
+		messageId: parsed.messageId,
+		inReplyTo: parsed.inReplyTo,
+		references: parsed.references,
+		date: parsed.date,
+		attachments: parsed.attachments as readonly ParsedAttachment[],
+		forward: async () => {},
+		reply: async () => {},
+		setReject: () => {},
+	};
+}
+
+function headersFromRaw(raw: string): Headers {
+	const out = new Headers();
+	const headerBlock = raw.split(/\r?\n\r?\n/, 1)[0] ?? "";
+	let current: { name: string; value: string } | null = null;
+	const commit = () => {
+		if (current) out.set(current.name, current.value);
+	};
+	for (const line of headerBlock.split(/\r?\n/)) {
+		if (/^[ \t]/.test(line) && current) {
+			current.value += ` ${line.trim()}`;
+			continue;
+		}
+		const m = line.match(/^([A-Za-z][A-Za-z0-9-]*)\s*:\s*(.*)$/);
+		if (!m) continue;
+		commit();
+		current = { name: m[1], value: m[2] };
+	}
+	commit();
+	return out;
+}
+
+const CRLF = "\r\n";
+
+function gmailHardBounce(): string {
+	const boundary = "BoundaryGmail";
+	return [
+		"From: Mail Delivery Subsystem <mailer-daemon@googlemail.com>",
+		"To: sender@entryexit.ai",
+		"Subject: Delivery Status Notification (Failure)",
+		"Date: Mon, 25 Mar 2026 10:00:00 +0000",
+		"MIME-Version: 1.0",
+		`Content-Type: multipart/report; report-type="delivery-status"; boundary="${boundary}"`,
+		"",
+		`--${boundary}`,
+		"Content-Type: text/plain; charset=UTF-8",
+		"",
+		"Address not found.",
+		"",
+		`--${boundary}`,
+		"Content-Type: message/delivery-status",
+		"",
+		"Reporting-MTA: dns; googlemail.com",
+		"",
+		"Final-Recipient: rfc822; nonexistent@example.com",
+		"Action: failed",
+		"Status: 5.1.1",
+		"Diagnostic-Code: smtp; 550 5.1.1 The email account that you tried to reach does not exist.",
+		"",
+		`--${boundary}`,
+		"Content-Type: message/rfc822",
+		"",
+		"From: sender@entryexit.ai",
+		"To: nonexistent@example.com",
+		"Subject: Welcome",
+		"Message-ID: <orig-abc123@entryexit.ai>",
+		"",
+		"hello",
+		`--${boundary}--`,
+	].join(CRLF);
+}
+
+function gmailSoftBounce(): string {
+	const boundary = "BoundarySoft";
+	return [
+		"From: Mail Delivery Subsystem <mailer-daemon@googlemail.com>",
+		"To: sender@entryexit.ai",
+		"Subject: Delivery Status Notification (Delay)",
+		`Content-Type: multipart/report; report-type="delivery-status"; boundary="${boundary}"`,
+		"MIME-Version: 1.0",
+		"",
+		`--${boundary}`,
+		"Content-Type: text/plain",
+		"",
+		"Mailbox temporarily full.",
+		"",
+		`--${boundary}`,
+		"Content-Type: message/delivery-status",
+		"",
+		"Reporting-MTA: dns; googlemail.com",
+		"",
+		"Final-Recipient: rfc822; <full@example.com>",
+		"Action: failed",
+		"Status: 4.2.2",
+		"Diagnostic-Code: smtp; 452 4.2.2 Mailbox full",
+		`--${boundary}--`,
+	].join(CRLF);
+}
+
+function outlookHardBounce(): string {
+	const boundary = "BoundaryOutlook";
+	return [
+		"From: postmaster@outlook.com",
+		"To: sender@entryexit.ai",
+		"Subject: Undeliverable: Your message",
+		`Content-Type: multipart/report; report-type=delivery-status; boundary="${boundary}"`,
+		"MIME-Version: 1.0",
+		"",
+		`--${boundary}`,
+		"Content-Type: text/html",
+		"",
+		"<p>Your message could not be delivered.</p>",
+		"",
+		`--${boundary}`,
+		"Content-Type: message/delivery-status",
+		"",
+		"Reporting-MTA: dns;outlook.com",
+		"",
+		"Final-Recipient: rfc822;gone@hotmail.com",
+		"Action: failed",
+		"Status: 5.0.0",
+		"Diagnostic-Code: smtp;550 5.5.0 Requested action not taken: mailbox unavailable",
+		`--${boundary}--`,
+	].join(CRLF);
+}
+
+function delayedNonBounce(): string {
+	const boundary = "BoundaryDelayed";
+	return [
+		"From: postmaster@example.com",
+		"To: sender@entryexit.ai",
+		"Subject: Delivery delayed",
+		`Content-Type: multipart/report; report-type="delivery-status"; boundary="${boundary}"`,
+		"MIME-Version: 1.0",
+		"",
+		`--${boundary}`,
+		"Content-Type: text/plain",
+		"",
+		"We will keep trying.",
+		"",
+		`--${boundary}`,
+		"Content-Type: message/delivery-status",
+		"",
+		"Reporting-MTA: dns; example.com",
+		"",
+		"Final-Recipient: rfc822; user@example.com",
+		"Action: delayed",
+		"Status: 4.4.7",
+		`--${boundary}--`,
+	].join(CRLF);
+}
+
+function plainNonDsn(): string {
+	return [
+		"From: friend@example.com",
+		"To: sender@entryexit.ai",
+		"Subject: Hi there",
+		"Content-Type: text/plain",
+		"MIME-Version: 1.0",
+		"",
+		"Just saying hi.",
+	].join(CRLF);
+}
+
+function autoReplyNonDsn(): string {
+	return [
+		"From: oof@example.com",
+		"To: sender@entryexit.ai",
+		"Subject: Out of office: Your message",
+		"Auto-Submitted: auto-replied",
+		"Content-Type: text/plain",
+		"MIME-Version: 1.0",
+		"",
+		"I am out of office until next week.",
+	].join(CRLF);
+}
+
+function malformedDsnNoFinalRecipient(): string {
+	const boundary = "BoundaryMalformed";
+	return [
+		"From: postmaster@example.com",
+		"To: sender@entryexit.ai",
+		"Subject: Undeliverable",
+		`Content-Type: multipart/report; report-type="delivery-status"; boundary="${boundary}"`,
+		"MIME-Version: 1.0",
+		"",
+		`--${boundary}`,
+		"Content-Type: text/plain",
+		"",
+		"Bad news.",
+		"",
+		`--${boundary}`,
+		"Content-Type: message/delivery-status",
+		"",
+		"Reporting-MTA: dns; example.com",
+		"",
+		"Action: failed",
+		"Status: 5.5.0",
+		`--${boundary}--`,
+	].join(CRLF);
+}
+
+function noStatusBounceWithDiagnosticHard(): string {
+	const boundary = "BoundaryNoStatus";
+	return [
+		"From: postmaster@example.com",
+		"To: sender@entryexit.ai",
+		"Subject: Undeliverable",
+		`Content-Type: multipart/report; report-type="delivery-status"; boundary="${boundary}"`,
+		"MIME-Version: 1.0",
+		"",
+		`--${boundary}`,
+		"Content-Type: text/plain",
+		"",
+		"Bad news.",
+		"",
+		`--${boundary}`,
+		"Content-Type: message/delivery-status",
+		"",
+		"Reporting-MTA: dns; example.com",
+		"",
+		"Final-Recipient: rfc822; gone@example.com",
+		"Action: failed",
+		"Diagnostic-Code: smtp; 550 user unknown",
+		`--${boundary}--`,
+	].join(CRLF);
+}
+
+describe("parseBounceDSN()", () => {
+	it("parses Gmail hard bounce → kind:'hard', recipient, status, diagnostic, originalMessageId", async () => {
+		const email = await inboundFromRaw(gmailHardBounce());
+		const info = parseBounceDSN(email);
+		expect(info).not.toBeNull();
+		expect(info?.kind).toBe("hard");
+		expect(info?.recipient).toBe("nonexistent@example.com");
+		expect(info?.status).toBe("5.1.1");
+		expect(info?.diagnosticCode).toMatch(/550 5\.1\.1/);
+		expect(info?.reportingMta).toBe("googlemail.com");
+		expect(info?.originalMessageId).toBe("<orig-abc123@entryexit.ai>");
+	});
+
+	it("classifies a 4.x status as soft bounce", async () => {
+		const email = await inboundFromRaw(gmailSoftBounce());
+		const info = parseBounceDSN(email);
+		expect(info?.kind).toBe("soft");
+		expect(info?.recipient).toBe("full@example.com");
+		expect(info?.status).toBe("4.2.2");
+	});
+
+	it("parses Outlook-style hard bounce (no quotes around report-type, html sibling part)", async () => {
+		const email = await inboundFromRaw(outlookHardBounce());
+		const info = parseBounceDSN(email);
+		expect(info?.kind).toBe("hard");
+		expect(info?.recipient).toBe("gone@hotmail.com");
+		expect(info?.status).toBe("5.0.0");
+	});
+
+	it("returns null when Action is 'delayed' (not a bounce)", async () => {
+		const email = await inboundFromRaw(delayedNonBounce());
+		expect(parseBounceDSN(email)).toBeNull();
+	});
+
+	it("returns null for plain inbound mail", async () => {
+		const email = await inboundFromRaw(plainNonDsn());
+		expect(parseBounceDSN(email)).toBeNull();
+	});
+
+	it("returns null for an out-of-office auto-reply (not a DSN even though it's automated)", async () => {
+		const email = await inboundFromRaw(autoReplyNonDsn());
+		expect(parseBounceDSN(email)).toBeNull();
+	});
+
+	it("returns null when the delivery-status part is missing Final-Recipient", async () => {
+		const email = await inboundFromRaw(malformedDsnNoFinalRecipient());
+		expect(parseBounceDSN(email)).toBeNull();
+	});
+
+	it("falls back to Diagnostic-Code's SMTP class when Status is absent", async () => {
+		const email = await inboundFromRaw(noStatusBounceWithDiagnosticHard());
+		const info = parseBounceDSN(email);
+		expect(info?.kind).toBe("hard");
+		expect(info?.recipient).toBe("gone@example.com");
+		expect(info?.status).toBeUndefined();
+	});
+
+	it("defaults to soft when classification is ambiguous (no status, no diagnostic)", async () => {
+		const boundary = "BoundaryAmb";
+		const raw = [
+			"From: postmaster@example.com",
+			"To: sender@entryexit.ai",
+			"Subject: Undeliverable",
+			`Content-Type: multipart/report; report-type="delivery-status"; boundary="${boundary}"`,
+			"MIME-Version: 1.0",
+			"",
+			`--${boundary}`,
+			"Content-Type: text/plain",
+			"",
+			"...",
+			"",
+			`--${boundary}`,
+			"Content-Type: message/delivery-status",
+			"",
+			"Reporting-MTA: dns; example.com",
+			"",
+			"Final-Recipient: rfc822; ambiguous@example.com",
+			"Action: failed",
+			`--${boundary}--`,
+		].join(CRLF);
+		const email = await inboundFromRaw(raw);
+		const info = parseBounceDSN(email);
+		expect(info?.kind).toBe("soft");
+		expect(info?.recipient).toBe("ambiguous@example.com");
+	});
+
+	it("strips angle brackets from Final-Recipient values", async () => {
+		const email = await inboundFromRaw(gmailSoftBounce());
+		const info = parseBounceDSN(email);
+		expect(info?.recipient).not.toContain("<");
+		expect(info?.recipient).not.toContain(">");
+	});
+});

--- a/packages/notify/src/adapters/email/bounce-route.ts
+++ b/packages/notify/src/adapters/email/bounce-route.ts
@@ -1,0 +1,74 @@
+import type { InboundEmail } from "@workkit/mail";
+import { parseBounceDSN } from "@workkit/mail";
+import type { EmailOptOutHook } from "./providers/resend";
+
+export interface BounceRouteOptions {
+	/**
+	 * Called when a hard bounce DSN is parsed. Same shape as the Resend
+	 * provider's `autoOptOut.hook` so consumers can share one implementation
+	 * across both transports. The reason is always `"hard-bounce"`; soft
+	 * bounces don't fire the hook (auto-opting-out on a transient delivery
+	 * failure would silently lose real subscribers).
+	 */
+	readonly optOutHook: EmailOptOutHook;
+	/**
+	 * Optional. Called when an email arrives at the bounce route but isn't
+	 * a DSN — typically a misrouted reply, an auto-responder, or a delayed
+	 * notification. Default: no-op (silently drop). Use this to log or to
+	 * route the message somewhere else.
+	 */
+	readonly onNonBounce?: (email: InboundEmail) => void | Promise<void>;
+}
+
+/**
+ * Build an inbound-email handler that drives `autoOptOut` from RFC 3464
+ * delivery-status notifications. Restores bounce-driven opt-out parity for
+ * the Cloudflare `send_email` transport, which has no delivery-webhook
+ * surface (so the Resend-style provider webhook isn't available — see
+ * `cloudflareEmailProvider`).
+ *
+ * Wire it into `createEmailRouter()` from `@workkit/mail` against whichever
+ * inbound mailbox you've configured for bounces in Cloudflare Email
+ * Routing (commonly `bounces@yourdomain`).
+ *
+ * ```ts
+ * import { createEmailRouter } from "@workkit/mail";
+ * import { createBounceRoute } from "@workkit/notify/email";
+ * import { optOut } from "@workkit/notify";
+ *
+ * const bounces = createBounceRoute({
+ *   optOutHook: async (address, channel, _nid, reason) => {
+ *     const userId = await lookupUserIdByEmail(address);
+ *     if (userId) await optOut(env.DB, userId, channel, null, reason);
+ *   },
+ * });
+ *
+ * export default {
+ *   email: createEmailRouter()
+ *     .match((e) => e.to === "bounces@yourdomain.com", bounces)
+ *     .default((e) => e.setReject("Unknown recipient"))
+ *     .handle,
+ * };
+ * ```
+ *
+ * Errors from `optOutHook` propagate to the caller — Email Routing will
+ * see the rejection and the MTA will retry. If you'd rather swallow
+ * transient hook failures, wrap the hook yourself.
+ */
+export function createBounceRoute(
+	opts: BounceRouteOptions,
+): (email: InboundEmail) => Promise<void> {
+	return async (email) => {
+		const bounce = parseBounceDSN(email);
+		if (!bounce) {
+			await opts.onNonBounce?.(email);
+			return;
+		}
+		// Only hard bounces auto-opt-out. Soft bounces (`Status: 4.x`,
+		// e.g. mailbox full) recover on retry — opting the user out on
+		// the first 4xx would drop legitimate subscribers.
+		if (bounce.kind === "hard") {
+			await opts.optOutHook(bounce.recipient, "email", null, "hard-bounce");
+		}
+	};
+}

--- a/packages/notify/src/adapters/email/index.ts
+++ b/packages/notify/src/adapters/email/index.ts
@@ -13,6 +13,9 @@ export type { CloudflareEmailProviderOptions } from "./providers/cloudflare";
 export { resendEmailProvider } from "./providers/resend";
 export type { ResendEmailProviderOptions, EmailOptOutHook } from "./providers/resend";
 
+export { createBounceRoute } from "./bounce-route";
+export type { BounceRouteOptions } from "./bounce-route";
+
 export { renderEmail, htmlToText } from "./render";
 
 export { loadAttachments } from "./attachments";

--- a/packages/notify/tests/bounce-route.test.ts
+++ b/packages/notify/tests/bounce-route.test.ts
@@ -1,0 +1,130 @@
+import type { InboundEmail, ParsedAttachment } from "@workkit/mail";
+import { parseEmail } from "@workkit/mail";
+import { describe, expect, it, vi } from "vitest";
+import { createBounceRoute } from "../src/adapters/email/bounce-route";
+
+const CRLF = "\r\n";
+
+async function inboundFromRaw(raw: string): Promise<InboundEmail> {
+	const parsed = await parseEmail(raw);
+	return {
+		from: parsed.from,
+		to: parsed.to,
+		subject: parsed.subject,
+		text: parsed.text,
+		html: parsed.html,
+		headers: new Headers(),
+		rawSize: raw.length,
+		messageId: parsed.messageId,
+		inReplyTo: parsed.inReplyTo,
+		references: parsed.references,
+		date: parsed.date,
+		attachments: parsed.attachments as readonly ParsedAttachment[],
+		forward: async () => {},
+		reply: async () => {},
+		setReject: () => {},
+	};
+}
+
+function dsn(opts: { status: string; recipient: string; action?: string }): string {
+	const boundary = "BoundaryDSN";
+	return [
+		"From: postmaster@example.com",
+		"To: bounces@yourdomain.com",
+		"Subject: Delivery Status",
+		`Content-Type: multipart/report; report-type="delivery-status"; boundary="${boundary}"`,
+		"MIME-Version: 1.0",
+		"",
+		`--${boundary}`,
+		"Content-Type: text/plain",
+		"",
+		"...",
+		"",
+		`--${boundary}`,
+		"Content-Type: message/delivery-status",
+		"",
+		"Reporting-MTA: dns; example.com",
+		"",
+		`Final-Recipient: rfc822; ${opts.recipient}`,
+		`Action: ${opts.action ?? "failed"}`,
+		`Status: ${opts.status}`,
+		`--${boundary}--`,
+	].join(CRLF);
+}
+
+function plain(): string {
+	return [
+		"From: friend@example.com",
+		"To: bounces@yourdomain.com",
+		"Subject: hi",
+		"MIME-Version: 1.0",
+		"Content-Type: text/plain",
+		"",
+		"misrouted reply",
+	].join(CRLF);
+}
+
+describe("createBounceRoute()", () => {
+	it("hard bounce → optOutHook called with 'hard-bounce' reason", async () => {
+		const optOutHook = vi.fn().mockResolvedValue(undefined);
+		const handler = createBounceRoute({ optOutHook });
+
+		await handler(await inboundFromRaw(dsn({ status: "5.1.1", recipient: "gone@example.com" })));
+
+		expect(optOutHook).toHaveBeenCalledTimes(1);
+		expect(optOutHook).toHaveBeenCalledWith("gone@example.com", "email", null, "hard-bounce");
+	});
+
+	it("soft bounce → optOutHook NOT called", async () => {
+		const optOutHook = vi.fn().mockResolvedValue(undefined);
+		const handler = createBounceRoute({ optOutHook });
+
+		await handler(await inboundFromRaw(dsn({ status: "4.2.2", recipient: "full@example.com" })));
+
+		expect(optOutHook).not.toHaveBeenCalled();
+	});
+
+	it("non-DSN email → onNonBounce invoked", async () => {
+		const optOutHook = vi.fn();
+		const onNonBounce = vi.fn();
+		const handler = createBounceRoute({ optOutHook, onNonBounce });
+
+		const email = await inboundFromRaw(plain());
+		await handler(email);
+
+		expect(optOutHook).not.toHaveBeenCalled();
+		expect(onNonBounce).toHaveBeenCalledWith(email);
+	});
+
+	it("non-DSN email + no onNonBounce → silent no-op (no throw)", async () => {
+		const optOutHook = vi.fn();
+		const handler = createBounceRoute({ optOutHook });
+
+		await expect(handler(await inboundFromRaw(plain()))).resolves.toBeUndefined();
+		expect(optOutHook).not.toHaveBeenCalled();
+	});
+
+	it("delayed (non-failed Action) → treated as non-bounce; onNonBounce fires", async () => {
+		const optOutHook = vi.fn();
+		const onNonBounce = vi.fn();
+		const handler = createBounceRoute({ optOutHook, onNonBounce });
+
+		await handler(
+			await inboundFromRaw(
+				dsn({ status: "4.4.7", recipient: "user@example.com", action: "delayed" }),
+			),
+		);
+
+		expect(optOutHook).not.toHaveBeenCalled();
+		expect(onNonBounce).toHaveBeenCalledTimes(1);
+	});
+
+	it("hook throws → error propagates so the MTA can retry", async () => {
+		const optOutHook = vi.fn().mockRejectedValue(new Error("D1 down"));
+		const handler = createBounceRoute({ optOutHook });
+
+		await expect(
+			handler(await inboundFromRaw(dsn({ status: "5.7.1", recipient: "spammed@example.com" }))),
+		).rejects.toThrow("D1 down");
+	});
+});


### PR DESCRIPTION
## Summary

The Cloudflare \`send_email\` binding has no delivery-webhook surface, so \`autoOptOut\` was Resend-only. This PR closes that gap end-to-end:

- **#53 (\`@workkit/mail\`, minor)** — New \`parseBounceDSN(email)\` helper. Pure parser over \`InboundEmail\` → \`BounceInfo | null\`. Detects RFC 3464 multipart/report and the single-part-in-body variant; classifies via RFC 3463 status-code prefix (5.x → hard, 4.x → soft) with a \`Diagnostic-Code\` SMTP-class fallback. Returns null for non-DSN mail, non-\`failed\` Action (delayed/relayed/delivered), and malformed DSNs missing \`Final-Recipient\`.
- **#54 (\`@workkit/notify/email\`, minor)** — New \`createBounceRoute({ optOutHook, onNonBounce? })\` helper. Builds an inbound-email handler that runs \`parseBounceDSN\`, then fires \`optOutHook\` on hard bounces only. Same \`EmailOptOutHook\` signature as the Resend provider, so consumers can share one implementation across both transports. Soft bounces no-op (transient failures shouldn't silently drop subscribers); hook errors propagate so the MTA retries.

Docs added to \`apps/docs\` under the notifications guide → "Bounces on the Cloudflare transport".

## Test plan

- [x] \`bun run --cwd packages/mail test\` — 74/74 (10 new for parseBounceDSN: Gmail hard/soft, Outlook hard, delayed-not-bounce, plain inbound, OOO auto-reply, malformed DSN, Diagnostic-Code-only fallback, ambiguous → soft default, angle-bracket stripping).
- [x] \`bun run --cwd packages/mail typecheck\` — clean.
- [x] \`bun run --cwd packages/notify test\` — 180/180 (6 new for createBounceRoute: hard → hook, soft → no-op, non-DSN → onNonBounce, missing onNonBounce → silent, delayed → onNonBounce, hook throws → propagates).
- [x] \`bun run --cwd packages/notify typecheck\` — clean.
- [x] \`maina verify\` per commit — 13 tools, all green.
- [ ] CodeRabbit review.

## Out of scope (per the issue specs)

- Soft-bounce retry tracking — separate signal, separate issue.
- Complaint / feedback-loop (FBL / ARF) parsing — different format.
- Persistent bounce-log storage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)