### PR TITLE
refactor(notify): preserve retry semantics through adapter send results (#55)

### DIFF
--- a/.changeset/notify-adapter-retry-semantics.md
+++ b/.changeset/notify-adapter-retry-semantics.md
@@ -1,0 +1,31 @@
+---
+"@workkit/notify": minor
+---
+
+**Preserve retry semantics through adapter `send()` results.** `AdapterSendResult` now carries optional `retryable?: boolean` and `retryStrategy?: RetryStrategy` fields on failures, so the provider's classification of "this is transient, retry with backoff" vs "this is terminal, don't retry" survives the boundary into the dispatch pipeline. See [ADR-002](.maina/decisions/002-notify-adapter-retry-semantics.md).
+
+```ts
+const result = await emailAdapter.send(args);
+if (result.status === "failed") {
+  if (result.retryable === false) {
+    // Terminal failure — don't requeue.
+  } else if (result.retryStrategy?.kind === "exponential") {
+    // Server / queue can apply the recommended backoff.
+  }
+}
+```
+
+Migrated providers in this change:
+
+- **`cloudflareEmailProvider`** — catches `WorkkitError` from `@workkit/mail` (e.g. `DeliveryError` → retryable + exponential, `InvalidAddressError` → terminal) and propagates the metadata via the new `adapterFailedFromError` helper.
+- **`resendEmailProvider`** — classifies failure modes explicitly: network errors and HTTP `5xx`/`429` are retryable (exponential), other `4xx` are terminal, missing-id responses are terminal.
+
+`adapterFailedFromError(err)` is exported from `@workkit/notify` so custom-adapter authors can opt in with one call inside their `catch` blocks instead of inlining the `instanceof WorkkitError` check.
+
+**Out of scope (separate follow-ups):**
+
+- `createNotifyConsumer` does not yet act on the new fields when deciding ack vs retry — that requires touching `@workkit/queue`'s ack/retry contract and is filed separately. Until then, the metadata flows through the result type but isn't yet consumed by the dispatcher.
+- In-app and WhatsApp adapters still return the legacy flat shape. Migrating them is mechanical follow-up work; the new fields are optional so this isn't a breaking gap.
+- Persisting the retry hints in `notification_deliveries` is a schema migration and tracked separately.
+
+Closes #55.

--- a/.maina/decisions/002-notify-adapter-retry-semantics.md
+++ b/.maina/decisions/002-notify-adapter-retry-semantics.md
@@ -1,0 +1,112 @@
+# ADR-002: Preserve retry semantics through `@workkit/notify` adapter results
+
+**Status:** Accepted
+**Date:** 2026-04-20
+**Supersedes:** —
+**Tracks:** [#55](https://github.com/beeeku/workkit/issues/55)
+
+## Context
+
+`AdapterSendResult` (the value every notify adapter — email, in-app, WhatsApp — returns from `send()`) is currently flat:
+
+```ts
+export interface AdapterSendResult {
+  providerId?: string;
+  status: Exclude<DeliveryStatus, "queued" | "duplicate" | "skipped">;
+  error?: string;
+}
+```
+
+When a provider's underlying call fails, the adapter typically catches a `WorkkitError` from `@workkit/mail`, `@workkit/errors`, or its own SDK and converts it to this shape:
+
+```ts
+} catch (err) {
+  return { status: "failed", error: err instanceof Error ? err.message : String(err) };
+}
+```
+
+That conversion **loses the two pieces of metadata `WorkkitError` already carries**:
+
+- `retryable: boolean` — whether the operation should be retried at all.
+- `defaultRetryStrategy: RetryStrategy` — the recommended backoff (`{ kind: "exponential", baseMs, maxMs, maxAttempts }`, etc.).
+
+The pipeline downstream of the adapter (`createNotifyConsumer` → delivery records → queue retry) therefore can't distinguish between "this email failed because the upstream returned 503, please retry with exponential backoff" and "this email failed because the From address is malformed, never retry." The only retry policy in play today is whatever the queue consumer applies uniformly to every failure — which is correct for transient failures and wrong for terminal ones.
+
+## Decision drivers
+
+1. **Errors already know.** `WorkkitError.retryable` and `WorkkitError.defaultRetryStrategy` are the source of truth. The adapter shouldn't have to second-guess them.
+2. **Additive, not breaking.** Custom adapter authors should not be forced to migrate. Existing flat `{ status, error }` results must keep working.
+3. **No cross-package gymnastics.** `@workkit/notify` should not start importing `WorkkitError` *types* in its public signature — that couples every adapter to the error class hierarchy. We surface the *primitive* shapes (`boolean` + `RetryStrategy`) instead.
+4. **Defer queue-policy changes.** The question of whether `createNotifyConsumer` should consult the new fields and call `ack` vs `retry` is a separate decision (touches `@workkit/queue` retry semantics). This ADR scopes only the *transport* of the metadata.
+
+## Options considered
+
+### Option A — Extend `AdapterSendResult` with primitive retry hints
+
+```ts
+interface AdapterSendFailedResult {
+  providerId?: string;
+  status: "failed";
+  error: string;
+  retryable?: boolean;
+  retryStrategy?: RetryStrategy;
+}
+```
+
+- ✅ Additive. Existing adapters keep returning `{ status: "failed", error }` and the new fields default to `undefined`.
+- ✅ No new public type imports — `RetryStrategy` already lives in `@workkit/errors` (already a peer dep of `@workkit/notify`).
+- ✅ Consumers that *do* want the metadata can check it.
+- ❌ Two ways to encode the same information: the legacy stringified `error` plus the new structured fields. Adapter authors have to populate both.
+
+### Option B — Pass the underlying error through
+
+```ts
+interface AdapterSendFailedResult {
+  status: "failed";
+  error: string;
+  cause?: WorkkitError;
+}
+```
+
+- ✅ No information loss — consumer reads `cause.retryable`, `cause.retryStrategy`, `cause.context`, etc.
+- ❌ Forces every consumer of `AdapterSendResult` to depend on `@workkit/errors`'s `WorkkitError` class shape.
+- ❌ Couples the public adapter contract to a *class*, not just a *type* — class identity is brittle across versions of `@workkit/errors` (instanceof checks break when two copies are bundled).
+- ❌ Adapter authors who don't use `@workkit/errors` (e.g. wrapping a third-party SDK that throws plain `Error`) would have to construct a `WorkkitError` just to populate this field.
+
+### Option C — New typed result for failures (`Result`-style discriminated union)
+
+Replace `{ status, error?, providerId? }` with a tagged union: `{ ok: true, providerId } | { ok: false, error, retryable?, retryStrategy? }`.
+
+- ✅ Cleanest type story.
+- ❌ Breaking change for every existing adapter (custom + ours). Per decision driver #2, ruled out for now.
+
+## Decision
+
+**Option A.** Extend `AdapterSendResult` with optional `retryable?: boolean` and `retryStrategy?: RetryStrategy` fields on the failure shape. Update `cloudflareEmailProvider` and `resendEmailProvider` to populate both when they catch a `WorkkitError` (using the existing `WorkkitError.retryable` and `.retryStrategy` accessors). Other adapters (in-app, WhatsApp, custom) are not migrated in the same change — the new fields are optional and they keep their current behavior.
+
+A thin convenience helper `adapterFailedFromError(err)` is added inside `@workkit/notify`'s adapter code to standardize the conversion (catch → `AdapterSendResult`) so adapter authors don't have to inline the `instanceof WorkkitError` check.
+
+## Out of scope (deliberately)
+
+1. **`createNotifyConsumer` retry policy.** The consumer continues to run the dispatch pipeline and surface failures to the queue consumer; it does not yet act on the new `retryable` / `retryStrategy` fields. That requires touching `@workkit/queue`'s ack/retry contract and is filed separately as a follow-up.
+2. **Migration of in-app and WhatsApp adapters.** Their failure paths today either rarely hit `WorkkitError` or wrap their own provider errors. Migrating them is mechanical follow-up work; the new fields stay optional so this isn't a breaking gap.
+3. **Persistence of retry metadata in delivery records.** The `notification_deliveries` table writes `error` (text). Adding `retryable` / `retry_strategy` columns is a schema migration; tracked separately.
+
+## Consequences
+
+### Positive
+
+- The CF + Resend providers stop discarding the retry metadata at the boundary.
+- Future consumers (custom orchestrators, observability dashboards, queue-side retry policy) can read structured retry hints out of `AdapterSendResult` without re-parsing the `error` string.
+- The change is non-breaking for all existing adapters and consumers.
+
+### Negative
+
+- Two-stage rollout: the metadata flows through the result type but isn't yet consumed by `createNotifyConsumer`. Until the consumer-side follow-up lands, the only observable benefit is the structured fields being readable from the result.
+- Two encodings of the same information (`error: string` plus `retryable + retryStrategy`) — by design, but adapter authors must remember to populate both for full fidelity.
+
+### Follow-up issues
+
+- Wire `createNotifyConsumer` (and downstream `@workkit/queue` orchestration) to consult the new fields when deciding to ack vs retry. **NEW.**
+- Migrate the in-app + WhatsApp adapters to populate retry hints from their internal failure modes. **NEW.**
+- Schema migration: add `retryable` + `retry_strategy_kind` columns to `notification_deliveries` so the metadata persists. **NEW.**

--- a/packages/notify/src/adapter-result.ts
+++ b/packages/notify/src/adapter-result.ts
@@ -1,0 +1,35 @@
+import { WorkkitError } from "@workkit/errors";
+import type { AdapterSendResult } from "./types";
+
+/**
+ * Convert any thrown value into a failed `AdapterSendResult`. When the
+ * value is a `WorkkitError`, populates `retryable` and `retryStrategy`
+ * from it; otherwise the structured fields are left undefined and only
+ * `error` (the stringified message) is set. See ADR-002.
+ *
+ * Adapter authors can use this helper in their `catch` blocks to avoid
+ * inlining the `instanceof WorkkitError` check on every provider:
+ *
+ * ```ts
+ * try {
+ *   const { messageId } = await provider.deliver(...);
+ *   return { status: "sent", providerId: messageId };
+ * } catch (err) {
+ *   return adapterFailedFromError(err);
+ * }
+ * ```
+ */
+export function adapterFailedFromError(err: unknown): AdapterSendResult {
+	if (err instanceof WorkkitError) {
+		return {
+			status: "failed",
+			error: err.message,
+			retryable: err.retryable,
+			retryStrategy: err.retryStrategy,
+		};
+	}
+	return {
+		status: "failed",
+		error: err instanceof Error ? err.message : String(err),
+	};
+}

--- a/packages/notify/src/adapters/email/providers/cloudflare.ts
+++ b/packages/notify/src/adapters/email/providers/cloudflare.ts
@@ -1,3 +1,4 @@
+import { adapterFailedFromError } from "../../../adapter-result";
 import type { AdapterSendResult } from "../../../types";
 import type { EmailAttachmentWire, EmailProvider, EmailProviderSendArgs } from "../provider";
 
@@ -54,7 +55,11 @@ export function cloudflareEmailProvider(options: CloudflareEmailProviderOptions)
 				});
 				return { status: "sent", providerId: messageId };
 			} catch (err) {
-				return { status: "failed", error: err instanceof Error ? err.message : String(err) };
+				// `@workkit/mail` throws WorkkitError subclasses (DeliveryError →
+				// retryable, InvalidAddressError → terminal). adapterFailedFromError
+				// preserves their `retryable` and `retryStrategy` so consumers /
+				// queue policy can act on them. See ADR-002.
+				return adapterFailedFromError(err);
 			}
 		},
 	};

--- a/packages/notify/src/adapters/email/providers/resend.ts
+++ b/packages/notify/src/adapters/email/providers/resend.ts
@@ -1,3 +1,4 @@
+import { RetryStrategies } from "@workkit/errors";
 import type { AdapterSendResult, WebhookEvent } from "../../../types";
 import { FromDomainError } from "../errors";
 import type { EmailAttachmentWire, EmailProvider, EmailProviderSendArgs } from "../provider";
@@ -85,7 +86,14 @@ export function resendEmailProvider(options: ResendEmailProviderOptions): EmailP
 					body: JSON.stringify(body),
 				});
 			} catch (err) {
-				return { status: "failed", error: err instanceof Error ? err.message : String(err) };
+				// Network-level failure — DNS, TLS, connection reset. Always
+				// retryable with exponential backoff. See ADR-002.
+				return {
+					status: "failed",
+					error: err instanceof Error ? err.message : String(err),
+					retryable: true,
+					retryStrategy: RetryStrategies.exponential(),
+				};
 			}
 
 			let json: ResendSendResponse | null = null;
@@ -95,13 +103,27 @@ export function resendEmailProvider(options: ResendEmailProviderOptions): EmailP
 				json = null;
 			}
 			if (!resp.ok) {
+				// 5xx and 429 are retryable (server / rate limit); other 4xx
+				// are terminal (auth, validation, malformed payload). See
+				// ADR-002.
+				const transient = resp.status >= 500 || resp.status === 429;
 				return {
 					status: "failed",
 					error: json?.error?.message ?? `resend HTTP ${resp.status} ${resp.statusText}`,
+					retryable: transient,
+					retryStrategy: transient ? RetryStrategies.exponential() : RetryStrategies.none(),
 				};
 			}
 			if (!json?.id) {
-				return { status: "failed", error: "resend response missing id" };
+				// Resend returned 2xx but no id — response-shape regression on
+				// their side. Not safe to retry blindly (we may have already
+				// queued the email server-side); flag as terminal.
+				return {
+					status: "failed",
+					error: "resend response missing id",
+					retryable: false,
+					retryStrategy: RetryStrategies.none(),
+				};
 			}
 			return { status: "sent", providerId: json.id };
 		},

--- a/packages/notify/src/index.ts
+++ b/packages/notify/src/index.ts
@@ -10,6 +10,7 @@ export type { NotifyConsumerOptions, ConsumerLookup } from "./consumer";
 
 // adapters
 export { AdapterRegistry, buildRegistry } from "./adapters";
+export { adapterFailedFromError } from "./adapter-result";
 
 // preferences / opt-out
 export { readPreferences, upsertPreferences } from "./preferences";

--- a/packages/notify/src/types.ts
+++ b/packages/notify/src/types.ts
@@ -100,6 +100,19 @@ export interface AdapterSendResult {
 	providerId?: string;
 	status: Exclude<DeliveryStatus, "queued" | "duplicate" | "skipped">;
 	error?: string;
+	/**
+	 * Optional. Whether the failure should be retried. Adapters that catch
+	 * a `WorkkitError` populate this from `WorkkitError.retryable`; other
+	 * adapters can leave it undefined. See ADR-002.
+	 */
+	retryable?: boolean;
+	/**
+	 * Optional. Recommended backoff strategy for the failure. Adapters that
+	 * catch a `WorkkitError` populate this from `WorkkitError.retryStrategy`.
+	 * Consumers / queue policy can opt into reading this field; today it is
+	 * not yet acted on by `createNotifyConsumer` (see ADR-002 follow-ups).
+	 */
+	retryStrategy?: import("@workkit/errors").RetryStrategy;
 }
 
 export interface WebhookEvent {

--- a/packages/notify/tests/adapter-result.test.ts
+++ b/packages/notify/tests/adapter-result.test.ts
@@ -1,0 +1,63 @@
+import { ServiceUnavailableError, ValidationError, WorkkitError } from "@workkit/errors";
+import type { RetryStrategy } from "@workkit/errors";
+import { describe, expect, it } from "vitest";
+import { adapterFailedFromError } from "../src/adapter-result";
+
+describe("adapterFailedFromError()", () => {
+	it("WorkkitError → preserves retryable + retryStrategy", () => {
+		const err = new ServiceUnavailableError("upstream");
+
+		const result = adapterFailedFromError(err);
+
+		expect(result.status).toBe("failed");
+		expect(result.error).toContain("upstream");
+		expect(result.retryable).toBe(true);
+		expect(result.retryStrategy).toEqual(expect.objectContaining({ kind: "exponential" }));
+	});
+
+	it("non-retryable WorkkitError → retryable: false", () => {
+		const err = new ValidationError("bad input", []);
+
+		const result = adapterFailedFromError(err);
+
+		expect(result.status).toBe("failed");
+		expect(result.retryable).toBe(false);
+		expect(result.retryStrategy).toEqual({ kind: "none" });
+	});
+
+	it("plain Error → status:'failed' + error message; structured fields undefined", () => {
+		const result = adapterFailedFromError(new Error("plain old failure"));
+
+		expect(result.status).toBe("failed");
+		expect(result.error).toBe("plain old failure");
+		expect(result.retryable).toBeUndefined();
+		expect(result.retryStrategy).toBeUndefined();
+	});
+
+	it("non-Error thrown value → stringified", () => {
+		const result = adapterFailedFromError("string thrown directly");
+
+		expect(result.status).toBe("failed");
+		expect(result.error).toBe("string thrown directly");
+		expect(result.retryable).toBeUndefined();
+	});
+
+	it("custom WorkkitError with overridden retryStrategy → preserved", () => {
+		// Subclass to control the retry strategy precisely.
+		class CustomFlaky extends WorkkitError {
+			readonly code = "WORKKIT_INTERNAL" as const;
+			readonly statusCode = 502;
+			readonly retryable = true;
+			readonly defaultRetryStrategy: RetryStrategy = {
+				kind: "fixed",
+				delayMs: 250,
+				maxAttempts: 4,
+			};
+		}
+
+		const result = adapterFailedFromError(new CustomFlaky("test"));
+
+		expect(result.retryable).toBe(true);
+		expect(result.retryStrategy).toEqual({ kind: "fixed", delayMs: 250, maxAttempts: 4 });
+	});
+});

--- a/packages/notify/tests/adapters/email/providers/resend.test.ts
+++ b/packages/notify/tests/adapters/email/providers/resend.test.ts
@@ -61,7 +61,7 @@ describe("resendEmailProvider", () => {
 		expect(body.reply_to).toBe("reply@example.com");
 	});
 
-	it("returns failed on 4xx", async () => {
+	it("returns failed on 4xx (terminal — not retryable)", async () => {
 		(globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
 			new Response(JSON.stringify({ error: { message: "from-domain not verified" } }), {
 				status: 403,
@@ -71,9 +71,34 @@ describe("resendEmailProvider", () => {
 		const result = await provider.send(baseArgs());
 		expect(result.status).toBe("failed");
 		expect(result.error).toContain("from-domain");
+		// 4xx (other than 429) is a terminal failure — no retry value.
+		expect(result.retryable).toBe(false);
+		expect(result.retryStrategy).toEqual({ kind: "none" });
 	});
 
-	it("returns failed when fetch throws", async () => {
+	it("returns failed on 429 with retryable: true (rate-limited)", async () => {
+		(globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+			new Response(JSON.stringify({ error: { message: "rate limited" } }), { status: 429 }),
+		);
+		const provider = resendEmailProvider({ apiKey: "k", from: "x@example.com" });
+		const result = await provider.send(baseArgs());
+		expect(result.status).toBe("failed");
+		expect(result.retryable).toBe(true);
+		expect(result.retryStrategy?.kind).toBe("exponential");
+	});
+
+	it("returns failed on 5xx with retryable: true (transient)", async () => {
+		(globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+			new Response("upstream error", { status: 503 }),
+		);
+		const provider = resendEmailProvider({ apiKey: "k", from: "x@example.com" });
+		const result = await provider.send(baseArgs());
+		expect(result.status).toBe("failed");
+		expect(result.retryable).toBe(true);
+		expect(result.retryStrategy?.kind).toBe("exponential");
+	});
+
+	it("returns failed when fetch throws (network error → retryable)", async () => {
 		(globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(
 			new Error("ENOTFOUND"),
 		);
@@ -81,6 +106,9 @@ describe("resendEmailProvider", () => {
 		const result = await provider.send(baseArgs());
 		expect(result.status).toBe("failed");
 		expect(result.error).toContain("ENOTFOUND");
+		// Network failures (DNS, TLS, connection reset) are always retryable.
+		expect(result.retryable).toBe(true);
+		expect(result.retryStrategy?.kind).toBe("exponential");
 	});
 
 	it("returns failed when response lacks id", async () => {


### PR DESCRIPTION
## Summary

Per [ADR-002](.maina/decisions/002-notify-adapter-retry-semantics.md). \`AdapterSendResult\` gains optional \`retryable?: boolean\` and \`retryStrategy?: RetryStrategy\` on the failure shape so a provider's classification ("transient, retry with backoff" vs "terminal, don't retry") survives the boundary into the dispatch pipeline.

Today these fields aren't yet acted on by \`createNotifyConsumer\` — that requires changing the queue ack/retry contract and is left as a follow-up — but they're now structurally present so consumers / observability dashboards / future queue policies can read them.

## Changes

- **ADR-002** added under \`.maina/decisions/\`. Walks Option A (extend the result), Option B (pass full \`WorkkitError\` through), Option C (\`Result\`-style discriminated union); decision is Option A for additive non-breaking rollout.
- **\`AdapterSendResult\`** gets optional \`retryable\` + \`retryStrategy\`. Existing flat \`{ status, error }\` returns keep working unchanged.
- **\`adapterFailedFromError(err)\`** helper exported from \`@workkit/notify\` — converts a thrown value into the new shape, preserving \`WorkkitError\` metadata when present.
- **\`cloudflareEmailProvider\`** wraps its catch in \`adapterFailedFromError\` — \`@workkit/mail\` throws \`WorkkitError\` subclasses (\`DeliveryError\` → retryable+exponential, \`InvalidAddressError\` → terminal), so the metadata flows automatically.
- **\`resendEmailProvider\`** classifies failure modes explicitly: network errors and HTTP \`5xx\`/\`429\` → retryable+exponential; other \`4xx\` and missing-id responses → terminal.

## Out of scope (separate follow-ups, called out in the ADR)

- \`createNotifyConsumer\` consuming the new fields (touches \`@workkit/queue\`'s ack/retry contract).
- Migrating in-app + WhatsApp adapters.
- Schema migration for \`notification_deliveries\` to persist the new metadata.

## Test plan

- [x] \`bun run --cwd packages/notify test\` — 193/193 (5 new for \`adapterFailedFromError\`, 3 new + 1 reworded for the resend retry classification).
- [x] \`bun run --cwd packages/notify typecheck\` — clean.
- [x] \`maina verify\` — 13 tools, all green.
- [ ] CodeRabbit review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)