### PR TITLE
feat(notify/email): SES + Postmark provider stubs (#57)

### DIFF
--- a/.changeset/notify-ses-postmark-stubs.md
+++ b/.changeset/notify-ses-postmark-stubs.md
@@ -1,0 +1,21 @@
+---
+"@workkit/notify": minor
+---
+
+**Add `sesEmailProvider` and `postmarkEmailProvider` stubs to `@workkit/notify/email`.** Mirrors the WhatsApp adapter's existing stub pattern (`twilioWaProvider`, `gupshupWaProvider`) — `send` / `parseWebhook` / `verifySignature` throw `NotImplementedError` with a link to the tracking issue (#57), but the option types, the conformance to `EmailProvider`, and the export surface are stable so a real implementation can drop in without touching the adapter or caller code.
+
+```ts
+import { emailAdapter, sesEmailProvider, postmarkEmailProvider } from "@workkit/notify/email";
+
+// Same emailAdapter, different provider — the adapter is provider-agnostic.
+const ses = emailAdapter({
+  provider: sesEmailProvider({
+    region: "us-east-1",
+    accessKeyId: env.AWS_ACCESS_KEY_ID,
+    secretAccessKey: env.AWS_SECRET_ACCESS_KEY,
+    from: "Reports <reports@entryexit.ai>",
+  }),
+});
+```
+
+Closes #57.

--- a/packages/notify/README.md
+++ b/packages/notify/README.md
@@ -202,6 +202,35 @@ const email = emailAdapter({
 - Hard bounce + complaint → auto opt-out (configurable, default on).
 - Attachment cap default 40MB; bounded R2 fetch concurrency 4.
 
+#### Stubs: AWS SES + Postmark
+
+```ts
+import { emailAdapter, sesEmailProvider, postmarkEmailProvider } from "@workkit/notify/email";
+
+// Either provider conforms to the EmailProvider interface — adapter and
+// caller code don't change between providers; only the construction does.
+const ses = emailAdapter({
+  provider: sesEmailProvider({
+    region: "us-east-1",
+    accessKeyId: env.AWS_ACCESS_KEY_ID,
+    secretAccessKey: env.AWS_SECRET_ACCESS_KEY,
+    from: "Reports <reports@entryexit.ai>",
+  }),
+});
+
+const postmark = emailAdapter({
+  provider: postmarkEmailProvider({
+    serverToken: env.POSTMARK_SERVER_TOKEN,
+    from: "Reports <reports@entryexit.ai>",
+  }),
+});
+```
+
+- Both are **stubs** — `send` / `parseWebhook` / `verifySignature` throw with a link back to [#57](https://github.com/beeeku/workkit/issues/57). The interface is fixed, so a real implementation drops in without touching the adapter or caller code.
+- `sesEmailProvider` will need SigV4 signing + `SendRawEmail`; SES delivery notifications are SNS-wrapped (the webhook handler should decode the SNS envelope first).
+- `postmarkEmailProvider` will need `POST /email` + Postmark's webhook signature scheme.
+- Community implementations welcome.
+
 #### Migrating from the pre-provider shape
 
 ```diff

--- a/packages/notify/src/adapters/email/index.ts
+++ b/packages/notify/src/adapters/email/index.ts
@@ -13,6 +13,12 @@ export type { CloudflareEmailProviderOptions } from "./providers/cloudflare";
 export { resendEmailProvider } from "./providers/resend";
 export type { ResendEmailProviderOptions, EmailOptOutHook } from "./providers/resend";
 
+export { sesEmailProvider } from "./providers/ses";
+export type { SesEmailProviderOptions } from "./providers/ses";
+
+export { postmarkEmailProvider } from "./providers/postmark";
+export type { PostmarkEmailProviderOptions } from "./providers/postmark";
+
 export { createBounceRoute } from "./bounce-route";
 export type { BounceRouteOptions } from "./bounce-route";
 

--- a/packages/notify/src/adapters/email/providers/postmark.ts
+++ b/packages/notify/src/adapters/email/providers/postmark.ts
@@ -1,0 +1,38 @@
+import type { AdapterSendResult, WebhookEvent } from "../../../types";
+import type { EmailProvider } from "../provider";
+
+export interface PostmarkEmailProviderOptions {
+	/** Server token from a Postmark "Server" — narrower scope than the account token. */
+	readonly serverToken: string;
+	/** Default `From:` address — must be a verified sender signature in Postmark. */
+	readonly from: string;
+	/** Optional. Override the API host (rarely needed). */
+	readonly apiUrl?: string;
+}
+
+const NOT_IMPLEMENTED =
+	"postmarkEmailProvider is not implemented yet — see github.com/beeeku/workkit/issues/57 (community contribution welcome)";
+
+/**
+ * Stub for Postmark. The provider interface is fixed (matches the
+ * existing `cloudflareEmailProvider` / `resendEmailProvider`), so a real
+ * `POST /email` + webhook implementation can drop in without touching
+ * the adapter or any caller code.
+ *
+ * Community implementation welcome — see
+ * [#57](https://github.com/beeeku/workkit/issues/57).
+ */
+export function postmarkEmailProvider(_options: PostmarkEmailProviderOptions): EmailProvider {
+	return {
+		name: "postmark",
+		async send(_args): Promise<AdapterSendResult> {
+			throw new Error(NOT_IMPLEMENTED);
+		},
+		async parseWebhook(_req): Promise<WebhookEvent[]> {
+			throw new Error(NOT_IMPLEMENTED);
+		},
+		async verifySignature(_req, _secret): Promise<boolean> {
+			throw new Error(NOT_IMPLEMENTED);
+		},
+	};
+}

--- a/packages/notify/src/adapters/email/providers/ses.ts
+++ b/packages/notify/src/adapters/email/providers/ses.ts
@@ -1,0 +1,45 @@
+import type { AdapterSendResult, WebhookEvent } from "../../../types";
+import type { EmailProvider } from "../provider";
+
+export interface SesEmailProviderOptions {
+	/** AWS region, e.g. `"us-east-1"`. */
+	readonly region: string;
+	/** IAM access key id with `ses:SendRawEmail` (or `ses:SendEmail`) permission. */
+	readonly accessKeyId: string;
+	/** IAM secret access key paired with `accessKeyId`. */
+	readonly secretAccessKey: string;
+	/** Default `From:` address — must be a verified identity in SES. */
+	readonly from: string;
+	/** Optional. Override the API host (e.g. for VPC endpoints). */
+	readonly apiUrl?: string;
+}
+
+const NOT_IMPLEMENTED =
+	"sesEmailProvider is not implemented yet — see github.com/beeeku/workkit/issues/57 (community contribution welcome)";
+
+/**
+ * Stub for AWS SES. The provider interface is fixed (matches the existing
+ * `cloudflareEmailProvider` / `resendEmailProvider`), so a real SigV4 +
+ * `SendRawEmail` implementation can drop in without touching the adapter
+ * or any caller code.
+ *
+ * Community implementation welcome — see
+ * [#57](https://github.com/beeeku/workkit/issues/57).
+ */
+export function sesEmailProvider(_options: SesEmailProviderOptions): EmailProvider {
+	return {
+		name: "ses",
+		async send(_args): Promise<AdapterSendResult> {
+			throw new Error(NOT_IMPLEMENTED);
+		},
+		async parseWebhook(_req): Promise<WebhookEvent[]> {
+			// SES delivery notifications come over SNS — when implemented,
+			// this method should accept the SNS envelope and decode the
+			// inner SES payload.
+			throw new Error(NOT_IMPLEMENTED);
+		},
+		async verifySignature(_req, _secret): Promise<boolean> {
+			throw new Error(NOT_IMPLEMENTED);
+		},
+	};
+}

--- a/packages/notify/tests/email-provider-stubs.test.ts
+++ b/packages/notify/tests/email-provider-stubs.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { postmarkEmailProvider } from "../src/adapters/email/providers/postmark";
+import { sesEmailProvider } from "../src/adapters/email/providers/ses";
+
+describe("sesEmailProvider stub", () => {
+	const provider = sesEmailProvider({
+		region: "us-east-1",
+		accessKeyId: "AKIA0",
+		secretAccessKey: "secret",
+		from: "noreply@example.com",
+	});
+
+	it("constructs without throwing", () => {
+		expect(provider.name).toBe("ses");
+	});
+
+	it("send() throws NotImplementedError citing #57", async () => {
+		await expect(
+			provider.send({
+				to: "user@example.com",
+				subject: "x",
+				html: "<p>x</p>",
+				text: "x",
+				notificationId: "n",
+				deliveryId: "d",
+			}),
+		).rejects.toThrow(/issues\/57/);
+	});
+
+	it("parseWebhook() and verifySignature() throw NotImplementedError", async () => {
+		const req = new Request("https://example.com/webhook");
+		await expect(provider.parseWebhook?.(req)).rejects.toThrow(/issues\/57/);
+		await expect(provider.verifySignature?.(req, "secret")).rejects.toThrow(/issues\/57/);
+	});
+});
+
+describe("postmarkEmailProvider stub", () => {
+	const provider = postmarkEmailProvider({
+		serverToken: "00000000-0000-0000-0000-000000000000",
+		from: "noreply@example.com",
+	});
+
+	it("constructs without throwing", () => {
+		expect(provider.name).toBe("postmark");
+	});
+
+	it("send() throws NotImplementedError citing #57", async () => {
+		await expect(
+			provider.send({
+				to: "user@example.com",
+				subject: "x",
+				html: "<p>x</p>",
+				text: "x",
+				notificationId: "n",
+				deliveryId: "d",
+			}),
+		).rejects.toThrow(/issues\/57/);
+	});
+
+	it("parseWebhook() and verifySignature() throw NotImplementedError", async () => {
+		const req = new Request("https://example.com/webhook");
+		await expect(provider.parseWebhook?.(req)).rejects.toThrow(/issues\/57/);
+		await expect(provider.verifySignature?.(req, "secret")).rejects.toThrow(/issues\/57/);
+	});
+});


### PR DESCRIPTION
## Summary

Mirror the WhatsApp adapter's existing stub pattern (\`twilioWaProvider\`, \`gupshupWaProvider\`) for the email surface. Both new providers throw \`NotImplementedError\` from \`send\` / \`parseWebhook\` / \`verifySignature\`, but the option types and \`EmailProvider\` conformance are stable so a real implementation can drop in without touching the adapter or any caller code.

- \`sesEmailProvider({ region, accessKeyId, secretAccessKey, from })\` — IAM-based SigV4 + \`SendRawEmail\` shape.
- \`postmarkEmailProvider({ serverToken, from })\` — \`POST /email\` + Postmark webhook scheme.

Both throw with a link back to #57 from \`send\`, \`parseWebhook\`, and \`verifySignature\`.

## Test plan

- [x] \`bun run --cwd packages/notify test\` — 186/186 (6 new for stubs)
- [x] \`bun run --cwd packages/notify typecheck\` — clean
- [x] \`maina verify\` — 13 tools, all green
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)