### PR TITLE
feat(realtime): SSE-over-Durable-Objects broker + fetch-based client

### DIFF
--- a/.changeset/realtime-initial.md
+++ b/.changeset/realtime-initial.md
@@ -1,0 +1,49 @@
+---
+"@workkit/realtime": minor
+---
+
+**New package: `@workkit/realtime` — SSE-over-Durable-Objects broadcast primitive for Cloudflare Workers.**
+
+Closes the gap called out at `packages/notify/src/adapters/inapp/sse.ts:11` — the single-isolate SSE helper there explicitly defers multi-isolate fan-out to "a future Durable-Object-backed adapter." This is that adapter.
+
+Server side:
+
+```ts
+import { createBroker, publish } from "@workkit/realtime";
+
+export const SseBroker = createBroker({
+  authorize: async (channel, request, env) => {
+    // return a principal or null to deny
+  },
+  replayBufferSize: 50,         // default
+  maxSubscribersPerChannel: 1000, // default
+  heartbeatMs: 30_000,           // default
+});
+
+// From any Worker handler:
+await publish(env.SSE_BROKER, `run:${runId}`, "run.stage", { stage: "verify" });
+```
+
+Client side (`@workkit/realtime/client` subpath):
+
+```ts
+import { subscribe } from "@workkit/realtime/client";
+
+const sub = subscribe(`/sse/run:${runId}`, {
+  onEvent: (event, data, id) => { /* update DOM */ },
+  onReconnect: (attempt) => { /* optional */ },
+  backoff: { initialMs: 500, maxMs: 10_000 },
+  fallbackPollingUrl: `/poll/run/${runId}`,
+  pollingAfterMs: 45_000,
+});
+```
+
+Design highlights (see `adr/0005-realtime-sse-over-durable-objects-broker.md`):
+
+- One Durable Object per channel — addressed via `singleton(namespace, channelName)` from `@workkit/do`.
+- In-memory ring buffer replay keyed by `Last-Event-ID` header or `lastEventId` query param.
+- `authorize()` returning `null` (or throwing) → HTTP 403 on subscribe.
+- Channel name validated against `^[a-zA-Z0-9:_.-]{1,128}$` by default.
+- No WebSocket transport in v1; polling fallback in the client covers proxy strip scenarios.
+
+Tracks #111.

--- a/.maina/features/010-realtime/plan.md
+++ b/.maina/features/010-realtime/plan.md
@@ -14,7 +14,7 @@ New package `packages/realtime/` following the `@workkit/ratelimit` shape (same 
 - `publish(namespace, channel, event, data)` — convenience wrapper that does `singleton(namespace, channel).fetch("/publish", …)`.
 
 **Client side (subpath `./client`):**
-- `subscribe(url, opts)` — wraps `EventSource`, tracks `lastEventId`, applies backoff on `onerror`, and (if `pollingAfterMs` configured) swaps to a polling loop against `opts.fallbackPollingUrl`.
+- `subscribe(url, opts)` — wraps `fetch` + `ReadableStream` (uniform across browser/Bun/Node), tracks `lastEventId`, applies exponential backoff on stream end/error, and (if `pollingAfterMs` configured) swaps to a polling loop against `opts.fallbackPollingUrl`.
 
 ### Integration points
 
@@ -74,7 +74,7 @@ New package `packages/realtime/` following the `@workkit/ratelimit` shape (same 
 - **Unit (pure):** `framing.ts`, `ring-buffer.ts` — no runtime deps, direct `bun test`.
 - **Broker:** instantiate the DO class with a `createMockDO()`-backed `DurableObjectState`, call its `fetch()` with synthetic requests, assert stream output + status codes. Use `TransformStream` tee or a simple collector to snapshot subscriber writes.
 - **Publish helper:** mock a `DurableObjectNamespace` with an in-process stub that records the fetch URL + body.
-- **Client:** mock `globalThis.EventSource` with a fake that emits scripted events + `error` to verify backoff; use `vi.useFakeTimers()` for backoff assertions.
+- **Client:** mock `globalThis.fetch` with a helper that returns controllable `ReadableStream`s (push/close/error); assert reconnect URL + headers carry `lastEventId` and that `unsubscribe` aborts in-flight fetches.
 - **No integration test against `wrangler dev`** in v1 — that belongs in maina-cloud's first-consumer E2E suite.
 - **`@workkit/testing` wired** in devDependencies to satisfy constitution rule #3, even if only used in broker.test.ts.
 

--- a/.maina/features/010-realtime/plan.md
+++ b/.maina/features/010-realtime/plan.md
@@ -24,7 +24,7 @@ New package `packages/realtime/` following the `@workkit/ratelimit` shape (same 
 | `scheduleAlarm` / `createAlarmHandler` | `@workkit/do` | Optional idle-eviction alarm (release subscriber map after N min of no publish). |
 | `createMockDO()` | `@workkit/testing` | Broker unit test: storage mock + operation tracking. |
 | SSE framing pattern | `packages/notify/src/adapters/inapp/sse.ts:122-160` | Reference for `data:` / `: keepalive` line shape. Not imported — duplicated in `framing.ts`. |
-| `authorize` hook shape | `@workkit/auth` `createAuthHandler` | Match `(req, env) => Promise<T | null>` return-null-means-deny pattern, extended to include `channel`. |
+| `authorize` hook shape | `@workkit/auth` `createAuthHandler` | Match `(req, env) => Promise<T \| null>` return-null-means-deny pattern, extended to include `channel`. |
 
 ## Key Technical Decisions
 

--- a/.maina/features/010-realtime/plan.md
+++ b/.maina/features/010-realtime/plan.md
@@ -1,52 +1,93 @@
-# Implementation Plan
+# Implementation Plan — @workkit/realtime
 
 > HOW only — see spec.md for WHAT and WHY.
 
 ## Architecture
 
-What is the technical approach? How does it fit into existing architecture?
-Where are the integration points with existing code?
+New package `packages/realtime/` following the `@workkit/ratelimit` shape (same build, same constitution profile).
 
-- Pattern: [NEEDS CLARIFICATION]
-- Integration points: [NEEDS CLARIFICATION]
+**Server side (default export):**
+- `createBroker(config)` → returns a class implementing `DurableObject`. Holds `Map<channel, Set<Writer>>` for active subscribers and `Map<channel, RingBuffer>` for replay. The DO instance is channel-scoped via `singleton(namespace, channel)` — each active channel is its own DO.
+- DO's `fetch(request)` routes internally:
+  - `GET /subscribe` — returns a `ReadableStream<Uint8Array>` with `text/event-stream`, after calling `authorize(channel, request, env)`. Replays buffered events past `Last-Event-ID` before going live.
+  - `POST /publish` — reads the event JSON, assigns a monotonic id, appends to ring buffer, fans out to every writer, returns `{ delivered: number }`.
+- `publish(namespace, channel, event, data)` — convenience wrapper that does `singleton(namespace, channel).fetch("/publish", …)`.
+
+**Client side (subpath `./client`):**
+- `subscribe(url, opts)` — wraps `EventSource`, tracks `lastEventId`, applies backoff on `onerror`, and (if `pollingAfterMs` configured) swaps to a polling loop against `opts.fallbackPollingUrl`.
+
+### Integration points
+
+| Primitive | Source | Usage |
+|---|---|---|
+| `singleton(namespace, channel)` | `@workkit/do` | Channel → DO stub lookup. |
+| `scheduleAlarm` / `createAlarmHandler` | `@workkit/do` | Optional idle-eviction alarm (release subscriber map after N min of no publish). |
+| `createMockDO()` | `@workkit/testing` | Broker unit test: storage mock + operation tracking. |
+| SSE framing pattern | `packages/notify/src/adapters/inapp/sse.ts:122-160` | Reference for `data:` / `: keepalive` line shape. Not imported — duplicated in `framing.ts`. |
+| `authorize` hook shape | `@workkit/auth` `createAuthHandler` | Match `(req, env) => Promise<T | null>` return-null-means-deny pattern, extended to include `channel`. |
 
 ## Key Technical Decisions
 
-What libraries, patterns, or approaches? WHY these and not alternatives?
-
-- [NEEDS CLARIFICATION]
+1. **Per-channel DO via `singleton`** — reuses `@workkit/do` instead of reimplementing `idFromName`. Channels hibernate independently.
+2. **Ring buffer is a plain `{ id, event, data }[]` with a max length** — O(1) push, O(n) replay where n ≤ `replayBufferSize`. No heap, no sorted structure needed.
+3. **Monotonic id is a DO-local counter** — scoped per broker instance; resets only when the DO evicts. Clients that see an id decrease on reconnect know their buffer was dropped and can surface a "resync" event if they want.
+4. **Writers held as `{ id, write(chunk), close() }`** — same shape as notify's `SseSubscriber`, purpose-built for the DO broker.
+5. **`authorize` signature:** `(channel: string, request: Request, env: Env) => Promise<unknown | null>` — null = 403, non-null = allow (optionally typed by the caller for their own use).
+6. **Failure isolation:** if one writer's `controller.enqueue` throws, remove that writer and continue fan-out — same pattern as notify's `sse.ts:39-49`.
+7. **No storage writes on the publish hot path** — replay buffer lives in DO memory.
+8. **Standard Schema (not Zod) for config validation** — constitution rule #2. Config is small enough we'll do a hand-written typed check, no runtime validator dep.
 
 ## Files
 
 | File | Purpose | New/Modified |
-|------|---------|-------------|
-| [NEEDS CLARIFICATION] | | |
-
-## Tasks
-
-TDD: every implementation task must have a preceding test task.
-
-- [ ] [NEEDS CLARIFICATION] Break down into small, testable tasks.
+|---|---|---|
+| `packages/realtime/package.json` | Package manifest; declare deps on `@workkit/do`, `@workkit/testing`; single `.` export + `./client` subpath | New |
+| `packages/realtime/tsconfig.json` | Standard package tsconfig | New |
+| `packages/realtime/bunup.config.ts` | Build config mirroring ratelimit | New |
+| `packages/realtime/src/index.ts` | Re-exports `createBroker`, `publish`, types | New |
+| `packages/realtime/src/framing.ts` | SSE line encoder — pure, no deps | New |
+| `packages/realtime/src/ring-buffer.ts` | Bounded replay buffer with `since(id)` slice | New |
+| `packages/realtime/src/broker.ts` | `createBroker()` factory → DO class | New |
+| `packages/realtime/src/publish.ts` | `publish(namespace, channel, event, data)` helper | New |
+| `packages/realtime/src/client.ts` | Browser `subscribe(url, opts)` wrapper | New |
+| `packages/realtime/src/types.ts` | Shared types (`BrokerConfig`, `AuthorizeHook`, `RealtimeEvent`, `SubscribeOptions`) | New |
+| `packages/realtime/tests/framing.test.ts` | Framing round-trip, edge cases (multi-line data, unicode) | New |
+| `packages/realtime/tests/ring-buffer.test.ts` | Bounded growth, `since()` correctness, id monotonicity | New |
+| `packages/realtime/tests/broker.test.ts` | Authorize deny, subscribe flow, publish fan-out, replay-on-reconnect via `createMockDO` | New |
+| `packages/realtime/tests/publish.test.ts` | `publish` helper calls DO stub correctly; error surface | New |
+| `packages/realtime/tests/client.test.ts` | Reconnect with `Last-Event-ID`, polling fallback swap | New |
+| `adr/0005-realtime-sse-over-durable-objects-broker.md` | ADR — why per-channel DO + in-memory ring + no WebSocket in v1 | New |
+| `.changeset/realtime-initial.md` | Changeset for new package | New |
 
 ## Failure Modes
 
-What can go wrong? How do we handle it gracefully?
-
-- [NEEDS CLARIFICATION]
+- **DO eviction mid-session** → replay buffer lost. Client sees `Last-Event-ID` ignored (id counter reset); handled by client surfacing a "resync" event or full reload. Documented.
+- **Slow subscriber / back-pressure** → `controller.enqueue` queues in memory. Cap via per-writer max queued bytes? **v1: no cap, trust SSE stream back-pressure**. Revisit if we see runaway memory.
+- **`authorize()` throws** → treat as deny, log via `console.error`? No — constitution rule #7 forbids `console.log` in src. Return 403 and swallow. Test asserts this.
+- **Proxy strips SSE** → client never receives events. `subscribe()` times out via heartbeat-miss detection, swaps to polling.
+- **Flood publisher** → one channel's publish rate exhausts DO wall time. Fire-and-forget, no back-pressure on publisher. Documented as a v1 limitation.
+- **Channel-name injection** → validated at subscribe (`^[a-zA-Z0-9:_.-]{1,128}$`). Reject with 400.
+- **Concurrent subscriber cap exceeded** → 429 response. Per spec's resolved-value cap of 1000/channel.
 
 ## Testing Strategy
 
-Unit tests, integration tests, or both? What mocks are needed?
+- **Unit (pure):** `framing.ts`, `ring-buffer.ts` — no runtime deps, direct `bun test`.
+- **Broker:** instantiate the DO class with a `createMockDO()`-backed `DurableObjectState`, call its `fetch()` with synthetic requests, assert stream output + status codes. Use `TransformStream` tee or a simple collector to snapshot subscriber writes.
+- **Publish helper:** mock a `DurableObjectNamespace` with an in-process stub that records the fetch URL + body.
+- **Client:** mock `globalThis.EventSource` with a fake that emits scripted events + `error` to verify backoff; use `vi.useFakeTimers()` for backoff assertions.
+- **No integration test against `wrangler dev`** in v1 — that belongs in maina-cloud's first-consumer E2E suite.
+- **`@workkit/testing` wired** in devDependencies to satisfy constitution rule #3, even if only used in broker.test.ts.
 
-- [NEEDS CLARIFICATION]
+## Tasks
 
+TDD order (tests precede impl). See tasks.md for the full breakdown and dependencies.
 
 ## Wiki Context
 
 ### Related Modules
 
-- **src** (69 entities) — `modules/src.md`
+- **src** (69 entities) — `modules/src.md` (scaffolded default; re-evaluate after wiki recompile post-merge)
 
 ### Suggestions
 
-- Module 'src' already has 69 entities — consider extending it
+- Run `maina wiki compile` after merge to index the new package's public API.

--- a/.maina/features/010-realtime/plan.md
+++ b/.maina/features/010-realtime/plan.md
@@ -1,0 +1,52 @@
+# Implementation Plan
+
+> HOW only — see spec.md for WHAT and WHY.
+
+## Architecture
+
+What is the technical approach? How does it fit into existing architecture?
+Where are the integration points with existing code?
+
+- Pattern: [NEEDS CLARIFICATION]
+- Integration points: [NEEDS CLARIFICATION]
+
+## Key Technical Decisions
+
+What libraries, patterns, or approaches? WHY these and not alternatives?
+
+- [NEEDS CLARIFICATION]
+
+## Files
+
+| File | Purpose | New/Modified |
+|------|---------|-------------|
+| [NEEDS CLARIFICATION] | | |
+
+## Tasks
+
+TDD: every implementation task must have a preceding test task.
+
+- [ ] [NEEDS CLARIFICATION] Break down into small, testable tasks.
+
+## Failure Modes
+
+What can go wrong? How do we handle it gracefully?
+
+- [NEEDS CLARIFICATION]
+
+## Testing Strategy
+
+Unit tests, integration tests, or both? What mocks are needed?
+
+- [NEEDS CLARIFICATION]
+
+
+## Wiki Context
+
+### Related Modules
+
+- **src** (69 entities) — `modules/src.md`
+
+### Suggestions
+
+- Module 'src' already has 69 entities — consider extending it

--- a/.maina/features/010-realtime/spec-tests.ts
+++ b/.maina/features/010-realtime/spec-tests.ts
@@ -1,0 +1,4 @@
+import { describe, expect, it } from "bun:test";
+
+describe("Feature: realtime", () => {
+});

--- a/.maina/features/010-realtime/spec-tests.ts
+++ b/.maina/features/010-realtime/spec-tests.ts
@@ -1,4 +1,0 @@
-import { describe, expect, it } from "bun:test";
-
-describe("Feature: realtime", () => {
-});

--- a/.maina/features/010-realtime/spec.md
+++ b/.maina/features/010-realtime/spec.md
@@ -74,8 +74,8 @@ Constitution rule #4 requires a single `src/index.ts`; subpaths via the `exports
 ### 6. New package, not an adapter in `@workkit/notify`
 Notify is *deliver-to-user* (retryable, provider-backed). Realtime is *broadcast-to-topic* (fire-and-forget, ephemeral). Different failure model, different consumer (UI vs. domain code), different future (realtime earns WebSocket; notify earns more providers). Merging would muddy both.
 
-## Open Questions
+## Resolved Questions
 
-- **Max concurrent subscribers per channel** — SSE on DO can't hibernate an active response stream, so each subscriber holds the DO awake. Do we enforce a cap? *Proposed:* soft cap at 1000/channel, configurable, 429 beyond. Resolve before implement.
-- **Heartbeat cadence default** — notify uses 30s. Same default here? *Proposed:* yes, match.
-- **Channel name validation** — regex or free-form string? *Proposed:* `^[a-zA-Z0-9:_.-]{1,128}$` to prevent path traversal in the subscribe URL.
+- **Max concurrent subscribers per channel** — soft cap at 1000/channel, configurable via `maxSubscribersPerChannel`, 429 beyond.
+- **Heartbeat cadence** — 30s default (`DEFAULT_HEARTBEAT_MS`), matching notify.
+- **Channel name validation** — `/^[a-zA-Z0-9:_.-]{1,128}$/` default (`DEFAULT_CHANNEL_PATTERN`), configurable via `channelPattern`.

--- a/.maina/features/010-realtime/spec.md
+++ b/.maina/features/010-realtime/spec.md
@@ -13,12 +13,12 @@ Without this primitive, every Workkit-built app that needs live UI (maina-cloud 
 ## Target User
 
 - **Primary:** Workers application developers who need live UI updates and already use other `@workkit/*` primitives. First consumer: `mainahq/maina-cloud` dashboard-v1 (spec: `mainahq/maina-cloud/.maina/specs/001-dashboard-v1/realtime.md`).
-- **Secondary:** CLI consumers (`mainahq/maina` — `maina run follow <runId>`) using the client helper over plain `fetch`/EventSource in a Node context.
+- **Secondary:** CLI consumers (`mainahq/maina` — `maina run follow <runId>`) using the client helper in a Node context (no `EventSource` dependency — the client is `fetch`+stream based).
 
 ## User Stories
 
 - As a Worker handler, I want to publish an event to a channel with one call and have every active subscriber receive it within ~100ms.
-- As a browser client, I want to subscribe to a channel via `EventSource`, survive a network drop, and replay missed events on reconnect via `Last-Event-ID`.
+- As a browser client, I want to subscribe to a channel (via the package's `fetch`+stream client), survive a network drop, and replay missed events on reconnect via `Last-Event-ID`.
 - As the app owner, I want to reject unauthorized subscribes via a per-request hook that sees the channel name, the `Request`, and the `Env`.
 - As an operator, I want connections behind an SSE-stripping proxy to fall back to polling without client code changes.
 

--- a/.maina/features/010-realtime/spec.md
+++ b/.maina/features/010-realtime/spec.md
@@ -1,0 +1,45 @@
+# Feature: [Name]
+
+## Problem Statement
+
+What specific problem does this solve? Who experiences it? What happens if we don't solve it?
+
+- [NEEDS CLARIFICATION] Define the problem clearly.
+
+## Target User
+
+Who benefits? What is their current workflow? What frustrates them about it?
+
+- Primary: [NEEDS CLARIFICATION]
+- Secondary: [NEEDS CLARIFICATION]
+
+## User Stories
+
+- As a [role], I want [capability] so that [benefit].
+
+## Success Criteria
+
+How do we know this works? Every criterion must be testable — if you can't write
+an assertion for it, the requirement isn't clear enough.
+
+- [ ] [NEEDS CLARIFICATION] Define measurable, testable criteria.
+
+## Scope
+
+### In Scope
+
+- [NEEDS CLARIFICATION] What this feature does.
+
+### Out of Scope
+
+- [NEEDS CLARIFICATION] What this feature explicitly does NOT do (prevents over-building).
+
+## Design Decisions
+
+Key choices made and WHY. Record tradeoffs — future you will thank you.
+
+- [NEEDS CLARIFICATION] What alternatives were considered? Why was this one chosen?
+
+## Open Questions
+
+- [NEEDS CLARIFICATION] List ambiguities. Every question here must be resolved before implementation.

--- a/.maina/features/010-realtime/spec.md
+++ b/.maina/features/010-realtime/spec.md
@@ -1,45 +1,81 @@
-# Feature: [Name]
+# Feature: @workkit/realtime — SSE-over-Durable-Objects broadcast primitive
+
+Tracks: #111
 
 ## Problem Statement
 
-What specific problem does this solve? Who experiences it? What happens if we don't solve it?
+Cloudflare Workers isolates are ephemeral — a subscriber connected to isolate A cannot receive an event published from isolate B, because no cross-isolate in-memory state exists. The only way to hold a shared subscriber list across a Worker deployment is a Durable Object.
 
-- [NEEDS CLARIFICATION] Define the problem clearly.
+Today `packages/notify/src/adapters/inapp/sse.ts:11` already ships a single-isolate SSE helper and explicitly defers multi-isolate fan-out to *"a future Durable-Object-backed adapter"*. That adapter is this package.
+
+Without this primitive, every Workkit-built app that needs live UI (maina-cloud dashboard, `maina run follow`, future deploy dashboard) re-solves the same DO + SSE + reconnect + replay problem. Consolidating into one tested package removes that duplication and gives a single back-compat story for DO bindings + migrations.
 
 ## Target User
 
-Who benefits? What is their current workflow? What frustrates them about it?
-
-- Primary: [NEEDS CLARIFICATION]
-- Secondary: [NEEDS CLARIFICATION]
+- **Primary:** Workers application developers who need live UI updates and already use other `@workkit/*` primitives. First consumer: `mainahq/maina-cloud` dashboard-v1 (spec: `mainahq/maina-cloud/.maina/specs/001-dashboard-v1/realtime.md`).
+- **Secondary:** CLI consumers (`mainahq/maina` — `maina run follow <runId>`) using the client helper over plain `fetch`/EventSource in a Node context.
 
 ## User Stories
 
-- As a [role], I want [capability] so that [benefit].
+- As a Worker handler, I want to publish an event to a channel with one call and have every active subscriber receive it within ~100ms.
+- As a browser client, I want to subscribe to a channel via `EventSource`, survive a network drop, and replay missed events on reconnect via `Last-Event-ID`.
+- As the app owner, I want to reject unauthorized subscribes via a per-request hook that sees the channel name, the `Request`, and the `Env`.
+- As an operator, I want connections behind an SSE-stripping proxy to fall back to polling without client code changes.
 
 ## Success Criteria
 
-How do we know this works? Every criterion must be testable — if you can't write
-an assertion for it, the requirement isn't clear enough.
-
-- [ ] [NEEDS CLARIFICATION] Define measurable, testable criteria.
+- [ ] `createBroker({ authorize, replayBufferSize })` returns a DO class that handles `POST /publish` and `GET /subscribe?channel=<name>` on its stub fetch.
+- [ ] `publish(namespace, channel, event, data)` fans out to every active subscriber of `channel` with a monotonic `id:` within one DO RPC.
+- [ ] `authorize()` returning `null` produces HTTP 403 on the subscribe response; a thrown error is treated as deny.
+- [ ] Reconnect with `Last-Event-ID: N` replays every buffered event with `id > N` in order before resuming live delivery, bounded by `replayBufferSize`.
+- [ ] `subscribe(url, opts)` (client) reconnects with exponential backoff, persists `lastEventId` across reconnects, and calls `fallbackToPolling` after `opts.pollingAfterMs` of continuous failures.
+- [ ] Broker survives zero-subscriber idle: DO evicts, next subscribe re-creates; callers see no error.
+- [ ] Package passes `bun run constitution:check` (including the `@workkit/testing` wiring rule).
+- [ ] Unit + integration test coverage: framing, ring buffer, broker state, publish, client reconnect, authorize.
 
 ## Scope
 
-### In Scope
+### In Scope (v1)
 
-- [NEEDS CLARIFICATION] What this feature does.
+- DO broker factory with per-channel fan-out, keyed by channel name via `singleton(namespace, channel)`.
+- SSE line framing (`event:`, `id:`, `data:`, heartbeat `:`).
+- In-memory ring buffer per channel (LRU-trimmed to `replayBufferSize`).
+- `Last-Event-ID` replay on subscribe.
+- Per-channel `authorize(channel, request, env)` hook.
+- Browser client: `subscribe(url, opts)` with backoff + `Last-Event-ID` persistence + optional polling fallback URL.
+- Test harness: broker unit tests via `createMockDO`; framing + ring buffer are pure.
 
-### Out of Scope
+### Out of Scope (v1)
 
-- [NEEDS CLARIFICATION] What this feature explicitly does NOT do (prevents over-building).
+- **WebSocket transport** — SSE + polling fallback covers maina's surface; WebSocket belongs in v2 and earns a new ADR.
+- **Cross-region persistence** — DO storage write on every publish inverts the fire-and-forget contract. If the DO evicts, replay is lost; reload is the documented recovery.
+- **At-least-once delivery** — not guaranteed. Delivery is best-effort + bounded replay.
+- **Presence / member lists** — future; not required for the first-consumer surface.
+- **Channel schemas or typed event validation** — callers stringify their own payloads.
+- **Built-in auth provider** — we expose the hook; we don't ship cookie parsing, JWT, etc.
 
 ## Design Decisions
 
-Key choices made and WHY. Record tradeoffs — future you will thank you.
+### 1. Per-channel DO (not sharded multi-channel)
+Workers bills per request, not per idle DO instance; hibernation + eviction make sparse channels effectively free. Sharding adds a routing table with zero scale benefit at current usage. **Rejected alternative:** one DO hosting many channels — added complexity for no measurable win.
 
-- [NEEDS CLARIFICATION] What alternatives were considered? Why was this one chosen?
+### 2. Explicit `DurableObjectNamespace` arg, not env-convention
+`publish(namespace, channel, event, data)` mirrors `singleton(namespace, name)` from `@workkit/do`. Apps may run multiple brokers under different auth scopes; a convention like `env.SSE_BROKER` hides that flexibility. **Rejected alternative:** `publish(env, channel, ...)` with hard-coded binding name.
+
+### 3. In-memory ring buffer (not DO storage)
+Storage-backed replay turns every publish into a write — inverts the ephemeral contract and blows up cost. SSE's own reconnect model accepts "reload on long disconnect." Matches the issue's explicit direction. **Rejected alternative:** persistent replay log.
+
+### 4. Subpath exports: `@workkit/realtime` + `@workkit/realtime/client`
+Constitution rule #4 requires a single `src/index.ts`; subpaths via the `exports` map keep server code out of the browser bundle and vice versa.
+
+### 5. Duplicate 20-line SSE framing, don't extract
+`@workkit/notify` has its own private framing. A third micro-package just to share ~20 lines is premature abstraction. Duplicate now; extract if a third caller shows up. Matches the "three similar lines beats premature abstraction" rule.
+
+### 6. New package, not an adapter in `@workkit/notify`
+Notify is *deliver-to-user* (retryable, provider-backed). Realtime is *broadcast-to-topic* (fire-and-forget, ephemeral). Different failure model, different consumer (UI vs. domain code), different future (realtime earns WebSocket; notify earns more providers). Merging would muddy both.
 
 ## Open Questions
 
-- [NEEDS CLARIFICATION] List ambiguities. Every question here must be resolved before implementation.
+- **Max concurrent subscribers per channel** — SSE on DO can't hibernate an active response stream, so each subscriber holds the DO awake. Do we enforce a cap? *Proposed:* soft cap at 1000/channel, configurable, 429 beyond. Resolve before implement.
+- **Heartbeat cadence default** — notify uses 30s. Same default here? *Proposed:* yes, match.
+- **Channel name validation** — regex or free-form string? *Proposed:* `^[a-zA-Z0-9:_.-]{1,128}$` to prevent path traversal in the subscribe URL.

--- a/.maina/features/010-realtime/tasks.md
+++ b/.maina/features/010-realtime/tasks.md
@@ -1,23 +1,71 @@
-# Task Breakdown
+# Task Breakdown — @workkit/realtime
 
 ## Tasks
 
-Each task should be completable in one commit. Test tasks precede implementation tasks.
+Each task is one commit. Test tasks precede implementation tasks (TDD always — constitution rule #9).
 
-- [ ] [NEEDS CLARIFICATION] Define tasks.
+### Scaffold
+- [x] T01 — Create `packages/realtime/` with `package.json`, `tsconfig.json`, `bunup.config.ts`, empty `src/index.ts`. Declare deps on `@workkit/do` + `@workkit/testing` (dev). Wire `.` and `./client` subpath exports. Verify `bun run constitution:check` passes on the scaffold.
+
+### Framing (pure)
+- [x] T02 — `tests/framing.test.ts`: encode round-trip (event+id+data), multi-line data string, unicode, missing id.
+- [x] T03 — `src/framing.ts`: `encodeEvent({event, id, data}) → Uint8Array`, `encodeComment(text) → Uint8Array` (for heartbeat + `: connected`).
+
+### Ring buffer (pure)
+- [x] T04 — `tests/ring-buffer.test.ts`: bounded capacity, FIFO trim, `since(id)` returns events with id > argument in order, empty buffer.
+- [x] T05 — `src/ring-buffer.ts`: `createRingBuffer(capacity)` with `push(event)`, `since(id)`, `nextId` getter. Monotonic id from `performance.now`-seeded counter? No — plain `++n`, since counter survives only while DO is alive (documented in spec).
+
+### Types
+- [x] T06 — `src/types.ts`: `RealtimeEvent`, `BrokerConfig`, `AuthorizeHook`, `SubscribeOptions`, `PublishResult`. No behavior; consumed by the next tasks.
+
+### Broker DO
+- [x] T07 — `tests/broker.test.ts`: `authorize` returning null → 403; invalid channel name → 400; subscribe → stream emits `: connected` and publisher events; `Last-Event-ID` → replay then live; writer throwing during fan-out → removed, others still delivered.
+- [x] T08 — `src/broker.ts`: `createBroker({ authorize, replayBufferSize, maxSubscribersPerChannel, heartbeatMs })` returns a `DurableObject` class. Routes `GET /subscribe` and `POST /publish` on its internal `fetch`. Idle-eviction alarm optional (v1: skip — DO hibernates on its own).
+
+### Publish helper
+- [x] T09 — `tests/publish.test.ts`: calls `singleton(ns, channel).fetch("/publish", ...)` with correct body; surfaces non-2xx as thrown Error.
+- [x] T10 — `src/publish.ts`: `publish(namespace, channel, event, data)` → `Promise<PublishResult>`.
+
+### Client wrapper
+- [x] T11 — `tests/client.test.ts`: with fake `EventSource`: first connect → receives events; `error` fires → reconnects with `Last-Event-ID` header; N consecutive failures → calls `fallbackToPolling`; `unsubscribe()` cleans up.
+- [x] T12 — `src/client.ts`: `subscribe(url, opts)` returns `{ unsubscribe() }`. Backoff from `opts.backoff` (default 500ms → 10s exponential). Persists `lastEventId` in closure.
+
+### Public exports
+- [x] T13 — `src/index.ts`: re-export `createBroker`, `publish`, all types. No default export. Verify tree-shakability.
+
+### Docs + ADR
+- [x] T14 — `adr/0005-realtime-sse-over-durable-objects-broker.md`: ADR capturing per-channel DO vs. sharded, in-memory ring vs. storage, no-WebSocket-in-v1.
+- [x] T15 — `.changeset/realtime-initial.md`: `@workkit/realtime@0.1.0` minor, summary linking #111.
+
+### Verify
+- [x] T16 — `bun run typecheck && bun run test --filter @workkit/realtime && bun run lint && bun run constitution:check`. All clean.
+- [x] T17 — `maina verify` on staged diff. `maina review` two-stage pass. `maina slop` on changed files.
 
 ## Dependencies
 
-Which tasks block which? Draw the critical path.
+```
+T01 ─┬─> T02 ─> T03
+     ├─> T04 ─> T05
+     ├─> T06 ─> T07 ─> T08 ─> T09 ─> T10
+     │                                  │
+     │                                  └─> T13
+     ├─> T11 ─> T12 ─────────────────────┘
+     └─> T14
+T13, T15 ─> T16 ─> T17
+```
 
-- [NEEDS CLARIFICATION]
+Critical path: T01 → T06 → T07 → T08 → T13 → T16 → T17 (≈ 7 sequential commits; others parallelize).
 
 ## Definition of Done
 
-How do we know this feature is complete?
-
-- [ ] All tests pass
-- [ ] Biome lint clean
-- [ ] TypeScript compiles
-- [ ] maina analyze shows no errors
-- [ ] [NEEDS CLARIFICATION] Feature-specific criteria
+- [ ] All tests pass (`bun run test`)
+- [ ] Biome lint clean (`bun run lint`)
+- [x] TypeScript compiles (`bun run typecheck`)
+- [ ] `bun run constitution:check` — 0 errors, no new warnings on this package
+- [ ] `maina verify` clean on final diff
+- [ ] `maina review` two-stage pass with no critical/important findings
+- [ ] `maina slop` reports no findings on changed files
+- [ ] ADR merged at `.maina/decisions/003-realtime-sse-do-broker.md`
+- [ ] Changeset added
+- [ ] Success criteria in spec.md all checkable
+- [ ] PR description links #111 and the maina-cloud spec reference

--- a/.maina/features/010-realtime/tasks.md
+++ b/.maina/features/010-realtime/tasks.md
@@ -1,0 +1,23 @@
+# Task Breakdown
+
+## Tasks
+
+Each task should be completable in one commit. Test tasks precede implementation tasks.
+
+- [ ] [NEEDS CLARIFICATION] Define tasks.
+
+## Dependencies
+
+Which tasks block which? Draw the critical path.
+
+- [NEEDS CLARIFICATION]
+
+## Definition of Done
+
+How do we know this feature is complete?
+
+- [ ] All tests pass
+- [ ] Biome lint clean
+- [ ] TypeScript compiles
+- [ ] maina analyze shows no errors
+- [ ] [NEEDS CLARIFICATION] Feature-specific criteria

--- a/.maina/features/010-realtime/tasks.md
+++ b/.maina/features/010-realtime/tasks.md
@@ -27,7 +27,7 @@ Each task is one commit. Test tasks precede implementation tasks (TDD always —
 - [x] T10 — `src/publish.ts`: `publish(namespace, channel, event, data)` → `Promise<PublishResult>`.
 
 ### Client wrapper
-- [x] T11 — `tests/client.test.ts`: with fake `EventSource`: first connect → receives events; `error` fires → reconnects with `Last-Event-ID` header; N consecutive failures → calls `fallbackToPolling`; `unsubscribe()` cleans up.
+- [x] T11 — `tests/client.test.ts`: mock `globalThis.fetch` with controllable `ReadableStream`s — first connect → receives events; stream closes/errors → reconnects with `Last-Event-ID` header + `?lastEventId=` query param; N consecutive failures → calls `fallbackPollingUrl`; `unsubscribe()` aborts the fetch.
 - [x] T12 — `src/client.ts`: `subscribe(url, opts)` returns `{ unsubscribe() }`. Backoff from `opts.backoff` (default 500ms → 10s exponential). Persists `lastEventId` in closure.
 
 ### Public exports

--- a/.maina/features/010-realtime/tasks.md
+++ b/.maina/features/010-realtime/tasks.md
@@ -43,7 +43,7 @@ Each task is one commit. Test tasks precede implementation tasks (TDD always —
 
 ## Dependencies
 
-```
+```text
 T01 ─┬─> T02 ─> T03
      ├─> T04 ─> T05
      ├─> T06 ─> T07 ─> T08 ─> T09 ─> T10
@@ -58,14 +58,14 @@ Critical path: T01 → T06 → T07 → T08 → T13 → T16 → T17 (≈ 7 sequen
 
 ## Definition of Done
 
-- [ ] All tests pass (`bun run test`)
-- [ ] Biome lint clean (`bun run lint`)
+- [x] All tests pass (`bun run test`) — 67 passing
+- [x] Biome lint clean (`bun run lint`)
 - [x] TypeScript compiles (`bun run typecheck`)
-- [ ] `bun run constitution:check` — 0 errors, no new warnings on this package
-- [ ] `maina verify` clean on final diff
-- [ ] `maina review` two-stage pass with no critical/important findings
-- [ ] `maina slop` reports no findings on changed files
-- [ ] ADR merged at `.maina/decisions/003-realtime-sse-do-broker.md`
-- [ ] Changeset added
-- [ ] Success criteria in spec.md all checkable
-- [ ] PR description links #111 and the maina-cloud spec reference
+- [x] `bun run constitution:check` — 0 errors, 0 warnings on this package
+- [x] `maina verify` clean on final diff
+- [x] `maina review` two-stage pass with no critical/important findings (independent review + Copilot + CodeRabbit addressed)
+- [x] `maina slop` reports no findings on changed files
+- [x] ADR published at `adr/0005-realtime-sse-over-durable-objects-broker.md`
+- [x] Changeset added (`.changeset/realtime-initial.md`)
+- [x] Success criteria in spec.md all checkable
+- [x] PR #112 links #111

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Every package wraps a Cloudflare binding or API with type safety, better DX, and
 | [`@workkit/ai`](packages/ai) | Typed Workers AI client with streaming, fallback chains, and retry |
 | [`@workkit/ai-gateway`](packages/ai-gateway) | Multi-provider AI gateway — Workers AI, OpenAI, Anthropic, custom. Routing, streaming, fallback, retry, prompt caching, Cloudflare AI Gateway routing, cost tracking |
 | [`@workkit/api`](packages/api) | Type-safe API definitions with Standard Schema and OpenAPI generation |
+| [`@workkit/realtime`](packages/realtime) | SSE-over-Durable-Objects broadcast primitive — per-channel pub/sub with Last-Event-ID replay and a fetch-based client wrapper |
 | [`@workkit/logger`](packages/logger) | Structured logging with request context and Hono middleware |
 | [`@workkit/auth`](packages/auth) | JWT, session management, and auth middleware |
 | [`@workkit/testing`](packages/testing) | In-memory mocks with operation tracking, seed builders, error injection, and snapshots |

--- a/adr/0005-realtime-sse-over-durable-objects-broker.md
+++ b/adr/0005-realtime-sse-over-durable-objects-broker.md
@@ -20,7 +20,7 @@ We want one tested primitive rather than N copies with subtly different back-off
 
 Ship a new package `@workkit/realtime` built on **one Durable Object instance per channel**, addressed via `singleton(namespace, channelName)` from `@workkit/do`. The DO holds in-memory `Map<channel, Set<Writer>>` for active subscribers and a per-channel bounded ring buffer for `Last-Event-ID` replay. Publish goes through a DO RPC; subscribe returns a streamed `text/event-stream` response after a caller-supplied `authorize(channel, request, env)` hook allows it.
 
-Client helper is a browser-targeted subpath export (`@workkit/realtime/client`) that wraps `EventSource`, persists `lastEventId`, applies exponential backoff, and optionally swaps to polling after a configured failure window.
+Client helper is a subpath export (`@workkit/realtime/client`) that wraps `fetch` + `ReadableStream` — works identically in browsers, Bun, and Node, unlike `EventSource`. It persists `lastEventId`, applies exponential backoff, sends both the `Last-Event-ID` header and a `?lastEventId=` query param on reconnect, and optionally swaps to polling after a configured failure window.
 
 Not adopting: WebSocket transport in v1 (earns its own ADR when needed), storage-backed replay (would invert the ephemeral contract), sharded multi-channel DO (complexity with no scale win at current usage), framing extraction to a shared helper package (~20 lines — premature).
 
@@ -53,7 +53,7 @@ Not adopting: WebSocket transport in v1 (earns its own ADR when needed), storage
 ┌─ Worker handler ─────────┐                    ┌─ Browser ────────────────┐
 │                          │                    │                          │
 │  publish(ns, ch, e, d) ──┼──┐              ┌──┼──> subscribe(url, opts) │
-│                          │  │              │  │     (EventSource +      │
+│                          │  │              │  │     (fetch + stream +   │
 └──────────────────────────┘  │              │  │      backoff + polling) │
                               │              │  └──────────────────────────┘
                               ▼              │
@@ -74,7 +74,7 @@ Not adopting: WebSocket transport in v1 (earns its own ADR when needed), storage
 | `ring-buffer.ts` | Bounded FIFO with monotonic id and `since(id)` slice. Pure. | — |
 | `broker.ts` | `createBroker(config)` returns a `DurableObject` class with `fetch()` routing `/subscribe` + `/publish`. | `framing`, `ring-buffer` |
 | `publish.ts` | `publish(namespace, channel, event, data)` convenience over DO stub fetch. | `@workkit/do` `singleton` |
-| `client.ts` | Browser `subscribe(url, opts)` — `EventSource` wrapper with backoff + polling fallback. | — |
+| `client.ts` | `subscribe(url, opts)` — `fetch` + `ReadableStream` wrapper with backoff + polling fallback. | — |
 | `types.ts` | `RealtimeEvent`, `BrokerConfig`, `AuthorizeHook`, `SubscribeOptions`, `PublishResult`. | `@workkit/types` where applicable |
 
 ### Data Flow
@@ -83,7 +83,7 @@ Not adopting: WebSocket transport in v1 (earns its own ADR when needed), storage
 
 **Subscribe:** client `GET /sse/:channel` (caller-routed) → caller's Worker invokes `singleton(ns, channel).fetch("/subscribe", { headers: { "Last-Event-ID": … } })` → DO runs `authorize(channel, request, env)`; if null → 403; else creates a `ReadableStream`, registers the `Writer` in the channel's `Set`, replays `ringBuffer.since(lastId)`, emits `: connected`, starts heartbeat interval, returns `Response(stream, { headers: { "content-type": "text/event-stream" } })`.
 
-**Reconnect:** client's `onerror` fires → closes `EventSource` → exponential backoff wait → new `EventSource` with `Last-Event-ID: <persisted>` header → server replays missed events past that id, up to buffer capacity.
+**Reconnect:** upstream stream errors or closes → current `AbortController` is torn down → exponential backoff wait → new `fetch` with both `Last-Event-ID: <persisted>` header and `?lastEventId=<persisted>` query param → server replays missed events past that id, up to buffer capacity.
 
 ### External Dependencies
 
@@ -192,4 +192,4 @@ None. No storage writes in v1.
 - **Subscriber closes mid-replay:** `controller.enqueue` throws on the next event, writer is pruned; no crash.
 - **Caller passes a channel name that collides across tenants (e.g. two apps both using `"general"`):** prevented by the caller's naming convention (`team:<id>:<topic>`); package does not enforce tenant prefixes.
 - **Publisher floods a channel:** no back-pressure in v1. Documented as a limitation.
-- **Heartbeat while client is in EventSource-retry state:** `: keepalive` comment is ignored by `EventSource`; harmless.
+- **Heartbeat while client is in reconnect backoff:** the client has already aborted its fetch so no bytes arrive anywhere; heartbeats enqueued server-side are dropped when the stream cancel fires.

--- a/adr/0005-realtime-sse-over-durable-objects-broker.md
+++ b/adr/0005-realtime-sse-over-durable-objects-broker.md
@@ -1,0 +1,195 @@
+# 0005. Realtime SSE-over-Durable-Objects broker
+
+Date: 2026-04-22
+
+## Status
+
+Proposed
+
+Tracks: #111. Feature: `.maina/features/010-realtime/`.
+
+## Context
+
+Cloudflare Workers isolates don't share in-memory state. A subscriber connected to isolate A cannot receive an event published from isolate B, because the two isolates have no shared mutable process. The only Workers primitive that gives a single addressable point of shared state is Durable Objects.
+
+`@workkit/notify` already ships a single-isolate SSE helper (`packages/notify/src/adapters/inapp/sse.ts`) and explicitly defers multi-isolate fan-out to "a future Durable-Object-backed adapter" (line 11). Every Workkit-built app that needs live UI — maina-cloud's dashboard-v1, the `maina run follow` CLI, future deploy dashboards — independently hits the same problem: DO + SSE + reconnect + replay.
+
+We want one tested primitive rather than N copies with subtly different back-off, replay, and auth semantics.
+
+## Decision
+
+Ship a new package `@workkit/realtime` built on **one Durable Object instance per channel**, addressed via `singleton(namespace, channelName)` from `@workkit/do`. The DO holds in-memory `Map<channel, Set<Writer>>` for active subscribers and a per-channel bounded ring buffer for `Last-Event-ID` replay. Publish goes through a DO RPC; subscribe returns a streamed `text/event-stream` response after a caller-supplied `authorize(channel, request, env)` hook allows it.
+
+Client helper is a browser-targeted subpath export (`@workkit/realtime/client`) that wraps `EventSource`, persists `lastEventId`, applies exponential backoff, and optionally swaps to polling after a configured failure window.
+
+Not adopting: WebSocket transport in v1 (earns its own ADR when needed), storage-backed replay (would invert the ephemeral contract), sharded multi-channel DO (complexity with no scale win at current usage), framing extraction to a shared helper package (~20 lines — premature).
+
+## Consequences
+
+### Positive
+
+- Single tested implementation of the fan-out primitive across Workkit apps.
+- Clean long-term home for future realtime transports (WebSocket v2, MQTT bridge, presence) — they slot into this package, not into notify.
+- Reuses `@workkit/do`'s `singleton` + alarm helpers; no duplicated `idFromName` plumbing.
+- `@workkit/notify` stays focused on durable, retryable delivery semantics — its contract doesn't drift to cover ephemeral broadcast.
+
+### Negative
+
+- Each active channel is a live DO instance. Per-channel isolation is the intended property, but it does mean a burst of 10k distinct short-lived channels creates 10k DO instances (short hibernation + eviction make this low-cost, not zero).
+- SSE on DO cannot hibernate an in-flight HTTP response body. Each subscriber keeps its channel's DO awake for the connection's lifetime. We cap subscribers per channel at 1000 (429 beyond) to bound this.
+- In-memory ring buffer is lost on DO eviction. Clients whose `Last-Event-ID` predates eviction receive a fresh id stream and are expected to do a reload/resync.
+- ~20 lines of SSE framing are duplicated between `notify` and `realtime`. Accepted tradeoff vs. premature extraction.
+
+### Neutral
+
+- Adds one package to the monorepo (33 → 34).
+- Adds a DO binding requirement for consumers (`[[durable_objects.bindings]] name = "SSE_BROKER"`). Matches the existing pattern consumers already use for workflow / approval / health DOs.
+
+## High-Level Design
+
+### System Overview
+
+```
+┌─ Worker handler ─────────┐                    ┌─ Browser ────────────────┐
+│                          │                    │                          │
+│  publish(ns, ch, e, d) ──┼──┐              ┌──┼──> subscribe(url, opts) │
+│                          │  │              │  │     (EventSource +      │
+└──────────────────────────┘  │              │  │      backoff + polling) │
+                              │              │  └──────────────────────────┘
+                              ▼              │
+                       ┌─ DO: channel "ch" ──┴─┐
+                       │  Set<Writer> subs     │
+                       │  RingBuffer<Event>    │
+                       │  fetch()              │
+                       │    GET  /subscribe    │
+                       │    POST /publish      │
+                       └───────────────────────┘
+```
+
+### Component Boundaries
+
+| Component | Responsibility | Reuses |
+|---|---|---|
+| `framing.ts` | SSE line encoding (`event:`, `id:`, `data:`, comments). Pure. | — (mirrors `notify/…/sse.ts:122-160`) |
+| `ring-buffer.ts` | Bounded FIFO with monotonic id and `since(id)` slice. Pure. | — |
+| `broker.ts` | `createBroker(config)` returns a `DurableObject` class with `fetch()` routing `/subscribe` + `/publish`. | `framing`, `ring-buffer` |
+| `publish.ts` | `publish(namespace, channel, event, data)` convenience over DO stub fetch. | `@workkit/do` `singleton` |
+| `client.ts` | Browser `subscribe(url, opts)` — `EventSource` wrapper with backoff + polling fallback. | — |
+| `types.ts` | `RealtimeEvent`, `BrokerConfig`, `AuthorizeHook`, `SubscribeOptions`, `PublishResult`. | `@workkit/types` where applicable |
+
+### Data Flow
+
+**Publish:** handler → `publish(ns, channel, event, data)` → `singleton(ns, channel).fetch("/publish", { body })` → DO increments id, appends to ring, iterates `Set<Writer>`, calls each `controller.enqueue(encoded)`, returns `{ delivered: n }`.
+
+**Subscribe:** client `GET /sse/:channel` (caller-routed) → caller's Worker invokes `singleton(ns, channel).fetch("/subscribe", { headers: { "Last-Event-ID": … } })` → DO runs `authorize(channel, request, env)`; if null → 403; else creates a `ReadableStream`, registers the `Writer` in the channel's `Set`, replays `ringBuffer.since(lastId)`, emits `: connected`, starts heartbeat interval, returns `Response(stream, { headers: { "content-type": "text/event-stream" } })`.
+
+**Reconnect:** client's `onerror` fires → closes `EventSource` → exponential backoff wait → new `EventSource` with `Last-Event-ID: <persisted>` header → server replays missed events past that id, up to buffer capacity.
+
+### External Dependencies
+
+- `@workkit/do` — `singleton(namespace, name)` stub lookup; alarm helpers (used only if v1.1 adds idle eviction).
+- `@workkit/testing` (dev) — `createMockDO()` for broker unit tests; satisfies constitution rule #3.
+- `@cloudflare/workers-types` — `DurableObject`, `DurableObjectNamespace`, `DurableObjectState`.
+- No runtime deps on notify, auth, or api — realtime is a peer primitive.
+
+## Low-Level Design
+
+### Interfaces & Types
+
+```ts
+export interface RealtimeEvent {
+  event: string;        // SSE event name
+  data: unknown;        // JSON-serializable payload (broker JSON.stringifies)
+  id?: number;          // assigned by broker; callers never set
+}
+
+export type AuthorizeHook<TPrincipal = unknown> = (
+  channel: string,
+  request: Request,
+  env: unknown,
+) => Promise<TPrincipal | null>;
+
+export interface BrokerConfig<TPrincipal = unknown> {
+  authorize: AuthorizeHook<TPrincipal>;
+  replayBufferSize?: number;          // default 50
+  maxSubscribersPerChannel?: number;  // default 1000
+  heartbeatMs?: number;               // default 30_000
+  channelPattern?: RegExp;            // default /^[a-zA-Z0-9:_.-]{1,128}$/
+}
+
+export interface SubscribeOptions {
+  onEvent: (event: string, data: unknown, id: number) => void;
+  onReconnect?: (attempt: number) => void;
+  backoff?: { initialMs: number; maxMs: number };  // default 500 / 10_000
+  fallbackPollingUrl?: string;
+  pollingAfterMs?: number;                          // default 45_000
+  signal?: AbortSignal;
+}
+
+export interface PublishResult {
+  delivered: number;
+  id: number;
+}
+```
+
+### Function Signatures
+
+```ts
+export function createBroker<TEnv, TPrincipal>(
+  config: BrokerConfig<TPrincipal>,
+): new (state: DurableObjectState, env: TEnv) => DurableObject;
+
+export function publish(
+  namespace: DurableObjectNamespace,
+  channel: string,
+  event: string,
+  data: unknown,
+): Promise<PublishResult>;
+
+// Subpath @workkit/realtime/client
+export function subscribe(
+  url: string,
+  opts: SubscribeOptions,
+): { unsubscribe(): void };
+```
+
+### DB Schema Changes
+
+None. No storage writes in v1.
+
+### Sequence of Operations
+
+**Subscribe (happy path):**
+1. Caller Worker: `singleton(env.SSE_BROKER, channel).fetch("/subscribe", { headers })`.
+2. DO: validate channel name against `channelPattern`. If mismatch → 400.
+3. DO: `await authorize(channel, request, env)`. If returns null or throws → 403.
+4. DO: if `subs.get(channel)?.size >= maxSubscribersPerChannel` → 429.
+5. DO: create `ReadableStream`; on `start(controller)` → create Writer, register in `subs.get(channel)`, replay `ringBuffer.get(channel).since(lastEventId)`, enqueue `: connected`, start heartbeat interval.
+6. DO: return 200 with `text/event-stream` headers.
+7. Caller Worker forwards the `Response` to the browser unchanged.
+
+**Publish (happy path):**
+1. Caller Worker: `publish(ns, channel, "run.stage", { stage: "verify" })`.
+2. DO: `POST /publish` arrives with `{ event, data }`.
+3. DO: `id = ++counter[channel]`; `ringBuffer.get(channel).push({ id, event, data })`.
+4. DO: for each writer in `subs.get(channel)`: try `controller.enqueue(framing.encodeEvent({ id, event, data: JSON.stringify(data) }))`; on throw, mark for removal.
+5. DO: prune failed writers.
+6. DO: respond `{ delivered: subs.size, id }`.
+
+### Error Handling
+
+- `authorize` throws → treated as deny → 403, no stack exposed. No logging (constitution rule #7 — no `console.log`); observability is caller's responsibility via their own logger.
+- Writer `enqueue` throws → writer removed from set, fan-out to others continues. Pattern matches `packages/notify/src/adapters/inapp/sse.ts:39-49`.
+- Malformed publish body → 400.
+- Channel pattern mismatch → 400.
+- Subscribe cap exceeded → 429.
+
+### Edge Cases
+
+- **DO eviction between publishes:** counter and ring buffer reset. Clients reconnecting with an old `Last-Event-ID` see lower ids and should treat as "buffer lost."
+- **Client reconnect faster than heartbeat:** no duplicate delivery because replay is bounded by `lastEventId`.
+- **Simultaneous publish and subscribe:** JS single-threaded inside a DO — serialized.
+- **Subscriber closes mid-replay:** `controller.enqueue` throws on the next event, writer is pruned; no crash.
+- **Caller passes a channel name that collides across tenants (e.g. two apps both using `"general"`):** prevented by the caller's naming convention (`team:<id>:<topic>`); package does not enforce tenant prefixes.
+- **Publisher floods a channel:** no back-pressure in v1. Documented as a limitation.
+- **Heartbeat while client is in EventSource-retry state:** `: keepalive` comment is ignored by `EventSource`; harmless.

--- a/apps/docs/src/content/docs/guides/realtime.md
+++ b/apps/docs/src/content/docs/guides/realtime.md
@@ -1,0 +1,177 @@
+---
+title: "Realtime"
+---
+
+# Realtime
+
+`@workkit/realtime` is an SSE-over-Durable-Objects broadcast primitive for Cloudflare Workers. Fan out events from any Worker handler to every active subscriber of a channel, with Last-Event-ID replay and a fetch-based browser client that survives reconnects.
+
+## When to use it
+
+| You want… | Use |
+|---|---|
+| Multi-isolate live updates (dashboards, run timelines, presence-ish toasts) | **`@workkit/realtime`** (this guide) |
+| Single-isolate SSE for one user's inbox | `@workkit/notify/inapp` |
+| Retryable, provider-backed notification delivery (email, SMS, push, WhatsApp) | `@workkit/notify` |
+
+Realtime is *broadcast-to-topic* (fire-and-forget, ephemeral, replay by id). Notify is *deliver-to-user* (retryable, durable, per-provider). Different contracts — pick by failure mode you want.
+
+## Install
+
+```bash
+bun add @workkit/realtime @workkit/do
+```
+
+## Bind the Durable Object
+
+```toml
+# wrangler.toml
+[[durable_objects.bindings]]
+name = "SSE_BROKER"
+class_name = "SseBroker"
+
+[[migrations]]
+tag = "v1"
+new_classes = ["SseBroker"]
+```
+
+## Define a broker
+
+`createBroker` returns a `DurableObject` class you export from your Worker. The `authorize` hook is required — return a principal to allow, `null` to deny (produces HTTP 403). Thrown errors are treated as denies.
+
+```ts
+// worker.ts
+import { createBroker } from "@workkit/realtime";
+
+export const SseBroker = createBroker({
+  authorize: async (channel, request, env) => {
+    const session = await getSession(request, env);
+    if (!session) return null;
+    if (channel.startsWith(`team:${session.teamId}:`)) return session;
+    if (channel === `member:${session.userId}:notify`) return session;
+    return null; // not allowed on this channel
+  },
+  replayBufferSize: 50,          // default
+  maxSubscribersPerChannel: 1000, // default
+  heartbeatMs: 30_000,            // default
+  channelPattern: /^[a-zA-Z0-9:_.-]{1,128}$/, // default
+});
+```
+
+## Wire the subscribe route
+
+Route `/sse/:channel` to the broker's DO stub using `singleton(ns, channel)` from `@workkit/do`. Each channel is its own DO instance — hibernation keeps idle channels free.
+
+```ts
+import { singleton } from "@workkit/do";
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    if (url.pathname.startsWith("/sse/")) {
+      const channel = url.pathname.slice("/sse/".length);
+      const stub = singleton(env.SSE_BROKER, channel);
+      return stub.fetch(
+        new Request(`https://do/subscribe?channel=${encodeURIComponent(channel)}`, {
+          headers: request.headers, // forwards cookie / Last-Event-ID
+        }),
+      );
+    }
+    return new Response("not found", { status: 404 });
+  },
+} satisfies ExportedHandler<Env>;
+```
+
+## Publish from any handler
+
+```ts
+import { publish } from "@workkit/realtime";
+
+await publish(env.SSE_BROKER, `run:${runId}`, "run.stage", {
+  stage: "ai_verify",
+  progress: 40,
+});
+```
+
+`publish(namespace, channel, event, data)` is fire-and-forget — it resolves with `{ delivered, id }` so you can observe delivery. `data` must not be `undefined` (throws eagerly).
+
+## Subscribe from the browser
+
+```ts
+import { subscribe } from "@workkit/realtime/client";
+
+const sub = subscribe(`/sse/run:${runId}`, {
+  onEvent: (event, data, id) => {
+    if (event === "run.stage") updatePipeline(data);
+    if (event === "realtime.reset") location.reload(); // see "Eviction" below
+  },
+  onReconnect: (attempt) => console.log("reconnecting", attempt),
+  backoff: { initialMs: 500, maxMs: 10_000 }, // default
+  fallbackPollingUrl: `/poll/run/${runId}`,   // optional
+  pollingAfterMs: 45_000,                      // default
+});
+
+// later
+sub.unsubscribe();
+```
+
+The client uses `fetch` + streams (not `EventSource`), so it works identically in browsers, Bun, and Node. Reconnect carries `lastEventId` via both the `Last-Event-ID` header and a `?lastEventId=N` query param.
+
+## Eviction and the `realtime.reset` signal
+
+Durable Objects hibernate and can evict when idle. When they come back, the broker's in-memory id counter starts fresh at 0. If a reconnecting client reports a `Last-Event-ID` higher than the broker's current `lastId`, the broker emits:
+
+```
+event: realtime.reset
+id: <current-lastId>
+data: {"reason":"buffer_gap","lastKnownId":<client's-id>}
+```
+
+**before** any live events. Handle this by discarding local state and re-fetching — your Last-Event-ID is referring to events that no longer exist on the server.
+
+## Channel conventions
+
+The package enforces a syntactic pattern but leaves semantic scoping to you. Typical shapes:
+
+| Channel | Events |
+|---|---|
+| `team:<id>:runs.live` | `run.started`, `run.stage`, `run.completed` |
+| `team:<id>:findings` | `finding.created`, `finding.feedback` |
+| `run:<runId>` | `run.stage`, `run.completed` |
+| `member:<id>:notify` | `invite.received`, `mention` |
+
+Your `authorize` hook is the gate — the package does not enforce that `team:42:*` requires team 42 membership; you do.
+
+## Limits and failure modes
+
+- **No WebSocket transport in v1.** SSE + optional polling fallback covers the common shapes. WebSocket would earn a separate ADR.
+- **Replay is in-memory**, bounded by `replayBufferSize`. Clients disconnected longer than the buffer window miss events — reconnect with `Last-Event-ID` older than the oldest buffered id will replay whatever's left (not the full gap).
+- **Each active subscriber keeps its channel's DO awake** — SSE on DO cannot hibernate an in-flight response. Default cap is 1000 subscribers per channel; past that the broker returns 429.
+- **No back-pressure on publishers.** A flood on one channel can exhaust the DO's wall time for that tick. Out-of-scope for v1.
+- **`authorize()` throwing is treated as deny** — no `console.log` (constitution rule); observability is the caller's job.
+- **Channel-name validation** rejects anything outside `^[a-zA-Z0-9:_.-]{1,128}$` with HTTP 400.
+
+## Testing
+
+Unit-test the broker by instantiating the class directly — it holds no DO storage, so a cast `{} as DurableObjectState` is sufficient:
+
+```ts
+import { createBroker } from "@workkit/realtime";
+
+const Broker = createBroker({ authorize: async () => ({ userId: "u1" }) });
+const broker = new Broker({} as DurableObjectState, {});
+
+const res = await broker.fetch(
+  new Request("https://do/publish", {
+    method: "POST",
+    body: JSON.stringify({ event: "x", data: "y" }),
+  }),
+);
+expect(await res.json()).toEqual({ delivered: 0, id: 1 });
+```
+
+See `packages/realtime/tests/` for the full test set — framing, ring buffer, broker, publish, client parser, and client lifecycle.
+
+## Design background
+
+See [`adr/0005-realtime-sse-over-durable-objects-broker.md`](https://github.com/beeeku/workkit/blob/master/adr/0005-realtime-sse-over-durable-objects-broker.md) for the per-channel-vs-sharded DO tradeoff, the in-memory-vs-storage replay decision, and the no-WebSocket-in-v1 rationale.

--- a/apps/docs/src/content/docs/guides/realtime.md
+++ b/apps/docs/src/content/docs/guides/realtime.md
@@ -69,6 +69,9 @@ export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
     if (url.pathname.startsWith("/sse/")) {
+      if (request.method !== "GET") {
+        return new Response("method not allowed", { status: 405 });
+      }
       const channel = url.pathname.slice("/sse/".length);
       const stub = singleton(env.SSE_BROKER, channel);
       return stub.fetch(
@@ -121,7 +124,7 @@ The client uses `fetch` + streams (not `EventSource`), so it works identically i
 
 Durable Objects hibernate and can evict when idle. When they come back, the broker's in-memory id counter starts fresh at 0. If a reconnecting client reports a `Last-Event-ID` higher than the broker's current `lastId`, the broker emits:
 
-```
+```text
 event: realtime.reset
 id: <current-lastId>
 data: {"reason":"buffer_gap","lastKnownId":<client's-id>}

--- a/bun.lock
+++ b/bun.lock
@@ -99,7 +99,7 @@
     },
     "packages/agent": {
       "name": "@workkit/agent",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@workkit/ai-gateway": "workspace:*",
@@ -120,7 +120,7 @@
     },
     "packages/ai-gateway": {
       "name": "@workkit/ai-gateway",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@workkit/errors": "^1.0.1",
         "@workkit/types": "^1.0.1",
@@ -128,7 +128,7 @@
     },
     "packages/api": {
       "name": "@workkit/api",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "@workkit/errors": "^1.0.1",
         "@workkit/types": "^1.0.1",
@@ -139,7 +139,7 @@
     },
     "packages/approval": {
       "name": "@workkit/approval",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@workkit/crypto": "workspace:*",
         "@workkit/errors": "workspace:*",
@@ -185,7 +185,7 @@
     },
     "packages/chat": {
       "name": "@workkit/chat",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@workkit/errors": "^1.0.1",
         "@workkit/types": "^1.0.1",
@@ -193,7 +193,7 @@
     },
     "packages/cli": {
       "name": "workkit",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "bin": {
         "workkit": "dist/index.js",
       },
@@ -205,7 +205,7 @@
     },
     "packages/cron": {
       "name": "@workkit/cron",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@workkit/errors": "^1.0.1",
         "@workkit/types": "^1.0.1",
@@ -227,7 +227,7 @@
     },
     "packages/do": {
       "name": "@workkit/do",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@workkit/errors": "^1.0.1",
         "@workkit/types": "^1.0.1",
@@ -343,7 +343,7 @@
     },
     "packages/mcp": {
       "name": "@workkit/mcp",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@workkit/errors": "workspace:*",
         "@workkit/types": "^1.0.1",
@@ -430,9 +430,21 @@
         "@workkit/types": "^1.0.1",
       },
     },
+    "packages/realtime": {
+      "name": "@workkit/realtime",
+      "version": "0.1.0",
+      "dependencies": {
+        "@workkit/do": "workspace:*",
+        "@workkit/types": "^1.0.1",
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20250214.0",
+        "@workkit/testing": "workspace:*",
+      },
+    },
     "packages/testing": {
       "name": "@workkit/testing",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "devDependencies": {
         "@types/node": "^22.0.0",
       },
@@ -1204,6 +1216,8 @@
     "@workkit/r2": ["@workkit/r2@workspace:packages/r2"],
 
     "@workkit/ratelimit": ["@workkit/ratelimit@workspace:packages/ratelimit"],
+
+    "@workkit/realtime": ["@workkit/realtime@workspace:packages/realtime"],
 
     "@workkit/remix": ["@workkit/remix@workspace:integrations/remix"],
 

--- a/packages/realtime/bunup.config.ts
+++ b/packages/realtime/bunup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "bunup";
+
+export default defineConfig({
+	entry: ["src/index.ts", "src/client/index.ts"],
+	format: ["esm"],
+	dts: true,
+	sourcemap: "linked",
+	clean: true,
+	external: ["@workkit/types", "@workkit/do"],
+});

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@workkit/realtime",
+  "version": "0.1.0",
+  "description": "SSE-over-Durable-Objects broadcast primitive for Cloudflare Workers — per-channel pub/sub with Last-Event-ID replay and an EventSource client wrapper",
+  "license": "MIT",
+  "author": "Bikash Dash <beeeku>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/beeeku/workkit.git",
+    "directory": "packages/realtime"
+  },
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    },
+    "./client": {
+      "import": {
+        "types": "./dist/client/index.d.ts",
+        "default": "./dist/client/index.js"
+      }
+    }
+  },
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "bunup",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@workkit/do": "workspace:*",
+    "@workkit/types": "^1.0.1"
+  },
+  "devDependencies": {
+    "@workkit/testing": "workspace:*",
+    "@cloudflare/workers-types": "^4.20250214.0"
+  },
+  "keywords": [
+    "cloudflare",
+    "workers",
+    "sse",
+    "server-sent-events",
+    "durable-objects",
+    "realtime",
+    "pubsub",
+    "broadcast",
+    "workkit"
+  ]
+}

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@workkit/realtime",
   "version": "0.1.0",
-  "description": "SSE-over-Durable-Objects broadcast primitive for Cloudflare Workers — per-channel pub/sub with Last-Event-ID replay and an EventSource client wrapper",
+  "description": "SSE-over-Durable-Objects broadcast primitive for Cloudflare Workers — per-channel pub/sub with Last-Event-ID replay and a fetch+ReadableStream client wrapper",
   "license": "MIT",
   "author": "Bikash Dash <beeeku>",
   "repository": {

--- a/packages/realtime/src/broker.ts
+++ b/packages/realtime/src/broker.ts
@@ -32,13 +32,19 @@ export function createBroker<TEnv = unknown, TPrincipal = unknown>(
 	const channelPattern = config.channelPattern ?? DEFAULT_CHANNEL_PATTERN;
 
 	if (!Number.isInteger(replayBufferSize) || replayBufferSize < 0) {
-		throw new Error(`createBroker: replayBufferSize must be a non-negative integer, got ${replayBufferSize}`);
+		throw new Error(
+			`createBroker: replayBufferSize must be a non-negative integer, got ${replayBufferSize}`,
+		);
 	}
 	if (!Number.isInteger(maxSubs) || maxSubs <= 0) {
-		throw new Error(`createBroker: maxSubscribersPerChannel must be a positive integer, got ${maxSubs}`);
+		throw new Error(
+			`createBroker: maxSubscribersPerChannel must be a positive integer, got ${maxSubs}`,
+		);
 	}
 	if (!Number.isFinite(heartbeatMs) || heartbeatMs <= 0) {
-		throw new Error(`createBroker: heartbeatMs must be a positive finite number, got ${heartbeatMs}`);
+		throw new Error(
+			`createBroker: heartbeatMs must be a positive finite number, got ${heartbeatMs}`,
+		);
 	}
 
 	return class Broker implements BrokerInstance {

--- a/packages/realtime/src/broker.ts
+++ b/packages/realtime/src/broker.ts
@@ -1,0 +1,192 @@
+import { encodeComment, encodeEvent } from "./framing";
+import { type RingBuffer, createRingBuffer } from "./ring-buffer";
+import {
+	type BrokerConfig,
+	DEFAULT_CHANNEL_PATTERN,
+	DEFAULT_HEARTBEAT_MS,
+	DEFAULT_MAX_SUBSCRIBERS_PER_CHANNEL,
+	DEFAULT_REPLAY_BUFFER_SIZE,
+} from "./types";
+
+interface Writer {
+	write(bytes: Uint8Array): void;
+}
+
+interface BufferedEvent {
+	event: string;
+	data: string;
+}
+
+export interface BrokerInstance {
+	fetch(request: Request): Promise<Response>;
+}
+
+export type BrokerClass<TEnv> = new (state: DurableObjectState, env: TEnv) => BrokerInstance;
+
+export function createBroker<TEnv = unknown, TPrincipal = unknown>(
+	config: BrokerConfig<TEnv, TPrincipal>,
+): BrokerClass<TEnv> {
+	const replayBufferSize = config.replayBufferSize ?? DEFAULT_REPLAY_BUFFER_SIZE;
+	const maxSubs = config.maxSubscribersPerChannel ?? DEFAULT_MAX_SUBSCRIBERS_PER_CHANNEL;
+	const heartbeatMs = config.heartbeatMs ?? DEFAULT_HEARTBEAT_MS;
+	const channelPattern = config.channelPattern ?? DEFAULT_CHANNEL_PATTERN;
+
+	return class Broker implements BrokerInstance {
+		private subs = new Set<Writer>();
+		private buffer: RingBuffer<BufferedEvent> = createRingBuffer(replayBufferSize);
+
+		constructor(
+			readonly state: DurableObjectState,
+			readonly env: TEnv,
+		) {}
+
+		async fetch(request: Request): Promise<Response> {
+			const url = new URL(request.url);
+			if (url.pathname === "/subscribe") {
+				if (request.method !== "GET") {
+					return new Response("method not allowed", { status: 405 });
+				}
+				return this.handleSubscribe(url, request);
+			}
+			if (url.pathname === "/publish") {
+				if (request.method !== "POST") {
+					return new Response("method not allowed", { status: 405 });
+				}
+				return this.handlePublish(request);
+			}
+			return new Response("not found", { status: 404 });
+		}
+
+		private async handleSubscribe(url: URL, request: Request): Promise<Response> {
+			const channel = url.searchParams.get("channel");
+			if (!channel || !channelPattern.test(channel)) {
+				return new Response("invalid channel", { status: 400 });
+			}
+
+			let principal: TPrincipal | null;
+			try {
+				principal = await config.authorize(channel, request, this.env);
+			} catch {
+				// Authorize threw — treat as deny. No logging (constitution rule #7).
+				return new Response("forbidden", { status: 403 });
+			}
+			if (principal === null) return new Response("forbidden", { status: 403 });
+
+			if (this.subs.size >= maxSubs) {
+				return new Response("too many subscribers", { status: 429 });
+			}
+
+			// Header wins over query param; strict digit regex because parseInt("500abc") is 500.
+			const lastEventIdRaw =
+				request.headers.get("Last-Event-ID") ?? url.searchParams.get("lastEventId");
+			const lastEventId =
+				lastEventIdRaw && /^\d+$/.test(lastEventIdRaw) ? Number.parseInt(lastEventIdRaw, 10) : 0;
+
+			const subs = this.subs;
+			const buffer = this.buffer;
+
+			let timer: ReturnType<typeof setInterval> | undefined;
+			let writer: Writer | undefined;
+			let cleanedUp = false;
+			const cleanup = () => {
+				if (cleanedUp) return;
+				cleanedUp = true;
+				if (timer) clearInterval(timer);
+				if (writer) subs.delete(writer);
+			};
+
+			const stream = new ReadableStream<Uint8Array>({
+				start(controller) {
+					writer = {
+						write: (bytes) => controller.enqueue(bytes),
+					};
+
+					// Open-ack first so the client knows the stream is alive.
+					controller.enqueue(encodeComment("connected"));
+
+					// If the client reports a higher Last-Event-ID than we have, the DO
+					// evicted mid-session and our counter reset. Signal that so the
+					// client can discard local state and refetch, rather than silently
+					// merging a fresh id stream on top of stale state.
+					if (lastEventId > buffer.lastId) {
+						controller.enqueue(
+							encodeEvent({
+								event: "realtime.reset",
+								id: buffer.lastId,
+								data: JSON.stringify({ reason: "buffer_gap", lastKnownId: lastEventId }),
+							}),
+						);
+					} else if (lastEventId < buffer.lastId) {
+						// Replay missed events before live delivery.
+						for (const { id, event } of buffer.since(lastEventId)) {
+							controller.enqueue(encodeEvent({ event: event.event, id, data: event.data }));
+						}
+					}
+
+					subs.add(writer);
+
+					timer = setInterval(() => {
+						// Guard against a timer callback scheduled before cleanup() ran.
+						if (cleanedUp) return;
+						try {
+							controller.enqueue(encodeComment("keepalive"));
+						} catch {
+							cleanup();
+						}
+					}, heartbeatMs);
+				},
+				cancel() {
+					cleanup();
+				},
+			});
+
+			return new Response(stream, {
+				status: 200,
+				headers: {
+					"content-type": "text/event-stream",
+					"cache-control": "no-cache, no-transform",
+					connection: "keep-alive",
+				},
+			});
+		}
+
+		private async handlePublish(request: Request): Promise<Response> {
+			let parsed: unknown;
+			try {
+				parsed = await request.json();
+			} catch {
+				return new Response("invalid json", { status: 400 });
+			}
+			const body = parsed as { event?: unknown; data?: unknown };
+			if (typeof body.event !== "string" || body.event === "") {
+				return new Response("invalid event", { status: 400 });
+			}
+			if (body.data === undefined) {
+				return new Response("data required", { status: 400 });
+			}
+
+			const dataStr = JSON.stringify(body.data);
+			const id = this.buffer.push({ event: body.event, data: dataStr });
+			const bytes = encodeEvent({ event: body.event, id, data: dataStr });
+
+			let delivered = 0;
+			const failed: Writer[] = [];
+			// Iterate a snapshot so heartbeat-triggered prunes in the same tick
+			// don't mutate the set mid-loop.
+			for (const w of [...this.subs]) {
+				try {
+					w.write(bytes);
+					delivered += 1;
+				} catch {
+					failed.push(w);
+				}
+			}
+			for (const w of failed) this.subs.delete(w);
+
+			return new Response(JSON.stringify({ delivered, id }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		}
+	};
+}

--- a/packages/realtime/src/broker.ts
+++ b/packages/realtime/src/broker.ts
@@ -31,6 +31,16 @@ export function createBroker<TEnv = unknown, TPrincipal = unknown>(
 	const heartbeatMs = config.heartbeatMs ?? DEFAULT_HEARTBEAT_MS;
 	const channelPattern = config.channelPattern ?? DEFAULT_CHANNEL_PATTERN;
 
+	if (!Number.isInteger(replayBufferSize) || replayBufferSize < 0) {
+		throw new Error(`createBroker: replayBufferSize must be a non-negative integer, got ${replayBufferSize}`);
+	}
+	if (!Number.isInteger(maxSubs) || maxSubs <= 0) {
+		throw new Error(`createBroker: maxSubscribersPerChannel must be a positive integer, got ${maxSubs}`);
+	}
+	if (!Number.isFinite(heartbeatMs) || heartbeatMs <= 0) {
+		throw new Error(`createBroker: heartbeatMs must be a positive finite number, got ${heartbeatMs}`);
+	}
+
 	return class Broker implements BrokerInstance {
 		private subs = new Set<Writer>();
 		private buffer: RingBuffer<BufferedEvent> = createRingBuffer(replayBufferSize);

--- a/packages/realtime/src/client/index.ts
+++ b/packages/realtime/src/client/index.ts
@@ -161,10 +161,14 @@ export function subscribe(url: string, opts: SubscribeOptions): Subscription {
 				// Only reset the failure window once the stream actually delivers
 				// bytes — a 200 that immediately closes shouldn't clear the clock
 				// that feeds the polling threshold.
-				await consumeStream(res.body, () => {
-					failures = 0;
-					firstFailureAt = 0;
-				}, ctrl);
+				await consumeStream(
+					res.body,
+					() => {
+						failures = 0;
+						firstFailureAt = 0;
+					},
+					ctrl,
+				);
 			} catch (err) {
 				if (closed || (err as Error).name === "AbortError") return;
 			}

--- a/packages/realtime/src/client/index.ts
+++ b/packages/realtime/src/client/index.ts
@@ -1,0 +1,152 @@
+import type { SubscribeOptions } from "../types";
+import { createSseParser } from "./parse";
+
+const DEFAULT_BACKOFF = { initialMs: 500, maxMs: 10_000 };
+const DEFAULT_POLLING_AFTER_MS = 45_000;
+const POLL_INTERVAL_MS = 15_000;
+
+interface Subscription {
+	unsubscribe(): void;
+}
+
+interface PollEvent {
+	event: string;
+	id: number;
+	data: unknown;
+}
+
+function buildUrl(baseUrl: string, lastEventId: number): string {
+	const hasQuery = baseUrl.includes("?");
+	const sep = hasQuery ? "&" : "?";
+	return `${baseUrl}${sep}lastEventId=${lastEventId}`;
+}
+
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+	return new Promise((resolve) => {
+		if (signal.aborted) {
+			resolve();
+			return;
+		}
+		const timer = setTimeout(() => {
+			signal.removeEventListener("abort", onAbort);
+			resolve();
+		}, ms);
+		const onAbort = () => {
+			clearTimeout(timer);
+			resolve();
+		};
+		signal.addEventListener("abort", onAbort, { once: true });
+	});
+}
+
+export function subscribe(url: string, opts: SubscribeOptions): Subscription {
+	const backoff = opts.backoff ?? DEFAULT_BACKOFF;
+	const pollingAfterMs = opts.pollingAfterMs ?? DEFAULT_POLLING_AFTER_MS;
+
+	let closed = false;
+	let lastEventId = 0;
+	let failures = 0;
+	let firstFailureAt = 0;
+	let currentController: AbortController | undefined;
+
+	// Track the external-signal listener so unsubscribe can detach it — a
+	// page-level AbortController outlives any single subscription.
+	const externalSignal = opts.signal;
+	const onExternalAbort = () => unsubscribe();
+
+	const unsubscribe = () => {
+		if (closed) return;
+		closed = true;
+		externalSignal?.removeEventListener("abort", onExternalAbort);
+		currentController?.abort();
+	};
+
+	if (externalSignal) {
+		if (externalSignal.aborted) {
+			closed = true;
+		} else {
+			externalSignal.addEventListener("abort", onExternalAbort, { once: true });
+		}
+	}
+
+	const onFrame = ({ event, id, data }: { event: string; id?: number; data: string }) => {
+		if (id !== undefined) lastEventId = id;
+		let parsed: unknown = data;
+		try {
+			parsed = JSON.parse(data);
+		} catch {
+			// leave as string
+		}
+		opts.onEvent(event, parsed, lastEventId);
+	};
+
+	const consumeStream = async (body: ReadableStream<Uint8Array>): Promise<void> => {
+		const reader = body.getReader();
+		const decoder = new TextDecoder();
+		const feed = createSseParser(onFrame);
+		try {
+			while (true) {
+				const { value, done } = await reader.read();
+				if (done) return;
+				feed(decoder.decode(value, { stream: true }));
+			}
+		} finally {
+			reader.releaseLock();
+		}
+	};
+
+	const pollLoop = async (pollUrl: string): Promise<void> => {
+		while (!closed) {
+			const ctrl = new AbortController();
+			currentController = ctrl;
+			try {
+				const res = await fetch(buildUrl(pollUrl, lastEventId), { signal: ctrl.signal });
+				if (res.ok) {
+					const events = (await res.json()) as PollEvent[];
+					for (const e of events) {
+						lastEventId = e.id;
+						opts.onEvent(e.event, e.data, e.id);
+					}
+				}
+			} catch {
+				if (closed) return;
+			}
+			if (closed) return;
+			await sleep(POLL_INTERVAL_MS, ctrl.signal);
+		}
+	};
+
+	const run = async (): Promise<void> => {
+		while (!closed) {
+			const ctrl = new AbortController();
+			currentController = ctrl;
+			try {
+				const res = await fetch(buildUrl(url, lastEventId), {
+					signal: ctrl.signal,
+					headers: { accept: "text/event-stream" },
+				});
+				if (!res.ok || !res.body) throw new Error(`HTTP ${res.status}`);
+				failures = 0;
+				firstFailureAt = 0;
+				await consumeStream(res.body);
+			} catch (err) {
+				if (closed || (err as Error).name === "AbortError") return;
+			}
+			if (closed) return;
+			failures += 1;
+			if (firstFailureAt === 0) firstFailureAt = Date.now();
+			if (opts.fallbackPollingUrl && Date.now() - firstFailureAt >= pollingAfterMs) {
+				await pollLoop(opts.fallbackPollingUrl);
+				return;
+			}
+			opts.onReconnect?.(failures);
+			if (closed) return;
+			const delay = Math.min(backoff.maxMs, backoff.initialMs * 2 ** (failures - 1));
+			await sleep(delay, currentController.signal);
+		}
+	};
+
+	if (!closed) void run();
+
+	return { unsubscribe };
+}

--- a/packages/realtime/src/client/index.ts
+++ b/packages/realtime/src/client/index.ts
@@ -121,9 +121,13 @@ export function subscribe(url: string, opts: SubscribeOptions): Subscription {
 			const ctrl = new AbortController();
 			currentController = ctrl;
 			try {
+				const headers: Record<string, string> = { accept: "text/event-stream" };
+				// Send via both the header (native SSE convention) and the query param
+				// (our fallback), matching the broker's dual-read contract.
+				if (lastEventId > 0) headers["Last-Event-ID"] = String(lastEventId);
 				const res = await fetch(buildUrl(url, lastEventId), {
 					signal: ctrl.signal,
-					headers: { accept: "text/event-stream" },
+					headers,
 				});
 				if (!res.ok || !res.body) throw new Error(`HTTP ${res.status}`);
 				failures = 0;

--- a/packages/realtime/src/client/index.ts
+++ b/packages/realtime/src/client/index.ts
@@ -80,18 +80,46 @@ export function subscribe(url: string, opts: SubscribeOptions): Subscription {
 		opts.onEvent(event, parsed, lastEventId);
 	};
 
-	const consumeStream = async (body: ReadableStream<Uint8Array>): Promise<void> => {
+	// Idle timeout (stalled-proxy guard): tear the stream down if no bytes arrive for 2.5x the server heartbeat.
+	const idleTimeoutMs = (opts.heartbeatMs ?? 30_000) * 2.5;
+
+	const consumeStream = async (
+		body: ReadableStream<Uint8Array>,
+		onFirstByte: () => void,
+		controller: AbortController,
+	): Promise<void> => {
 		const reader = body.getReader();
 		const decoder = new TextDecoder();
 		const feed = createSseParser(onFrame);
+		let gotByte = false;
+		let idleTimer: ReturnType<typeof setTimeout> | undefined;
+		const armIdle = () => {
+			if (idleTimer) clearTimeout(idleTimer);
+			idleTimer = setTimeout(() => {
+				controller.abort();
+				// reader.cancel() forces the pending read() to resolve done.
+				reader.cancel().catch(() => undefined);
+			}, idleTimeoutMs);
+		};
+		armIdle();
 		try {
 			while (true) {
 				const { value, done } = await reader.read();
 				if (done) return;
+				if (!gotByte) {
+					gotByte = true;
+					onFirstByte();
+				}
 				feed(decoder.decode(value, { stream: true }));
+				armIdle();
 			}
 		} finally {
-			reader.releaseLock();
+			if (idleTimer) clearTimeout(idleTimer);
+			try {
+				reader.releaseLock();
+			} catch {
+				// reader.cancel() already released
+			}
 		}
 	};
 
@@ -130,9 +158,13 @@ export function subscribe(url: string, opts: SubscribeOptions): Subscription {
 					headers,
 				});
 				if (!res.ok || !res.body) throw new Error(`HTTP ${res.status}`);
-				failures = 0;
-				firstFailureAt = 0;
-				await consumeStream(res.body);
+				// Only reset the failure window once the stream actually delivers
+				// bytes — a 200 that immediately closes shouldn't clear the clock
+				// that feeds the polling threshold.
+				await consumeStream(res.body, () => {
+					failures = 0;
+					firstFailureAt = 0;
+				}, ctrl);
 			} catch (err) {
 				if (closed || (err as Error).name === "AbortError") return;
 			}

--- a/packages/realtime/src/client/parse.ts
+++ b/packages/realtime/src/client/parse.ts
@@ -34,8 +34,8 @@ export function createSseParser(onFrame: (frame: ParsedFrame) => void): (chunk: 
 		if (value.startsWith(" ")) value = value.slice(1);
 		if (field === "event") event = value;
 		else if (field === "id") {
-			const n = Number.parseInt(value, 10);
-			if (!Number.isNaN(n)) id = n;
+			// Strict digit match — parseInt("500abc") would be 500.
+			if (/^\d+$/.test(value)) id = Number.parseInt(value, 10);
 		} else if (field === "data") dataLines.push(value);
 	};
 

--- a/packages/realtime/src/client/parse.ts
+++ b/packages/realtime/src/client/parse.ts
@@ -1,0 +1,54 @@
+export interface ParsedFrame {
+	event: string;
+	id?: number;
+	data: string;
+}
+
+export function createSseParser(onFrame: (frame: ParsedFrame) => void): (chunk: string) => void {
+	let buf = "";
+	let event = "message";
+	let id: number | undefined;
+	let dataLines: string[] = [];
+
+	const reset = () => {
+		event = "message";
+		id = undefined;
+		dataLines = [];
+	};
+
+	const dispatch = () => {
+		if (dataLines.length === 0 && id === undefined && event === "message") return;
+		onFrame({ event, id, data: dataLines.join("\n") });
+		reset();
+	};
+
+	const consumeLine = (line: string) => {
+		if (line === "") {
+			dispatch();
+			return;
+		}
+		if (line.startsWith(":")) return; // comment
+		const colon = line.indexOf(":");
+		const field = colon === -1 ? line : line.slice(0, colon);
+		let value = colon === -1 ? "" : line.slice(colon + 1);
+		if (value.startsWith(" ")) value = value.slice(1);
+		if (field === "event") event = value;
+		else if (field === "id") {
+			const n = Number.parseInt(value, 10);
+			if (!Number.isNaN(n)) id = n;
+		} else if (field === "data") dataLines.push(value);
+	};
+
+	return (chunk: string) => {
+		buf += chunk;
+		let idx: number;
+		while ((idx = buf.indexOf("\n")) !== -1) {
+			let line = buf.slice(0, idx);
+			buf = buf.slice(idx + 1);
+			// Tolerate CRLF line endings — any HTTP proxy in front of the broker
+			// may rewrite LF to CRLF; without this strip, `field = "event\r"`.
+			if (line.endsWith("\r")) line = line.slice(0, -1);
+			consumeLine(line);
+		}
+	};
+}

--- a/packages/realtime/src/framing.ts
+++ b/packages/realtime/src/framing.ts
@@ -1,0 +1,21 @@
+const encoder = new TextEncoder();
+
+export interface EncodeEventInput {
+	event: string;
+	data: string;
+	id?: number;
+}
+
+export function encodeEvent({ event, data, id }: EncodeEventInput): Uint8Array {
+	let out = "";
+	if (event !== "") out += `event: ${event}\n`;
+	if (id !== undefined) out += `id: ${id}\n`;
+	const lines = data.split("\n");
+	for (const line of lines) out += `data: ${line}\n`;
+	out += "\n";
+	return encoder.encode(out);
+}
+
+export function encodeComment(text: string): Uint8Array {
+	return encoder.encode(`: ${text.replace(/\n/g, "")}\n\n`);
+}

--- a/packages/realtime/src/index.ts
+++ b/packages/realtime/src/index.ts
@@ -1,0 +1,16 @@
+export { createBroker } from "./broker";
+export type { BrokerClass, BrokerInstance } from "./broker";
+export { publish } from "./publish";
+export type {
+	AuthorizeHook,
+	BrokerConfig,
+	PublishResult,
+	RealtimeEvent,
+	SubscribeOptions,
+} from "./types";
+export {
+	DEFAULT_CHANNEL_PATTERN,
+	DEFAULT_HEARTBEAT_MS,
+	DEFAULT_MAX_SUBSCRIBERS_PER_CHANNEL,
+	DEFAULT_REPLAY_BUFFER_SIZE,
+} from "./types";

--- a/packages/realtime/src/publish.ts
+++ b/packages/realtime/src/publish.ts
@@ -1,0 +1,26 @@
+import { singleton } from "@workkit/do";
+import type { PublishResult } from "./types";
+
+export async function publish(
+	namespace: DurableObjectNamespace,
+	channel: string,
+	event: string,
+	data: unknown,
+): Promise<PublishResult> {
+	// Surface the footgun at the call site — JSON.stringify(undefined) produces
+	// no output and the broker would 400 with an opaque "data required" error.
+	if (data === undefined) {
+		throw new Error(`publish: data cannot be undefined (channel "${channel}", event "${event}")`);
+	}
+	const stub = singleton(namespace, channel);
+	const response = await stub.fetch("https://do-rpc.internal/publish", {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify({ event, data }),
+	});
+	if (!response.ok) {
+		const body = await response.text();
+		throw new Error(`publish to "${channel}" failed (${response.status}): ${body}`);
+	}
+	return (await response.json()) as PublishResult;
+}

--- a/packages/realtime/src/ring-buffer.ts
+++ b/packages/realtime/src/ring-buffer.ts
@@ -1,0 +1,37 @@
+export interface RingBufferEntry<T> {
+	id: number;
+	event: T;
+}
+
+export interface RingBuffer<T> {
+	push(event: T): number;
+	since(id: number): ReadonlyArray<RingBufferEntry<T>>;
+	readonly lastId: number;
+	readonly size: number;
+}
+
+export function createRingBuffer<T>(capacity: number): RingBuffer<T> {
+	const entries: RingBufferEntry<T>[] = [];
+	let counter = 0;
+
+	return {
+		push(event) {
+			counter += 1;
+			if (capacity > 0) {
+				entries.push({ id: counter, event });
+				if (entries.length > capacity) entries.shift();
+			}
+			return counter;
+		},
+		since(id) {
+			if (entries.length === 0 || id >= counter) return [];
+			return entries.filter((e) => e.id > id);
+		},
+		get lastId() {
+			return counter;
+		},
+		get size() {
+			return entries.length;
+		},
+	};
+}

--- a/packages/realtime/src/types.ts
+++ b/packages/realtime/src/types.ts
@@ -25,6 +25,9 @@ export interface SubscribeOptions {
 	fallbackPollingUrl?: string;
 	pollingAfterMs?: number;
 	signal?: AbortSignal;
+	/** Server heartbeat cadence — used by the client to detect stalled streams
+	 * (aborts after ~2.5x this value with no bytes). Defaults to 30000. */
+	heartbeatMs?: number;
 }
 
 export interface PublishResult {

--- a/packages/realtime/src/types.ts
+++ b/packages/realtime/src/types.ts
@@ -32,7 +32,7 @@ export interface PublishResult {
 	id: number;
 }
 
-export const DEFAULT_REPLAY_BUFFER_SIZE = 50;
-export const DEFAULT_MAX_SUBSCRIBERS_PER_CHANNEL = 1000;
-export const DEFAULT_HEARTBEAT_MS = 30_000;
-export const DEFAULT_CHANNEL_PATTERN = /^[a-zA-Z0-9:_.-]{1,128}$/;
+export const DEFAULT_REPLAY_BUFFER_SIZE: number = 50;
+export const DEFAULT_MAX_SUBSCRIBERS_PER_CHANNEL: number = 1000;
+export const DEFAULT_HEARTBEAT_MS: number = 30_000;
+export const DEFAULT_CHANNEL_PATTERN: RegExp = /^[a-zA-Z0-9:_.-]{1,128}$/;

--- a/packages/realtime/src/types.ts
+++ b/packages/realtime/src/types.ts
@@ -1,0 +1,38 @@
+export interface RealtimeEvent {
+	event: string;
+	data: unknown;
+	id?: number;
+}
+
+export type AuthorizeHook<TEnv = unknown, TPrincipal = unknown> = (
+	channel: string,
+	request: Request,
+	env: TEnv,
+) => Promise<TPrincipal | null>;
+
+export interface BrokerConfig<TEnv = unknown, TPrincipal = unknown> {
+	authorize: AuthorizeHook<TEnv, TPrincipal>;
+	replayBufferSize?: number;
+	maxSubscribersPerChannel?: number;
+	heartbeatMs?: number;
+	channelPattern?: RegExp;
+}
+
+export interface SubscribeOptions {
+	onEvent: (event: string, data: unknown, id: number) => void;
+	onReconnect?: (attempt: number) => void;
+	backoff?: { initialMs: number; maxMs: number };
+	fallbackPollingUrl?: string;
+	pollingAfterMs?: number;
+	signal?: AbortSignal;
+}
+
+export interface PublishResult {
+	delivered: number;
+	id: number;
+}
+
+export const DEFAULT_REPLAY_BUFFER_SIZE = 50;
+export const DEFAULT_MAX_SUBSCRIBERS_PER_CHANNEL = 1000;
+export const DEFAULT_HEARTBEAT_MS = 30_000;
+export const DEFAULT_CHANNEL_PATTERN = /^[a-zA-Z0-9:_.-]{1,128}$/;

--- a/packages/realtime/tests/broker.test.ts
+++ b/packages/realtime/tests/broker.test.ts
@@ -215,6 +215,35 @@ describe("createBroker — publish", () => {
 	});
 });
 
+describe("createBroker — config validation", () => {
+	it("rejects negative replayBufferSize", () => {
+		expect(() =>
+			createBroker({ authorize: async () => ({}), replayBufferSize: -1 }),
+		).toThrow(/replayBufferSize/);
+	});
+
+	it("rejects zero maxSubscribersPerChannel", () => {
+		expect(() =>
+			createBroker({ authorize: async () => ({}), maxSubscribersPerChannel: 0 }),
+		).toThrow(/maxSubscribersPerChannel/);
+	});
+
+	it("rejects non-positive heartbeatMs (would create a hot loop)", () => {
+		expect(() => createBroker({ authorize: async () => ({}), heartbeatMs: 0 })).toThrow(
+			/heartbeatMs/,
+		);
+		expect(() =>
+			createBroker({ authorize: async () => ({}), heartbeatMs: Number.POSITIVE_INFINITY }),
+		).toThrow(/heartbeatMs/);
+	});
+
+	it("rejects non-integer replayBufferSize", () => {
+		expect(() =>
+			createBroker({ authorize: async () => ({}), replayBufferSize: 1.5 }),
+		).toThrow(/replayBufferSize/);
+	});
+});
+
 describe("createBroker — eviction gap detection", () => {
 	it("emits realtime.reset when Last-Event-ID exceeds buffer.lastId (post-eviction)", async () => {
 		const Broker = createBroker({ authorize: async () => ({}) });

--- a/packages/realtime/tests/broker.test.ts
+++ b/packages/realtime/tests/broker.test.ts
@@ -1,0 +1,334 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { createBroker } from "../src/broker";
+
+const mockState = {} as unknown as DurableObjectState;
+const mockEnv = {};
+
+async function readFrames(res: Response, n: number): Promise<string[]> {
+	const reader = res.body?.getReader();
+	if (!reader) throw new Error("no body");
+	const decoder = new TextDecoder();
+	let buf = "";
+	const frames: string[] = [];
+	while (frames.length < n) {
+		const { value, done } = await reader.read();
+		if (done) break;
+		buf += decoder.decode(value, { stream: true });
+		let idx: number;
+		while ((idx = buf.indexOf("\n\n")) !== -1 && frames.length < n) {
+			frames.push(buf.slice(0, idx));
+			buf = buf.slice(idx + 2);
+		}
+	}
+	await reader.cancel();
+	return frames;
+}
+
+describe("createBroker — subscribe", () => {
+	it("returns 400 for invalid channel names", async () => {
+		const Broker = createBroker({ authorize: async () => ({}) });
+		const broker = new Broker(mockState, mockEnv);
+		const res = await broker.fetch(new Request("https://do/subscribe?channel=../etc/passwd"));
+		expect(res.status).toBe(400);
+	});
+
+	it("returns 400 when channel param is missing", async () => {
+		const Broker = createBroker({ authorize: async () => ({}) });
+		const broker = new Broker(mockState, mockEnv);
+		const res = await broker.fetch(new Request("https://do/subscribe"));
+		expect(res.status).toBe(400);
+	});
+
+	it("returns 403 when authorize returns null", async () => {
+		const Broker = createBroker({ authorize: async () => null });
+		const broker = new Broker(mockState, mockEnv);
+		const res = await broker.fetch(new Request("https://do/subscribe?channel=test"));
+		expect(res.status).toBe(403);
+	});
+
+	it("returns 403 when authorize throws (deny, don't surface error)", async () => {
+		const Broker = createBroker({
+			authorize: async () => {
+				throw new Error("db down");
+			},
+		});
+		const broker = new Broker(mockState, mockEnv);
+		const res = await broker.fetch(new Request("https://do/subscribe?channel=test"));
+		expect(res.status).toBe(403);
+	});
+
+	it("returns 429 when subscriber cap exceeded", async () => {
+		const Broker = createBroker({
+			authorize: async () => ({}),
+			maxSubscribersPerChannel: 2,
+		});
+		const broker = new Broker(mockState, mockEnv);
+		const a = await broker.fetch(new Request("https://do/subscribe?channel=test"));
+		const b = await broker.fetch(new Request("https://do/subscribe?channel=test"));
+		expect(a.status).toBe(200);
+		expect(b.status).toBe(200);
+		const c = await broker.fetch(new Request("https://do/subscribe?channel=test"));
+		expect(c.status).toBe(429);
+		await a.body?.cancel();
+		await b.body?.cancel();
+	});
+
+	it("emits `: connected` comment on subscribe", async () => {
+		const Broker = createBroker({ authorize: async () => ({}) });
+		const broker = new Broker(mockState, mockEnv);
+		const res = await broker.fetch(new Request("https://do/subscribe?channel=test"));
+		const frames = await readFrames(res, 1);
+		expect(frames[0]).toBe(": connected");
+	});
+
+	it("sets SSE response headers", async () => {
+		const Broker = createBroker({ authorize: async () => ({}) });
+		const broker = new Broker(mockState, mockEnv);
+		const res = await broker.fetch(new Request("https://do/subscribe?channel=test"));
+		expect(res.headers.get("content-type")).toBe("text/event-stream");
+		expect(res.headers.get("cache-control")).toBe("no-cache, no-transform");
+		await res.body?.cancel();
+	});
+
+	it("replays buffered events when Last-Event-ID header is set", async () => {
+		const Broker = createBroker({ authorize: async () => ({}) });
+		const broker = new Broker(mockState, mockEnv);
+		await broker.fetch(
+			new Request("https://do/publish", {
+				method: "POST",
+				body: JSON.stringify({ event: "x", data: "one" }),
+			}),
+		);
+		await broker.fetch(
+			new Request("https://do/publish", {
+				method: "POST",
+				body: JSON.stringify({ event: "x", data: "two" }),
+			}),
+		);
+		const res = await broker.fetch(
+			new Request("https://do/subscribe?channel=test", {
+				headers: { "Last-Event-ID": "0" },
+			}),
+		);
+		const frames = await readFrames(res, 3); // connected + 2 replays
+		expect(frames[0]).toBe(": connected");
+		expect(frames[1]).toContain("event: x");
+		expect(frames[1]).toContain("id: 1");
+		expect(frames[1]).toContain('data: "one"');
+		expect(frames[2]).toContain("id: 2");
+		expect(frames[2]).toContain('data: "two"');
+	});
+
+	it("accepts lastEventId via query param when header is absent", async () => {
+		const Broker = createBroker({ authorize: async () => ({}) });
+		const broker = new Broker(mockState, mockEnv);
+		await broker.fetch(
+			new Request("https://do/publish", {
+				method: "POST",
+				body: JSON.stringify({ event: "x", data: "one" }),
+			}),
+		);
+		const res = await broker.fetch(new Request("https://do/subscribe?channel=test&lastEventId=0"));
+		const frames = await readFrames(res, 2);
+		expect(frames[1]).toContain("id: 1");
+		expect(frames[1]).toContain('data: "one"');
+	});
+
+	it("honors Last-Event-ID to skip already-seen events", async () => {
+		const Broker = createBroker({ authorize: async () => ({}) });
+		const broker = new Broker(mockState, mockEnv);
+		await broker.fetch(
+			new Request("https://do/publish", {
+				method: "POST",
+				body: JSON.stringify({ event: "x", data: "one" }),
+			}),
+		);
+		await broker.fetch(
+			new Request("https://do/publish", {
+				method: "POST",
+				body: JSON.stringify({ event: "x", data: "two" }),
+			}),
+		);
+		const res = await broker.fetch(
+			new Request("https://do/subscribe?channel=test", {
+				headers: { "Last-Event-ID": "1" },
+			}),
+		);
+		const frames = await readFrames(res, 2); // connected + only event 2
+		expect(frames[1]).toContain("id: 2");
+		expect(frames[1]).not.toContain('data: "one"');
+	});
+});
+
+describe("createBroker — publish", () => {
+	it("returns 400 for malformed JSON body", async () => {
+		const Broker = createBroker({ authorize: async () => ({}) });
+		const broker = new Broker(mockState, mockEnv);
+		const res = await broker.fetch(
+			new Request("https://do/publish", { method: "POST", body: "not json" }),
+		);
+		expect(res.status).toBe(400);
+	});
+
+	it("returns 400 when body is missing required fields", async () => {
+		const Broker = createBroker({ authorize: async () => ({}) });
+		const broker = new Broker(mockState, mockEnv);
+		const res = await broker.fetch(
+			new Request("https://do/publish", {
+				method: "POST",
+				body: JSON.stringify({ event: "" }),
+			}),
+		);
+		expect(res.status).toBe(400);
+	});
+
+	it("returns delivered: 0 when no subscribers", async () => {
+		const Broker = createBroker({ authorize: async () => ({}) });
+		const broker = new Broker(mockState, mockEnv);
+		const res = await broker.fetch(
+			new Request("https://do/publish", {
+				method: "POST",
+				body: JSON.stringify({ event: "x", data: "y" }),
+			}),
+		);
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ delivered: 0, id: 1 });
+	});
+
+	it("fans out to every active subscriber", async () => {
+		const Broker = createBroker({ authorize: async () => ({}) });
+		const broker = new Broker(mockState, mockEnv);
+		const subA = await broker.fetch(new Request("https://do/subscribe?channel=test"));
+		const subB = await broker.fetch(new Request("https://do/subscribe?channel=test"));
+		const pubRes = await broker.fetch(
+			new Request("https://do/publish", {
+				method: "POST",
+				body: JSON.stringify({ event: "run.stage", data: { stage: "verify" } }),
+			}),
+		);
+		expect((await pubRes.json()) as { delivered: number }).toEqual({ delivered: 2, id: 1 });
+		const [, fromA] = await readFrames(subA, 2);
+		const [, fromB] = await readFrames(subB, 2);
+		expect(fromA).toContain("event: run.stage");
+		expect(fromA).toContain('data: {"stage":"verify"}');
+		expect(fromB).toContain("event: run.stage");
+	});
+});
+
+describe("createBroker — eviction gap detection", () => {
+	it("emits realtime.reset when Last-Event-ID exceeds buffer.lastId (post-eviction)", async () => {
+		const Broker = createBroker({ authorize: async () => ({}) });
+		const broker = new Broker(mockState, mockEnv);
+		// Broker is fresh — buffer.lastId === 0. Client reports id=500 (stale).
+		const res = await broker.fetch(
+			new Request("https://do/subscribe?channel=test", {
+				headers: { "Last-Event-ID": "500" },
+			}),
+		);
+		const frames = await readFrames(res, 2);
+		expect(frames[0]).toBe(": connected");
+		expect(frames[1]).toContain("event: realtime.reset");
+		expect(frames[1]).toContain('"reason":"buffer_gap"');
+		expect(frames[1]).toContain('"lastKnownId":500');
+	});
+
+	it("does not emit reset when Last-Event-ID is within buffer range", async () => {
+		const Broker = createBroker({ authorize: async () => ({}) });
+		const broker = new Broker(mockState, mockEnv);
+		await broker.fetch(
+			new Request("https://do/publish", {
+				method: "POST",
+				body: JSON.stringify({ event: "x", data: "a" }),
+			}),
+		);
+		const res = await broker.fetch(
+			new Request("https://do/subscribe?channel=test", {
+				headers: { "Last-Event-ID": "1" },
+			}),
+		);
+		const frames = await readFrames(res, 1);
+		expect(frames[0]).toBe(": connected");
+		expect(frames.join("\n")).not.toContain("realtime.reset");
+	});
+});
+
+describe("createBroker — Last-Event-ID parse hardening", () => {
+	it("treats malformed Last-Event-ID as 0 (no silent truncation)", async () => {
+		const Broker = createBroker({ authorize: async () => ({}) });
+		const broker = new Broker(mockState, mockEnv);
+		await broker.fetch(
+			new Request("https://do/publish", {
+				method: "POST",
+				body: JSON.stringify({ event: "x", data: "a" }),
+			}),
+		);
+		// "500abc" must NOT parse as 500; parseInt would accept it, our regex rejects.
+		const res = await broker.fetch(
+			new Request("https://do/subscribe?channel=test", {
+				headers: { "Last-Event-ID": "500abc" },
+			}),
+		);
+		const frames = await readFrames(res, 2);
+		// With strict parse → treated as 0 → replay event 1 (not a reset).
+		expect(frames[1]).toContain("id: 1");
+		expect(frames[1]).toContain('data: "a"');
+	});
+});
+
+describe("createBroker — routing", () => {
+	it("returns 404 for unknown paths", async () => {
+		const Broker = createBroker({ authorize: async () => ({}) });
+		const broker = new Broker(mockState, mockEnv);
+		const res = await broker.fetch(new Request("https://do/nope"));
+		expect(res.status).toBe(404);
+	});
+
+	it("returns 405 for POST /subscribe or GET /publish", async () => {
+		const Broker = createBroker({ authorize: async () => ({}) });
+		const broker = new Broker(mockState, mockEnv);
+		const a = await broker.fetch(
+			new Request("https://do/subscribe?channel=test", { method: "POST" }),
+		);
+		const b = await broker.fetch(new Request("https://do/publish"));
+		expect(a.status).toBe(405);
+		expect(b.status).toBe(405);
+	});
+});
+
+describe("createBroker — authorize hook contract", () => {
+	it("passes the channel name to authorize", async () => {
+		let seen: string | undefined;
+		const Broker = createBroker({
+			authorize: async (channel) => {
+				seen = channel;
+				return {};
+			},
+		});
+		const broker = new Broker(mockState, mockEnv);
+		const res = await broker.fetch(new Request("https://do/subscribe?channel=team:42:runs"));
+		expect(seen).toBe("team:42:runs");
+		await res.body?.cancel();
+	});
+
+	it("passes the request and env to authorize", async () => {
+		let seenReq: Request | undefined;
+		let seenEnv: unknown;
+		const Broker = createBroker({
+			authorize: async (_channel, request, env) => {
+				seenReq = request;
+				seenEnv = env;
+				return {};
+			},
+		});
+		const env = { SECRET: "x" };
+		const broker = new Broker(mockState, env);
+		const res = await broker.fetch(
+			new Request("https://do/subscribe?channel=test", {
+				headers: { cookie: "session=abc" },
+			}),
+		);
+		expect(seenReq?.headers.get("cookie")).toBe("session=abc");
+		expect(seenEnv).toBe(env);
+		await res.body?.cancel();
+	});
+});

--- a/packages/realtime/tests/broker.test.ts
+++ b/packages/realtime/tests/broker.test.ts
@@ -217,9 +217,9 @@ describe("createBroker — publish", () => {
 
 describe("createBroker — config validation", () => {
 	it("rejects negative replayBufferSize", () => {
-		expect(() =>
-			createBroker({ authorize: async () => ({}), replayBufferSize: -1 }),
-		).toThrow(/replayBufferSize/);
+		expect(() => createBroker({ authorize: async () => ({}), replayBufferSize: -1 })).toThrow(
+			/replayBufferSize/,
+		);
 	});
 
 	it("rejects zero maxSubscribersPerChannel", () => {
@@ -238,9 +238,9 @@ describe("createBroker — config validation", () => {
 	});
 
 	it("rejects non-integer replayBufferSize", () => {
-		expect(() =>
-			createBroker({ authorize: async () => ({}), replayBufferSize: 1.5 }),
-		).toThrow(/replayBufferSize/);
+		expect(() => createBroker({ authorize: async () => ({}), replayBufferSize: 1.5 })).toThrow(
+			/replayBufferSize/,
+		);
 	});
 });
 

--- a/packages/realtime/tests/broker.test.ts
+++ b/packages/realtime/tests/broker.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { createBroker } from "../src/broker";
 
 const mockState = {} as unknown as DurableObjectState;

--- a/packages/realtime/tests/client-parse.test.ts
+++ b/packages/realtime/tests/client-parse.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { type ParsedFrame, createSseParser } from "../src/client/parse";
+
+function collect(input: string): ParsedFrame[] {
+	const frames: ParsedFrame[] = [];
+	const feed = createSseParser((f) => frames.push(f));
+	feed(input);
+	return frames;
+}
+
+describe("createSseParser", () => {
+	it("parses a single event with event, id, data", () => {
+		const frames = collect('event: run.stage\nid: 1\ndata: {"k":1}\n\n');
+		expect(frames).toEqual([{ event: "run.stage", id: 1, data: '{"k":1}' }]);
+	});
+
+	it("joins multi-line data with newlines", () => {
+		const frames = collect("event: x\nid: 2\ndata: one\ndata: two\n\n");
+		expect(frames).toEqual([{ event: "x", id: 2, data: "one\ntwo" }]);
+	});
+
+	it("defaults event name to 'message' when omitted", () => {
+		const frames = collect("id: 5\ndata: hello\n\n");
+		expect(frames).toEqual([{ event: "message", id: 5, data: "hello" }]);
+	});
+
+	it("ignores comment lines", () => {
+		const frames = collect(": keepalive\n\nevent: x\nid: 1\ndata: y\n\n");
+		expect(frames).toEqual([{ event: "x", id: 1, data: "y" }]);
+	});
+
+	it("handles split chunks", () => {
+		const frames: ParsedFrame[] = [];
+		const feed = createSseParser((f) => frames.push(f));
+		feed("event: x\nid: 1\nda");
+		feed("ta: hello\n\n");
+		expect(frames).toEqual([{ event: "x", id: 1, data: "hello" }]);
+	});
+
+	it("parses multiple events in one chunk", () => {
+		const frames = collect("event: a\nid: 1\ndata: 1\n\nevent: b\nid: 2\ndata: 2\n\n");
+		expect(frames).toEqual([
+			{ event: "a", id: 1, data: "1" },
+			{ event: "b", id: 2, data: "2" },
+		]);
+	});
+
+	it("ignores stray non-field lines and malformed ids", () => {
+		const frames = collect("event: x\nid: abc\ndata: y\n\n");
+		expect(frames).toEqual([{ event: "x", id: undefined, data: "y" }]);
+	});
+
+	it("tolerates CRLF line endings from proxies", () => {
+		const frames = collect("event: x\r\nid: 1\r\ndata: y\r\n\r\n");
+		expect(frames).toEqual([{ event: "x", id: 1, data: "y" }]);
+	});
+});

--- a/packages/realtime/tests/client-parse.test.ts
+++ b/packages/realtime/tests/client-parse.test.ts
@@ -50,6 +50,11 @@ describe("createSseParser", () => {
 		expect(frames).toEqual([{ event: "x", id: undefined, data: "y" }]);
 	});
 
+	it("rejects ids with trailing garbage (parseInt would accept)", () => {
+		const frames = collect("event: x\nid: 500abc\ndata: y\n\n");
+		expect(frames).toEqual([{ event: "x", id: undefined, data: "y" }]);
+	});
+
 	it("tolerates CRLF line endings from proxies", () => {
 		const frames = collect("event: x\r\nid: 1\r\ndata: y\r\n\r\n");
 		expect(frames).toEqual([{ event: "x", id: 1, data: "y" }]);

--- a/packages/realtime/tests/client.test.ts
+++ b/packages/realtime/tests/client.test.ts
@@ -84,6 +84,31 @@ describe("subscribe", () => {
 		stream.close();
 	});
 
+	it("sends Last-Event-ID header (as well as query param) once lastEventId > 0", async () => {
+		const first = makeStreamResponse();
+		const second = makeStreamResponse();
+		fetchMock.mockResolvedValueOnce(first.response).mockResolvedValue(second.response);
+
+		const sub = subscribe("/sse/test", {
+			onEvent: () => {},
+			backoff: { initialMs: 10, maxMs: 10 },
+		});
+		await flush();
+		// First connect: no prior lastEventId → no header.
+		expect(fetchMock.mock.calls[0][1].headers["Last-Event-ID"]).toBeUndefined();
+
+		first.push("event: x\nid: 42\ndata: a\n\n");
+		await flush();
+		first.close();
+		await new Promise((r) => setTimeout(r, 30));
+		await flush();
+
+		// Reconnect: header must carry the last seen id.
+		expect(fetchMock.mock.calls[1][1].headers["Last-Event-ID"]).toBe("42");
+		sub.unsubscribe();
+		second.close();
+	});
+
 	it("includes updated lastEventId in URL on reconnect", async () => {
 		const first = makeStreamResponse();
 		const second = makeStreamResponse();

--- a/packages/realtime/tests/client.test.ts
+++ b/packages/realtime/tests/client.test.ts
@@ -200,6 +200,51 @@ describe("subscribe", () => {
 		sub.unsubscribe();
 	});
 
+	it("aborts and reconnects when stream stays silent past the idle timeout", async () => {
+		const first = makeStreamResponse();
+		const second = makeStreamResponse();
+		fetchMock.mockResolvedValueOnce(first.response).mockResolvedValue(second.response);
+
+		const sub = subscribe("/sse/test", {
+			onEvent: () => {},
+			backoff: { initialMs: 10, maxMs: 10 },
+			heartbeatMs: 20, // idle timeout becomes 50ms
+		});
+		await flush();
+		// Deliberately never push any bytes — proxy stalled the stream open.
+		await new Promise((r) => setTimeout(r, 120));
+		await flush();
+
+		// Second fetch happens after idle-timeout abort + backoff.
+		expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+		sub.unsubscribe();
+		// Both streams were already cancelled by idle timers — don't close again.
+	});
+
+	it("does not reset the failure window when stream yields zero bytes before closing", async () => {
+		// Short-lived 200 + immediate close should still accumulate time toward
+		// pollingAfterMs — otherwise a flapping proxy could prevent polling.
+		const shortLived = makeStreamResponse();
+		shortLived.close();
+		const polled = new Response(JSON.stringify([{ event: "ok", id: 1, data: "p" }]));
+		fetchMock.mockResolvedValueOnce(shortLived.response).mockResolvedValueOnce(polled);
+
+		const received: Array<{ event: string; data: unknown; id: number }> = [];
+		const sub = subscribe("/sse/test", {
+			onEvent: (event, data, id) => received.push({ event, data, id }),
+			backoff: { initialMs: 5, maxMs: 5 },
+			fallbackPollingUrl: "/poll/test",
+			pollingAfterMs: 0,
+		});
+		await new Promise((r) => setTimeout(r, 40));
+		await flush();
+
+		expect(
+			fetchMock.mock.calls.find((c) => c[0].startsWith("/poll/test")),
+		).toBeDefined();
+		sub.unsubscribe();
+	});
+
 	it("honors opts.signal by calling unsubscribe on abort", async () => {
 		const stream = makeStreamResponse();
 		fetchMock.mockResolvedValue(stream.response);

--- a/packages/realtime/tests/client.test.ts
+++ b/packages/realtime/tests/client.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { subscribe } from "../src/client";
+
+interface StreamHandle {
+	response: Response;
+	push: (chunk: string) => void;
+	close: () => void;
+	error: () => void;
+}
+
+function makeStreamResponse(status = 200): StreamHandle {
+	let controller!: ReadableStreamDefaultController<Uint8Array>;
+	const stream = new ReadableStream<Uint8Array>({
+		start(c) {
+			controller = c;
+		},
+	});
+	const response = new Response(stream, {
+		status,
+		headers: { "content-type": "text/event-stream" },
+	});
+	const encoder = new TextEncoder();
+	return {
+		response,
+		push: (chunk) => controller.enqueue(encoder.encode(chunk)),
+		close: () => controller.close(),
+		error: () => controller.error(new Error("stream error")),
+	};
+}
+
+// Yield to the event loop so fetch / reader microtasks can flush.
+const flush = async () => {
+	for (let i = 0; i < 5; i++) await Promise.resolve();
+	await new Promise((r) => setTimeout(r, 0));
+};
+
+describe("subscribe", () => {
+	let fetchMock: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("fetches the subscribe URL with lastEventId=0 on first connect", async () => {
+		const stream = makeStreamResponse();
+		fetchMock.mockResolvedValue(stream.response);
+
+		const sub = subscribe("/sse/test", { onEvent: () => {} });
+		await flush();
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const call = fetchMock.mock.calls[0];
+		expect(call[0]).toBe("/sse/test?lastEventId=0");
+		expect(call[1].headers.accept).toBe("text/event-stream");
+		sub.unsubscribe();
+		stream.close();
+	});
+
+	it("parses SSE frames and invokes onEvent with typed data", async () => {
+		const stream = makeStreamResponse();
+		fetchMock.mockResolvedValue(stream.response);
+		const received: Array<{ event: string; data: unknown; id: number }> = [];
+
+		const sub = subscribe("/sse/test", {
+			onEvent: (event, data, id) => received.push({ event, data, id }),
+		});
+		await flush();
+
+		stream.push('event: run.stage\nid: 1\ndata: {"stage":"verify"}\n\n');
+		await flush();
+		stream.push('event: run.stage\nid: 2\ndata: {"stage":"done"}\n\n');
+		await flush();
+
+		expect(received).toEqual([
+			{ event: "run.stage", data: { stage: "verify" }, id: 1 },
+			{ event: "run.stage", data: { stage: "done" }, id: 2 },
+		]);
+		sub.unsubscribe();
+		stream.close();
+	});
+
+	it("includes updated lastEventId in URL on reconnect", async () => {
+		const first = makeStreamResponse();
+		const second = makeStreamResponse();
+		fetchMock.mockResolvedValueOnce(first.response).mockResolvedValue(second.response);
+
+		const sub = subscribe("/sse/test", {
+			onEvent: () => {},
+			backoff: { initialMs: 10, maxMs: 10 },
+		});
+		await flush();
+		first.push("event: x\nid: 7\ndata: a\n\n");
+		await flush();
+		first.close();
+		// Wait for reconnect backoff + scheduled retry
+		await new Promise((r) => setTimeout(r, 30));
+		await flush();
+
+		expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+		expect(fetchMock.mock.calls[1][0]).toBe("/sse/test?lastEventId=7");
+		sub.unsubscribe();
+		second.close();
+	});
+
+	it("invokes onReconnect with attempt count on reconnect", async () => {
+		const first = makeStreamResponse();
+		const second = makeStreamResponse();
+		fetchMock.mockResolvedValueOnce(first.response).mockResolvedValue(second.response);
+		const onReconnect = vi.fn();
+
+		const sub = subscribe("/sse/test", {
+			onEvent: () => {},
+			onReconnect,
+			backoff: { initialMs: 10, maxMs: 10 },
+		});
+		await flush();
+		first.close();
+		await new Promise((r) => setTimeout(r, 30));
+		await flush();
+
+		expect(onReconnect).toHaveBeenCalledWith(1);
+		sub.unsubscribe();
+		second.close();
+	});
+
+	it("unsubscribe() aborts the in-flight fetch", async () => {
+		const stream = makeStreamResponse();
+		fetchMock.mockImplementation((_url: string, init: RequestInit) => {
+			return new Promise<Response>((resolve, reject) => {
+				init.signal?.addEventListener("abort", () => {
+					const err = new Error("aborted");
+					err.name = "AbortError";
+					reject(err);
+				});
+				resolve(stream.response);
+			});
+		});
+
+		const sub = subscribe("/sse/test", { onEvent: () => {} });
+		await flush();
+		sub.unsubscribe();
+		await flush();
+
+		// No further fetches after unsubscribe
+		const callsBefore = fetchMock.mock.calls.length;
+		await new Promise((r) => setTimeout(r, 50));
+		expect(fetchMock.mock.calls.length).toBe(callsBefore);
+	});
+
+	it("switches to polling URL once failure window exceeded", async () => {
+		const polled = new Response(JSON.stringify([{ event: "x", id: 1, data: "p" }]));
+		fetchMock
+			.mockResolvedValueOnce(new Response("nope", { status: 502 }))
+			.mockResolvedValueOnce(polled);
+
+		const received: Array<{ event: string; data: unknown; id: number }> = [];
+		const sub = subscribe("/sse/test", {
+			onEvent: (event, data, id) => received.push({ event, data, id }),
+			backoff: { initialMs: 5, maxMs: 5 },
+			fallbackPollingUrl: "/poll/test",
+			pollingAfterMs: 0,
+		});
+
+		await new Promise((r) => setTimeout(r, 30));
+		await flush();
+
+		const pollCall = fetchMock.mock.calls.find((c) => c[0].startsWith("/poll/test"));
+		expect(pollCall).toBeDefined();
+		expect(received[0]).toEqual({ event: "x", data: "p", id: 1 });
+		sub.unsubscribe();
+	});
+
+	it("honors opts.signal by calling unsubscribe on abort", async () => {
+		const stream = makeStreamResponse();
+		fetchMock.mockResolvedValue(stream.response);
+		const controller = new AbortController();
+
+		const sub = subscribe("/sse/test", { onEvent: () => {}, signal: controller.signal });
+		await flush();
+		controller.abort();
+		await flush();
+
+		const callsAfterAbort = fetchMock.mock.calls.length;
+		await new Promise((r) => setTimeout(r, 20));
+		expect(fetchMock.mock.calls.length).toBe(callsAfterAbort);
+		sub.unsubscribe();
+		stream.close();
+	});
+});

--- a/packages/realtime/tests/client.test.ts
+++ b/packages/realtime/tests/client.test.ts
@@ -239,9 +239,7 @@ describe("subscribe", () => {
 		await new Promise((r) => setTimeout(r, 40));
 		await flush();
 
-		expect(
-			fetchMock.mock.calls.find((c) => c[0].startsWith("/poll/test")),
-		).toBeDefined();
+		expect(fetchMock.mock.calls.find((c) => c[0].startsWith("/poll/test"))).toBeDefined();
 		sub.unsubscribe();
 	});
 

--- a/packages/realtime/tests/framing.test.ts
+++ b/packages/realtime/tests/framing.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { encodeComment, encodeEvent } from "../src/framing";
+
+const decode = (bytes: Uint8Array): string => new TextDecoder().decode(bytes);
+
+describe("encodeEvent", () => {
+	it("emits event, id, and data lines terminated by a blank line", () => {
+		const out = encodeEvent({ event: "run.stage", id: 42, data: '{"stage":"verify"}' });
+		expect(decode(out)).toBe('event: run.stage\nid: 42\ndata: {"stage":"verify"}\n\n');
+	});
+
+	it("splits multi-line data into multiple data: lines", () => {
+		const out = encodeEvent({ event: "msg", id: 1, data: "line one\nline two\nline three" });
+		expect(decode(out)).toBe(
+			"event: msg\nid: 1\ndata: line one\ndata: line two\ndata: line three\n\n",
+		);
+	});
+
+	it("preserves unicode in data without escaping", () => {
+		const out = encodeEvent({ event: "emoji", id: 7, data: "🚀 résumé" });
+		expect(decode(out)).toBe("event: emoji\nid: 7\ndata: 🚀 résumé\n\n");
+	});
+
+	it("omits the id line when id is undefined", () => {
+		const out = encodeEvent({ event: "anon", data: "x" });
+		expect(decode(out)).toBe("event: anon\ndata: x\n\n");
+	});
+
+	it("emits only data when event is empty string", () => {
+		const out = encodeEvent({ event: "", id: 0, data: "y" });
+		expect(decode(out)).toBe("id: 0\ndata: y\n\n");
+	});
+
+	it("handles empty data payload", () => {
+		const out = encodeEvent({ event: "ping", id: 5, data: "" });
+		expect(decode(out)).toBe("event: ping\nid: 5\ndata: \n\n");
+	});
+
+	it("handles trailing newline in data by emitting an extra empty data line", () => {
+		const out = encodeEvent({ event: "msg", id: 1, data: "one\n" });
+		expect(decode(out)).toBe("event: msg\nid: 1\ndata: one\ndata: \n\n");
+	});
+});
+
+describe("encodeComment", () => {
+	it("prefixes with colon-space and terminates with blank line", () => {
+		expect(decode(encodeComment("keepalive"))).toBe(": keepalive\n\n");
+	});
+
+	it("accepts empty comment", () => {
+		expect(decode(encodeComment(""))).toBe(": \n\n");
+	});
+
+	it("escapes embedded newlines by dropping them (comments are single-line)", () => {
+		expect(decode(encodeComment("a\nb"))).toBe(": ab\n\n");
+	});
+});

--- a/packages/realtime/tests/publish.test.ts
+++ b/packages/realtime/tests/publish.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { publish } from "../src/publish";
 
 interface FakeStub {

--- a/packages/realtime/tests/publish.test.ts
+++ b/packages/realtime/tests/publish.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import { publish } from "../src/publish";
+
+interface FakeStub {
+	fetch: (input: Request | string, init?: RequestInit) => Promise<Response>;
+}
+
+function fakeNamespace(respond: (req: Request) => Response | Promise<Response>): {
+	namespace: DurableObjectNamespace;
+	captured: Request[];
+	idsRequested: string[];
+} {
+	const captured: Request[] = [];
+	const idsRequested: string[] = [];
+	const namespace = {
+		idFromName(name: string) {
+			idsRequested.push(name);
+			return { _name: name, toString: () => name };
+		},
+		get(_id: unknown): FakeStub {
+			return {
+				fetch: async (input, init) => {
+					const req = typeof input === "string" ? new Request(input, init) : input;
+					captured.push(req);
+					return respond(req);
+				},
+			};
+		},
+	} as unknown as DurableObjectNamespace;
+	return { namespace, captured, idsRequested };
+}
+
+describe("publish", () => {
+	it("resolves channel name to DO stub via idFromName", async () => {
+		const { namespace, idsRequested } = fakeNamespace(
+			() => new Response(JSON.stringify({ delivered: 0, id: 1 })),
+		);
+		await publish(namespace, "team:42:runs", "run.stage", { stage: "verify" });
+		expect(idsRequested).toEqual(["team:42:runs"]);
+	});
+
+	it("POSTs JSON body with event and data to /publish", async () => {
+		const { namespace, captured } = fakeNamespace(
+			() => new Response(JSON.stringify({ delivered: 2, id: 5 })),
+		);
+		await publish(namespace, "ch", "x", { k: "v" });
+		expect(captured).toHaveLength(1);
+		const req = captured[0];
+		expect(req.method).toBe("POST");
+		expect(new URL(req.url).pathname).toBe("/publish");
+		expect(req.headers.get("content-type")).toBe("application/json");
+		expect(await req.json()).toEqual({ event: "x", data: { k: "v" } });
+	});
+
+	it("returns the parsed PublishResult", async () => {
+		const { namespace } = fakeNamespace(
+			() => new Response(JSON.stringify({ delivered: 7, id: 42 })),
+		);
+		const result = await publish(namespace, "ch", "x", "y");
+		expect(result).toEqual({ delivered: 7, id: 42 });
+	});
+
+	it("throws with status and body when DO responds non-2xx", async () => {
+		const { namespace } = fakeNamespace(() => new Response("invalid event", { status: 400 }));
+		await expect(publish(namespace, "ch", "", "y")).rejects.toThrow(/400/);
+	});
+
+	it("throws eagerly if data is undefined (publisher footgun)", async () => {
+		const { namespace } = fakeNamespace(
+			() => new Response(JSON.stringify({ delivered: 0, id: 1 })),
+		);
+		await expect(publish(namespace, "ch", "e", undefined)).rejects.toThrow(/undefined/);
+	});
+
+	it("passes null and primitive data without mangling", async () => {
+		const { namespace, captured } = fakeNamespace(
+			() => new Response(JSON.stringify({ delivered: 0, id: 1 })),
+		);
+		await publish(namespace, "ch", "e", null);
+		await publish(namespace, "ch", "e", 42);
+		await publish(namespace, "ch", "e", "str");
+		expect(await captured[0].json()).toEqual({ event: "e", data: null });
+		expect(await captured[1].json()).toEqual({ event: "e", data: 42 });
+		expect(await captured[2].json()).toEqual({ event: "e", data: "str" });
+	});
+});

--- a/packages/realtime/tests/ring-buffer.test.ts
+++ b/packages/realtime/tests/ring-buffer.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { createRingBuffer } from "../src/ring-buffer";
+
+describe("createRingBuffer", () => {
+	it("starts empty with lastId 0", () => {
+		const buf = createRingBuffer<string>(5);
+		expect(buf.size).toBe(0);
+		expect(buf.lastId).toBe(0);
+		expect(buf.since(0)).toEqual([]);
+	});
+
+	it("assigns monotonic ids on push starting at 1", () => {
+		const buf = createRingBuffer<string>(5);
+		expect(buf.push("a")).toBe(1);
+		expect(buf.push("b")).toBe(2);
+		expect(buf.push("c")).toBe(3);
+		expect(buf.lastId).toBe(3);
+		expect(buf.size).toBe(3);
+	});
+
+	it("since(id) returns events with id strictly greater than argument", () => {
+		const buf = createRingBuffer<string>(5);
+		buf.push("a");
+		buf.push("b");
+		buf.push("c");
+		expect(buf.since(0)).toEqual([
+			{ id: 1, event: "a" },
+			{ id: 2, event: "b" },
+			{ id: 3, event: "c" },
+		]);
+		expect(buf.since(1)).toEqual([
+			{ id: 2, event: "b" },
+			{ id: 3, event: "c" },
+		]);
+		expect(buf.since(3)).toEqual([]);
+	});
+
+	it("trims oldest when capacity exceeded, ids keep advancing", () => {
+		const buf = createRingBuffer<string>(3);
+		buf.push("a"); // 1
+		buf.push("b"); // 2
+		buf.push("c"); // 3
+		buf.push("d"); // 4, trims "a"
+		buf.push("e"); // 5, trims "b"
+		expect(buf.size).toBe(3);
+		expect(buf.lastId).toBe(5);
+		expect(buf.since(0)).toEqual([
+			{ id: 3, event: "c" },
+			{ id: 4, event: "d" },
+			{ id: 5, event: "e" },
+		]);
+	});
+
+	it("since(id) returning all kept when id predates oldest entry", () => {
+		const buf = createRingBuffer<string>(2);
+		buf.push("a"); // 1
+		buf.push("b"); // 2
+		buf.push("c"); // 3, trims "a"
+		expect(buf.since(0)).toEqual([
+			{ id: 2, event: "b" },
+			{ id: 3, event: "c" },
+		]);
+	});
+
+	it("since(id) preserves insertion order", () => {
+		const buf = createRingBuffer<number>(10);
+		for (let i = 0; i < 5; i++) buf.push(i);
+		const out = buf.since(0);
+		expect(out.map((e) => e.id)).toEqual([1, 2, 3, 4, 5]);
+		expect(out.map((e) => e.event)).toEqual([0, 1, 2, 3, 4]);
+	});
+
+	it("capacity of 0 keeps nothing but still advances ids", () => {
+		const buf = createRingBuffer<string>(0);
+		expect(buf.push("a")).toBe(1);
+		expect(buf.size).toBe(0);
+		expect(buf.lastId).toBe(1);
+		expect(buf.since(0)).toEqual([]);
+	});
+});

--- a/packages/realtime/tsconfig.json
+++ b/packages/realtime/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tooling/tsconfig/library.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "tests"]
+}

--- a/packages/realtime/vitest.config.ts
+++ b/packages/realtime/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineWorkkitVitest } from "@workkit/vitest-config";
+
+export default defineWorkkitVitest({
+	include: ["tests/**/*.test.ts"],
+});


### PR DESCRIPTION
## Summary

New `@workkit/realtime` package — per-channel Durable Object fan-out with `Last-Event-ID` replay, plus a fetch-based browser client with exponential backoff and optional polling fallback. Closes the multi-isolate gap called out at `packages/notify/src/adapters/inapp/sse.ts:11`.

Closes #111.

## What ships

**Server (`@workkit/realtime`):**
- `createBroker(config)` returns a `DurableObject` class routing `GET /subscribe` (authorize → stream) and `POST /publish` (fan-out)
- `publish(namespace, channel, event, data)` via `singleton()` from `@workkit/do`
- Configurable: subscriber cap (1000), heartbeat (30s), replay buffer (50 events), channel pattern `^[a-zA-Z0-9:_.-]{1,128}$`

**Client (`@workkit/realtime/client` subpath):**
- `subscribe(url, opts)` — fetch + `ReadableStream` (works in browser, Node, Bun)
- Exponential backoff, `Last-Event-ID` persistence, polling fallback, `AbortSignal`

## Design

See `adr/0005-realtime-sse-over-durable-objects-broker.md` for:
- Per-channel DO vs. sharded multi-channel (per-channel wins — hibernation makes sparse channels free)
- In-memory ring buffer vs. storage-backed (in-memory matches the ephemeral contract)
- Why a new package vs. extending `@workkit/notify` (different concept: broadcast vs. delivery)
- No WebSocket in v1

## Post-review hardening (bundled)

Applied after an independent code review pass — all fixes in this one commit:
- Strict `Last-Event-ID` parse (`parseInt('500abc')` was silently 500)
- `realtime.reset` event emitted when client id > broker `buffer.lastId` after DO eviction
- Heartbeat timer guarded with `if (cleanedUp) return`; fan-out iterates a snapshot
- `publish()` throws eagerly on `undefined` data (was opaque 400)
- External `AbortSignal` listener removed on unsubscribe (leak fix)
- SSE parser strips trailing `\r` for CRLF tolerance behind proxies

## Blast radius

New package + new DO binding. No existing `@workkit/*` package modified. `maina-cloud` will consume this as a new devDep once published.

## Test plan

- [x] `bun run test --filter @workkit/realtime` — 59 passing
- [x] `bun run typecheck --filter @workkit/realtime` — clean
- [x] `bun x @biomejs/biome check packages/realtime` — no findings
- [x] `bun run constitution:check --diff-only` — 0 errors, 0 warnings
- [x] `maina slop` on changed files — no findings
- [x] `maina verify` — passes
- [ ] Integration test against `wrangler dev` — deferred to first consumer (maina-cloud dashboard-v1)
- [ ] Two-tab E2E: live `run.stage` event delivered within 200ms — deferred to maina-cloud

## Docs

- `adr/0005-realtime-sse-over-durable-objects-broker.md`
- `apps/docs/src/content/docs/guides/realtime.md`
- README package table entry
- `.changeset/realtime-initial.md` (minor → `@workkit/realtime@0.1.0` on release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `@workkit/realtime` package for Server-Sent Events–based pub/sub messaging across channels.
  * Server brokers support configurable authorization, message replay via Last-Event-ID, subscriber caps, and heartbeat intervals.
  * Client subscriptions include automatic reconnection with exponential backoff and optional polling fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->