### PR TITLE
fix(ratelimit): clamp KV expirationTtl to >= 60s (#108)

### DIFF
--- a/.changeset/ratelimit-kv-ttl-clamp-60.md
+++ b/.changeset/ratelimit-kv-ttl-clamp-60.md
@@ -1,0 +1,7 @@
+---
+"@workkit/ratelimit": patch
+---
+
+**Clamp KV `expirationTtl` to ≥ 60s on all writes.** Cloudflare KV rejects any `expirationTtl` below 60 with `400 Invalid expiration_ttl`. Previously `fixedWindow`, `slidingWindow`, and `quota` wrote TTLs as low as 1s — breaking `wrangler dev` in the last ~minute of any window and violating the documented KV contract. The counter lives slightly past the logical window end, but each entry carries its own `windowStart`, so a stale read is reinterpreted correctly by the next write.
+
+Closes #108.

--- a/packages/ratelimit/src/fixed-window.ts
+++ b/packages/ratelimit/src/fixed-window.ts
@@ -52,7 +52,7 @@ export function fixedWindow(options: FixedWindowOptions): RateLimiter {
 				const ttlSeconds = Math.ceil((windowStart + windowMs - now) / 1000);
 
 				await options.namespace.put(kvKey, JSON.stringify(state), {
-					expirationTtl: Math.max(ttlSeconds, 1),
+					expirationTtl: Math.max(ttlSeconds, 60),
 				});
 			}
 

--- a/packages/ratelimit/src/quota.ts
+++ b/packages/ratelimit/src/quota.ts
@@ -112,7 +112,7 @@ export function quota(options: QuotaOptions): QuotaLimiter {
 					const k = kvKey(w.config.window, w.boundary, key);
 					const ttlSeconds = Math.ceil((w.boundary + w.config.durationMs - now) / 1000);
 					return options.namespace.put(k, JSON.stringify(newState), {
-						expirationTtl: Math.max(ttlSeconds, 1),
+						expirationTtl: Math.max(ttlSeconds, 60),
 					});
 				});
 				await Promise.all(writes);

--- a/packages/ratelimit/src/sliding-window.ts
+++ b/packages/ratelimit/src/sliding-window.ts
@@ -75,7 +75,7 @@ export function slidingWindow(options: SlidingWindowOptions): RateLimiter {
 				const ttlSeconds = Math.ceil((currentWindowStart + windowMs * 2 - now) / 1000);
 
 				await options.namespace.put(currentKey, JSON.stringify(state), {
-					expirationTtl: Math.max(ttlSeconds, 1),
+					expirationTtl: Math.max(ttlSeconds, 60),
 				});
 			}
 

--- a/packages/ratelimit/tests/ttl-clamp.test.ts
+++ b/packages/ratelimit/tests/ttl-clamp.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fixedWindow } from "../src/fixed-window";
+import { quota } from "../src/quota";
+import { slidingWindow } from "../src/sliding-window";
+import { createMockKV } from "./helpers/mock-kv";
+
+// Cloudflare KV rejects expirationTtl below 60 with
+// "400 Invalid expiration_ttl of N. Expiration TTL must be at least 60."
+// Every KV-backed limiter in this package must clamp at write time (issue #108).
+const MIN_KV_TTL = 60;
+
+describe("KV expirationTtl clamp (issue #108)", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2025-01-01T00:00:00.000Z"));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("fixedWindow never writes TTL < 60 near end of a 1m window", async () => {
+		const kv = createMockKV();
+		const putSpy = vi.spyOn(kv, "put");
+		const limiter = fixedWindow({ namespace: kv, limit: 10, window: "1m" });
+
+		// 50s into the minute — naive TTL would be 10.
+		vi.setSystemTime(new Date("2025-01-01T00:00:50.000Z"));
+		await limiter.check("user:1");
+
+		expect(putSpy).toHaveBeenCalled();
+		const opts = putSpy.mock.calls[0]![2] as { expirationTtl: number };
+		expect(opts.expirationTtl).toBeGreaterThanOrEqual(MIN_KV_TTL);
+	});
+
+	it("slidingWindow never writes TTL < 60 for sub-minute windows", async () => {
+		const kv = createMockKV();
+		const putSpy = vi.spyOn(kv, "put");
+		// 30s window → TTL formula yields values below 60 near end of window.
+		const limiter = slidingWindow({ namespace: kv, limit: 10, window: "30s" });
+
+		// 25s into the 30s window — naive TTL = (30*2 - 25) = 35.
+		vi.setSystemTime(new Date("2025-01-01T00:00:25.000Z"));
+		await limiter.check("user:1");
+
+		expect(putSpy).toHaveBeenCalled();
+		const opts = putSpy.mock.calls[0]![2] as { expirationTtl: number };
+		expect(opts.expirationTtl).toBeGreaterThanOrEqual(MIN_KV_TTL);
+	});
+
+	it("quota never writes TTL < 60 near end of any window", async () => {
+		const kv = createMockKV();
+		const putSpy = vi.spyOn(kv, "put");
+		const q = quota({ namespace: kv, limits: [{ window: "1m", limit: 10 }] });
+
+		// 50s into the minute — naive TTL would be 10.
+		vi.setSystemTime(new Date("2025-01-01T00:00:50.000Z"));
+		await q.check("user:1");
+
+		expect(putSpy).toHaveBeenCalled();
+		for (const call of putSpy.mock.calls) {
+			const opts = call[2] as { expirationTtl?: number } | undefined;
+			if (opts?.expirationTtl !== undefined) {
+				expect(opts.expirationTtl).toBeGreaterThanOrEqual(MIN_KV_TTL);
+			}
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- Clamp `expirationTtl` to `Math.max(ttlSeconds, 60)` in `fixedWindow`, `slidingWindow`, **and** `quota` — Cloudflare KV rejects any `expirationTtl < 60` with `400 Invalid expiration_ttl`.
- Adds `tests/ttl-clamp.test.ts` with 3 regression tests that spy on KV `put` and assert TTL ≥ 60 at end-of-window + for sub-minute sliding windows.
- Issue #108 called out `fixedWindow` / `slidingWindow` / `composite`; `composite` has no KV write — `quota.ts:115` does, and was missed by the issue.

## Test plan

- [x] `bun run test` — 93/93 pass (10 test files)
- [x] `bun run typecheck` clean
- [x] `maina verify` — 13 tools, passed
- [x] Constitution: diff-only fix, tests precede implementation (TDD), patch changeset included

Closes #108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `400 Invalid expiration_ttl` errors by clamping Cloudflare KV expiration time to a minimum of 60 seconds across all rate-limiting algorithms. Resolves issues in development environments near the end of time windows.

* **Tests**
  * Added comprehensive test coverage for TTL clamping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->