### PR TITLE
chore: gitignore Maina local artifacts under .maina/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ dist/
 *.tsbuildinfo
 .DS_Store
 .claude/worktrees/
+.maina/cache/
+.maina/context/
+.maina/*.db


### PR DESCRIPTION
## Summary
- Ignore per-developer Maina MCP tooling state (sqlite DBs + on-disk caches) generated under `.maina/`: `.maina/cache/`, `.maina/context/`, `.maina/*.db`.
- Tracked Maina content (`constitution.md`, `decisions/`, `features/`, `prompts/`) is unaffected.

## Why this supersedes #114
PR #114 had the right intent but added `.main/` patterns (missing the `a`) — those match nothing, so the artifacts kept showing up as untracked. CodeRabbit's pre-merge title check flagged the same mismatch. This PR uses the correct `.maina/` paths. Recommend closing #114 in favor of this.

## Test plan
- [x] Patterns target the real `.maina/` directory (confirmed `.maina/` is the tracked dir; `git ls-files .maina/` = 32 tracked files, all under `constitution.md`/`decisions`/`features`/`prompts`).
- [ ] Confirm Maina cache/db regenerate locally on first use after a fresh checkout.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SMSKutPGegZz7PiPwfMrXW)_