### PR TITLE
chore: gitignore Maina local artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ dist/
 *.tsbuildinfo
 .DS_Store
 .claude/worktrees/
+.maina/cache/
+.maina/context/
+.maina/*.db


### PR DESCRIPTION
## Summary
- Add `.maina/cache/`, `.maina/context/`, and `.maina/*.db` to `.gitignore`.
- These are per-developer Maina MCP tooling state (sqlite DBs + on-disk caches) that were appearing as untracked in every session.

Tracked Maina content under `.maina/` (constitution, decisions, features, wiki) is unaffected.

## Test plan
- [x] `git status` clean after the change
- [ ] Confirm Maina still functions on a fresh checkout (cache/db regenerate locally on first use)

https://claude.ai/code/session_013SNDJVrgKcvuuw6AS1rWrN

---
_Generated by [Claude Code](https://claude.ai/code/session_013SNDJVrgKcvuuw6AS1rWrN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Git configuration to exclude cache, context, and database files from version control.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/beeeku/workkit/pull/114)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->